### PR TITLE
Make `width` and `height` in `Widget` required methods

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -299,6 +299,14 @@ where
     A: Clone,
     Renderer: crate::Renderer,
 {
+    fn width(&self) -> Length {
+        self.widget.width()
+    }
+
+    fn height(&self) -> Length {
+        self.widget.height()
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,
@@ -375,6 +383,14 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: crate::Renderer + renderer::Debugger,
 {
+    fn width(&self) -> Length {
+        self.element.widget.width()
+    }
+
+    fn height(&self) -> Length {
+        self.element.widget.height()
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -69,6 +69,10 @@ pub trait Widget<Message, Renderer>: std::fmt::Debug
 where
     Renderer: crate::Renderer,
 {
+    fn width(&self) -> Length;
+
+    fn height(&self) -> Length;
+
     /// Returns the [`Node`] of the [`Widget`].
     ///
     /// This [`Node`] is used by the runtime to compute the [`Layout`] of the
@@ -82,14 +86,6 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node;
-
-    fn width(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
 
     /// Draws the [`Widget`] using the associated `Renderer`.
     ///

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -7,7 +7,7 @@
 //! [`Class`]: enum.Class.html
 
 use crate::input::{mouse, ButtonState};
-use crate::{layout, Element, Event, Hasher, Layout, Point, Widget};
+use crate::{layout, Element, Event, Hasher, Layout, Length, Point, Widget};
 use std::hash::Hash;
 
 pub use iced_core::button::State;
@@ -21,6 +21,14 @@ where
     Renderer: self::Renderer,
     Message: Clone + std::fmt::Debug,
 {
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        Length::Shrink
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -14,6 +14,10 @@ where
         Length::Fill
     }
 
+    fn height(&self) -> Length {
+        Length::Shrink
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -15,6 +15,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -15,6 +15,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -1,6 +1,6 @@
 //! Display images in your user interface.
 
-use crate::{layout, Element, Hasher, Layout, Point, Widget};
+use crate::{layout, Element, Hasher, Layout, Length, Point, Widget};
 
 use std::hash::Hash;
 
@@ -10,6 +10,14 @@ impl<Message, Renderer> Widget<Message, Renderer> for Image
 where
     Renderer: self::Renderer,
 {
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -15,6 +15,10 @@ where
         Length::Fill
     }
 
+    fn height(&self) -> Length {
+        Length::Shrink
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -15,6 +15,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -21,6 +21,14 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: self::Renderer + column::Renderer,
 {
+    fn width(&self) -> Length {
+        Length::Fill
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -19,6 +19,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        Length::Shrink
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -13,6 +13,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        self.height
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -15,6 +15,10 @@ where
         self.width
     }
 
+    fn height(&self) -> Length {
+        Length::Shrink
+    }
+
     fn layout(
         &self,
         renderer: &Renderer,


### PR DESCRIPTION
Fixes #59.

This PR makes the `width` and `height` methods in the `Widget` trait required methods. This should help us avoid pesky bugs in the future.

Additionally, the PR implements a correct version for all the supported widgets.