### PR TITLE
Fix Tour for HiDPI (for discussion)

### DIFF
--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -76,7 +76,7 @@ impl Application for Tour {
         }
 
         let element: Element<_> = Column::new()
-            .max_width(Length::Units(540))
+            .max_width(Length::Units((540.0*3.0) as u16))
             .spacing(20)
             .padding(20)
             .push(steps.view(self.debug).map(Message::StepMessage))

--- a/wgpu/src/renderer/text.rs
+++ b/wgpu/src/renderer/text.rs
@@ -6,6 +6,8 @@ use wgpu_glyph::{GlyphCruncher, Section};
 use std::cell::RefCell;
 use std::f32;
 
+pub const DEFAULT_TEXT_SIZE : f32 = 20.0*3.0;
+
 impl text::Renderer for Renderer {
     fn node(&self, text: &Text) -> Node {
         let glyph_brush = self.glyph_brush.clone();
@@ -18,7 +20,7 @@ impl text::Renderer for Renderer {
         // I noticed that the first measure is the one that matters in
         // practice. Here, we use a RefCell to store the cached measurement.
         let measure = RefCell::new(None);
-        let size = text.size.map(f32::from).unwrap_or(20.0);
+        let size = text.size.map(f32::from).unwrap_or(DEFAULT_TEXT_SIZE);
 
         let style = Style::default().width(text.width);
 
@@ -71,7 +73,7 @@ impl text::Renderer for Renderer {
         (
             Primitive::Text {
                 content: text.content.clone(),
-                size: f32::from(text.size.unwrap_or(20)),
+                size: text.size.map(f32::from).unwrap_or(DEFAULT_TEXT_SIZE),
                 bounds: layout.bounds(),
                 color: text.color.unwrap_or(Color::BLACK),
                 horizontal_alignment: text.horizontal_alignment,


### PR DESCRIPTION
The tour example sizes needs to be adapted to screen resolution.
It seems to use a lot of hardcoded pixel sizes, e.g wgpu default text size.
This PR is only to start the discussion : 
 It fixes some sizes hardcoded to my scale (288ppi) until it is clear how and where resolution independence should be implemented.

I think best would be to use physical units :
- font size: in pt 
- layout size: in em (relative to the text)