### PR TITLE
Touch support

### DIFF
--- a/core/src/mouse/event.rs
+++ b/core/src/mouse/event.rs
@@ -1,3 +1,5 @@
+use crate::Point;
+
 use super::Button;
 
 /// A mouse event.
@@ -16,11 +18,8 @@ pub enum Event {
 
     /// The mouse cursor was moved
     CursorMoved {
-        /// The X coordinate of the mouse position
-        x: f32,
-
-        /// The Y coordinate of the mouse position
-        y: f32,
+        /// The new position of the mouse cursor
+        position: Point,
     },
 
     /// A mouse button was pressed.

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -22,7 +22,7 @@ pub enum Event {
     Window(window::Event),
 
     /// A touch event
-    Touch(touch::Touch),
+    Touch(touch::Event),
 }
 
 /// The status of an [`Event`] after being processed.

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -1,5 +1,8 @@
 //! Handle events of a user interface.
-use crate::{keyboard, mouse, window};
+use crate::keyboard;
+use crate::mouse;
+use crate::touch;
+use crate::window;
 
 /// A user interface event.
 ///
@@ -17,6 +20,9 @@ pub enum Event {
 
     /// A window event
     Window(window::Event),
+
+    /// A touch event
+    Touch(touch::Touch),
 }
 
 /// The status of an [`Event`] after being processed.

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -41,6 +41,7 @@ pub mod overlay;
 pub mod program;
 pub mod renderer;
 pub mod subscription;
+pub mod touch;
 pub mod widget;
 pub mod window;
 

--- a/native/src/touch.rs
+++ b/native/src/touch.rs
@@ -1,0 +1,35 @@
+//! Build touch events.
+use crate::Point;
+
+/// A touch interaction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Touch {
+    /// The finger of the touch.
+    pub finger: Finger,
+
+    /// The position of the touch.
+    pub position: Point,
+
+    /// The state of the touch.
+    pub phase: Phase,
+}
+
+/// A unique identifier representing a finger on a touch interaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Finger(pub u64);
+
+/// The state of a touch interaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    /// A touch interaction was started.
+    Started,
+
+    /// An on-going touch interaction was moved.
+    Moved,
+
+    /// A touch interaction was ended.
+    Ended,
+
+    /// A touch interaction was canceled.
+    Canceled,
+}

--- a/native/src/touch.rs
+++ b/native/src/touch.rs
@@ -3,33 +3,21 @@ use crate::Point;
 
 /// A touch interaction.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Touch {
-    /// The finger of the touch.
-    pub finger: Finger,
+#[allow(missing_docs)]
+pub enum Event {
+    /// A touch interaction was started.
+    FingerPressed { id: Finger, position: Point },
 
-    /// The position of the touch.
-    pub position: Point,
+    /// An on-going touch interaction was moved.
+    FingerMoved { id: Finger, position: Point },
 
-    /// The state of the touch.
-    pub phase: Phase,
+    /// A touch interaction was ended.
+    FingerLifted { id: Finger, position: Point },
+
+    /// A touch interaction was canceled.
+    FingerLost { id: Finger, position: Point },
 }
 
 /// A unique identifier representing a finger on a touch interaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Finger(pub u64);
-
-/// The state of a touch interaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Phase {
-    /// A touch interaction was started.
-    Started,
-
-    /// An on-going touch interaction was moved.
-    Moved,
-
-    /// A touch interaction was ended.
-    Ended,
-
-    /// A touch interaction was canceled.
-    Canceled,
-}

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -4,7 +4,7 @@
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
-use crate::touch::{self, Touch};
+use crate::touch;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
@@ -166,10 +166,7 @@ where
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Started,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if self.on_press.is_some() {
                     let bounds = layout.bounds();
 
@@ -181,10 +178,7 @@ where
                 }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Ended,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerLifted { .. }) => {
                 if let Some(on_press) = self.on_press.clone() {
                     let bounds = layout.bounds();
 
@@ -199,10 +193,7 @@ where
                     }
                 }
             }
-            Event::Touch(Touch {
-                phase: touch::Phase::Canceled,
-                ..
-            }) => {
+            Event::Touch(touch::Event::FingerLost { .. }) => {
                 self.state.is_pressed = false;
             }
             _ => {}

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -4,6 +4,7 @@
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
+use crate::touch::{self, Touch};
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
@@ -164,7 +165,11 @@ where
         _clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
         match event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(Touch {
+                phase: touch::Phase::Started,
+                ..
+            }) => {
                 if self.on_press.is_some() {
                     let bounds = layout.bounds();
 
@@ -175,7 +180,11 @@ where
                     }
                 }
             }
-            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(Touch {
+                phase: touch::Phase::Ended,
+                ..
+            }) => {
                 if let Some(on_press) = self.on_press.clone() {
                     let bounds = layout.bounds();
 
@@ -189,6 +198,12 @@ where
                         return event::Status::Captured;
                     }
                 }
