### PR TITLE
Fork glam to remove a panic assert

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -13,6 +13,6 @@ wgpu = { version = "0.3", git = "https://github.com/gfx-rs/wgpu-rs", rev = "ed2c
 wgpu_glyph = { version = "0.4", git = "https://github.com/hecrj/wgpu_glyph", rev = "954ac865ca1b7f6b97bf403f8c6174a7120e667c" }
 raw-window-handle = "0.3"
 image = "0.22"
-glam = "0.8"
+glam = { git = "https://github.com/bitshifter/glam-rs?31" }
 font-kit = "0.4"
 log = "0.4"


### PR DESCRIPTION
Depends on #40 .
Not sure if/how you want to handle any 3D transforms.
Currently you are squashing Z (scale.z=0) which sounds foolproof, except glam foolproofs as well by panicking...
Alternatives : switch to 2D (Mat3), or forward: scale.z=1.

P.S: The panic was triggered on the page with the crab image. Would be nice to be able to skip to it.
P.S: I don't know if new PR to edit a previous one is the conventional github workflow, feel free to correct.
P.S: Are you testing only in release mode, that you did not catch this ?