### PR TITLE
Improve text rendering performance in some scenarios

### DIFF
--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -74,6 +74,7 @@ impl Renderer {
 
         let glyph_brush =
             GlyphBrushBuilder::using_fonts_bytes(vec![default_font, mono_font])
+                .initial_cache_size((2048, 2048))
                 .build(&mut device, TextureFormat::Bgra8UnormSrgb);
 
         let quad_pipeline = quad::Pipeline::new(&mut device);

--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -365,8 +365,8 @@ impl Renderer {
                 // Target physical coordinates directly to avoid blurry text
                 let text = Section {
                     screen_position: (
-                        text.screen_position.0 * dpi,
-                        text.screen_position.1 * dpi,
+                        (text.screen_position.0 * dpi).round(),
+                        (text.screen_position.1 * dpi).round(),
                     ),
                     bounds: (text.bounds.0 * dpi, text.bounds.1 * dpi),
                     scale: wgpu_glyph::Scale {


### PR DESCRIPTION
This PR implements a couple of simple optimizations that should improve text rendering performance under some circumstances.

In particular:
- The initial glyph cache size has been increased from `512x512` to `2048x2048`. This should reduce the amount of cache updates in most applications.
- The text positions are aligned to the physical pixel grid. This reduces the amount of rasterization (and therefore cache updates) in environments with a nonintegral DPI factor.