+            }
+            Event::Touch(Touch {
+                phase: touch::Phase::Canceled,
+                ..
+            }) => {
+                self.state.is_pressed = false;
             }
             _ => {}
         }

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -6,6 +6,7 @@ use crate::layout;
 use crate::mouse;
 use crate::row;
 use crate::text;
+use crate::touch::{self, Touch};
 use crate::{
     Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
     Point, Rectangle, Row, Text, VerticalAlignment, Widget,
@@ -154,7 +155,11 @@ where
         _clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
         match event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(Touch {
+                phase: touch::Phase::Started,
+                ..
+            }) => {
                 let mouse_over = layout.bounds().contains(cursor_position);
 
                 if mouse_over {

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -6,7 +6,7 @@ use crate::layout;
 use crate::mouse;
 use crate::row;
 use crate::text;
-use crate::touch::{self, Touch};
+use crate::touch;
 use crate::{
     Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
     Point, Rectangle, Row, Text, VerticalAlignment, Widget,
@@ -156,10 +156,7 @@ where
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Started,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 let mouse_over = layout.bounds().contains(cursor_position);
 
                 if mouse_over {

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -4,6 +4,7 @@ use crate::layout;
 use crate::mouse;
 use crate::row;
 use crate::text;
+use crate::touch::{self, Touch};
 use crate::{
     Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
     Point, Rectangle, Row, Text, VerticalAlignment, Widget,
@@ -160,7 +161,11 @@ where
         _clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
         match event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(Touch {
+                phase: touch::Phase::Started,
+                ..
+            }) => {
                 if layout.bounds().contains(cursor_position) {
                     messages.push(self.on_click.clone());
 

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -4,7 +4,7 @@ use crate::layout;
 use crate::mouse;
 use crate::row;
 use crate::text;
-use crate::touch::{self, Touch};
+use crate::touch;
 use crate::{
     Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
     Point, Rectangle, Row, Text, VerticalAlignment, Widget,
@@ -162,10 +162,7 @@ where
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Started,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if layout.bounds().contains(cursor_position) {
                     messages.push(self.on_click.clone());
 

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -4,7 +4,7 @@
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
-use crate::touch::{self, Touch};
+use crate::touch;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
@@ -209,10 +209,7 @@ where
 
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Started,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if layout.bounds().contains(cursor_position) {
                     change();
                     self.state.is_dragging = true;
@@ -221,10 +218,8 @@ where
                 }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Ended,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
                 if self.state.is_dragging {
                     if let Some(on_release) = self.on_release.clone() {
                         messages.push(on_release);
@@ -235,10 +230,7 @@ where
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. })
-            | Event::Touch(Touch {
-                phase: touch::Phase::Moved,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if self.state.is_dragging {
                     change();
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -16,7 +16,7 @@ use crate::keyboard;
 use crate::layout;
 use crate::mouse::{self, click};
 use crate::text;
-use crate::touch::{self, Touch};
+use crate::touch;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
@@ -249,10 +249,7 @@ where
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(Touch {
-                phase: touch::Phase::Started,
-                ..
-            }) => {
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 let is_clicked = layout.bounds().contains(cursor_position);
 
                 self.state.is_focused = is_clicked;

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -16,6 +16,7 @@ use crate::keyboard;
 use crate::layout;
 use crate::mouse::{self, click};
 use crate::text;
+use crate::touch::{self, Touch};
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
@@ -247,7 +248,11 @@ where
         clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
         match event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(Touch {
+                phase: touch::Phase::Started,
+                ..
+            }) => {
                 let is_clicked = layout.bounds().contains(cursor_position);
 
                 self.state.is_focused = is_clicked;
@@ -321,10 +326,10 @@ where
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 self.state.is_dragging = false;
             }
-            Event::Mouse(mouse::Event::CursorMoved { x, .. }) => {
+            Event::Mouse(mouse::Event::CursorMoved { position }) => {
                 if self.state.is_dragging {
                     let text_layout = layout.children().next().unwrap();
-                    let target = x - text_layout.bounds().x;
+                    let target = position.x - text_layout.bounds().x;
 
                     if target > 0.0 {
                         let value = if self.is_secure {

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -320,10 +320,13 @@ where
                     return event::Status::Captured;
                 }
             }
-            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
                 self.state.is_dragging = false;
             }
-            Event::Mouse(mouse::Event::CursorMoved { position }) => {
+            Event::Mouse(mouse::Event::CursorMoved { position })
+            | Event::Touch(touch::Event::FingerMoved { position, .. }) => {
                 if self.state.is_dragging {
                     let text_layout = layout.children().next().unwrap();
                     let target = position.x - text_layout.bounds().x;

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -2,7 +2,7 @@ use crate::conversion;
 use crate::{Application, Color, Debug, Mode, Point, Size, Viewport};
 
 use std::marker::PhantomData;
-use winit::event::WindowEvent;
+use winit::event::{Touch, WindowEvent};
 use winit::window::Window;
 
 /// The state of a windowed [`Application`].
@@ -128,7 +128,10 @@ impl<A: Application> State<A> {
 
                 self.viewport_version = self.viewport_version.wrapping_add(1);
             }
-            WindowEvent::CursorMoved { position, .. } => {
+            WindowEvent::CursorMoved { position, .. }
+            | WindowEvent::Touch(Touch {
+                location: position, ..
+            }) => {
                 self.cursor_position = *position;
             }
             WindowEvent::CursorLeft { .. } => {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -2,12 +2,11 @@
 //!
 //! [`winit`]: https://github.com/rust-windowing/winit
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-use crate::{
-    keyboard::{self, KeyCode, Modifiers},
-    mouse,
-    touch::{self, Touch},
-    window, Event, Mode, Point,
-};
+use crate::keyboard;
+use crate::mouse;
+use crate::touch;
+use crate::window;
+use crate::{Event, Mode, Point};
 
 /// Converts a winit window event into an iced event.
 pub fn window_event(
@@ -183,8 +182,10 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-pub fn modifiers(modifiers: winit::event::ModifiersState) -> Modifiers {
-    Modifiers {
+pub fn modifiers(
+    modifiers: winit::event::ModifiersState,
+) -> keyboard::Modifiers {
+    keyboard::Modifiers {
         shift: modifiers.shift(),
         control: modifiers.ctrl(),
         alt: modifiers.alt(),
@@ -206,18 +207,23 @@ pub fn cursor_position(
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-pub fn touch_event(touch: winit::event::Touch) -> Touch {
-    let phase = match touch.phase {
-        winit::event::TouchPhase::Started => touch::Phase::Started,
-        winit::event::TouchPhase::Moved => touch::Phase::Moved,
-        winit::event::TouchPhase::Ended => touch::Phase::Ended,
-        winit::event::TouchPhase::Cancelled => touch::Phase::Canceled,
-    };
+pub fn touch_event(touch: winit::event::Touch) -> touch::Event {
+    let id = touch::Finger(touch.id);
+    let position = Point::new(touch.location.x as f32, touch.location.y as f32);
 
-    Touch {
-        finger: touch::Finger(touch.id),
-        position: Point::new(touch.location.x as f32, touch.location.y as f32),
-        phase,
+    match touch.phase {
+        winit::event::TouchPhase::Started => {
+            touch::Event::FingerPressed { id, position }
+        }
+        winit::event::TouchPhase::Moved => {
+            touch::Event::FingerMoved { id, position }
+        }
+        winit::event::TouchPhase::Ended => {
+            touch::Event::FingerLifted { id, position }
+        }
+        winit::event::TouchPhase::Cancelled => {
+            touch::Event::FingerLost { id, position }
+        }
     }
 }
 
@@ -225,7 +231,11 @@ pub fn touch_event(touch: winit::event::Touch) -> Touch {
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-pub fn key_code(virtual_keycode: winit::event::VirtualKeyCode) -> KeyCode {
+pub fn key_code(
+    virtual_keycode: winit::event::VirtualKeyCode,
+) -> keyboard::KeyCode {
+    use keyboard::KeyCode;
+
     match virtual_keycode {
         winit::event::VirtualKeyCode::Key1 => KeyCode::Key1,
         winit::event::VirtualKeyCode::Key2 => KeyCode::Key2,

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -118,7 +118,9 @@ pub fn window_event(
         WindowEvent::HoveredFileCancelled => {
             Some(Event::Window(window::Event::FilesHoveredLeft))
         }
-        WindowEvent::Touch(touch) => Some(Event::Touch(touch_event(*touch))),
+        WindowEvent::Touch(touch) => {
+            Some(Event::Touch(touch_event(*touch, scale_factor)))
+        }
         _ => None,
     }
 }
@@ -207,9 +209,16 @@ pub fn cursor_position(
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-pub fn touch_event(touch: winit::event::Touch) -> touch::Event {
+pub fn touch_event(
+    touch: winit::event::Touch,
+    scale_factor: f64,
+) -> touch::Event {
     let id = touch::Finger(touch.id);
-    let position = Point::new(touch.location.x as f32, touch.location.y as f32);
+    let position = {
+        let location = touch.location.to_logical::<f64>(scale_factor);
+
+        Point::new(location.x as f32, location.y as f32)
+    };
 
     match touch.phase {
         winit::event::TouchPhase::Started => {


### PR DESCRIPTION
I've got mixed feelings about some of this - like that each touch enum has a position in it. I could have done it more similar to how the mouse events work.

I've tested the todo and tour examples on my iPhone 8 with iOS 13.2.2, the things that don't work are:
* Text input (though, the cursor ends up in the text box) - I think we need to signal to winit to pop up the keyboard.
* Touch scrolling on a scrollable widget. Given that the logic around cursor and touch movement not having the previous location, this didn't seem very easy to do. Fortunately, the side scrollbar works.

Here's what the tour example looks like (up to just before the rust image):

![output](https://user-images.githubusercontent.com/1163510/68925411-d8cb0180-0737-11ea-80ad-863694c75342.gif)
