### PR TITLE
Async actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ iced_web = { version = "0.1.0-alpha", path = "web" }
 
 [dev-dependencies]
 env_logger = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+directories = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = "0.2.51"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2018"
 description = "The essential concepts of Iced"
 license = "MIT"
 repository = "https://github.com/hecrj/iced"
+
+[features]
+# Exposes a future-based `Command` type
+command = ["futures"]
+
+[dependencies]
+futures = { version = "0.3", optional = true }

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -1,0 +1,49 @@
+use futures::future::{BoxFuture, Future, FutureExt};
+
+pub struct Command<T> {
+    futures: Vec<BoxFuture<'static, T>>,
+}
+
+impl<T> Command<T> {
+    pub fn none() -> Self {
+        Self {
+            futures: Vec::new(),
+        }
+    }
+
+    pub fn attempt<A>(
+        future: impl Future<Output = T> + 'static + Send,
+        f: impl Fn(T) -> A + 'static + Send,
+    ) -> Command<A> {
+        Command {
+            futures: vec![future.map(f).boxed()],
+        }
+    }
+
+    pub fn batch(commands: impl Iterator<Item = Command<T>>) -> Self {
+        Self {
+            futures: commands.flat_map(|command| command.futures).collect(),
+        }
+    }
+
+    pub fn futures(self) -> Vec<BoxFuture<'static, T>> {
+        self.futures
+    }
+}
+
+impl<T, A> From<A> for Command<T>
+where
+    A: Future<Output = T> + 'static + Send,
+{
+    fn from(future: A) -> Self {
+        Self {
+            futures: vec![future.boxed()],
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for Command<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command").finish()
+    }
+}

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -11,7 +11,7 @@ impl<T> Command<T> {
         }
     }
 
-    pub fn attempt<A>(
+    pub fn perform<A>(
         future: impl Future<Output = T> + 'static + Send,
         f: impl Fn(T) -> A + 'static + Send,
     ) -> Command<A> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,8 @@ pub mod widget;
 mod align;
 mod background;
 mod color;
+#[cfg(feature = "command")]
+mod command;
 mod font;
 mod length;
 mod point;
@@ -12,6 +14,8 @@ mod vector;
 pub use align::Align;
 pub use background::Background;
 pub use color::Color;
+#[cfg(feature = "command")]
+pub use command::Command;
 pub use font::Font;
 pub use length::Length;
 pub use point::Point;

--- a/core/src/widget/text_input.rs
+++ b/core/src/widget/text_input.rs
@@ -80,7 +80,7 @@ where
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct State {
     pub is_focused: bool,
     cursor_position: usize,

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -1,12 +1,12 @@
 use iced::{
-    button, scrollable, Align, Application, Button, Container, Element, Image,
-    Length, Scrollable, Text,
+    button, scrollable, Align, Application, Button, Command, Container,
+    Element, Image, Length, Scrollable, Text,
 };
 
 pub fn main() {
     env_logger::init();
 
-    Example::default().run()
+    Example::run()
 }
 
 #[derive(Default)]
@@ -25,16 +25,22 @@ pub enum Message {
 impl Application for Example {
     type Message = Message;
 
+    fn new() -> (Example, Command<Message>) {
+        (Example::default(), Command::none())
+    }
+
     fn title(&self) -> String {
         String::from("Scroll - Iced")
     }
 
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::AddItem => {
                 self.item_count += 1;
             }
         }
+
+        Command::none()
     }
 
     fn view(&mut self) -> Element<Message> {

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -1,11 +1,11 @@
 use iced::{
     button, scrollable, text::HorizontalAlignment, text_input, Align,
-    Application, Background, Button, Checkbox, Color, Column, Container,
-    Element, Font, Length, Row, Scrollable, Text, TextInput,
+    Application, Background, Button, Checkbox, Color, Column, Command,
+    Container, Element, Font, Length, Row, Scrollable, Text, TextInput,
 };
 
 pub fn main() {
-    Todos::default().run()
+    Todos::run()
 }
 
 #[derive(Debug, Default)]
@@ -29,11 +29,15 @@ pub enum Message {
 impl Application for Todos {
     type Message = Message;
 
+    fn new() -> (Todos, Command<Message>) {
+        (Todos::default(), Command::none())
+    }
+
     fn title(&self) -> String {
         String::from("Todos - Iced")
     }
 
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::InputChanged(value) => {
                 self.input_value = value;
@@ -58,6 +62,8 @@ impl Application for Todos {
         }
 
         dbg!(self);
+
+        Command::none()
     }
 
     fn view(&mut self) -> Element<Message> {

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -41,7 +41,7 @@ impl Application for Todos {
     type Message = Message;
 
     fn new() -> (Todos, Command<Message>) {
-        (Todos::Loading, Command::attempt(load(), Message::Loaded))
+        (Todos::Loading, Command::perform(load(), Message::Loaded))
     }
 
     fn title(&self) -> String {
@@ -114,7 +114,7 @@ impl Application for Todos {
                     state.dirty = false;
                     state.saving = true;
 
-                    Command::attempt(
+                    Command::perform(
                         save(SavedState {
                             input_value: state.input_value.clone(),
                             filter: state.filter,

--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -3,23 +3,34 @@ use iced::{
     Application, Background, Button, Checkbox, Color, Column, Command,
     Container, Element, Font, Length, Row, Scrollable, Text, TextInput,
 };
+use serde::{Deserialize, Serialize};
 
 pub fn main() {
     Todos::run()
 }
 
+#[derive(Debug)]
+enum Todos {
+    Loading,
+    Loaded(State),
+}
+
 #[derive(Debug, Default)]
-struct Todos {
+struct State {
     scroll: scrollable::State,
     input: text_input::State,
     input_value: String,
     filter: Filter,
     tasks: Vec<Task>,
     controls: Controls,
+    dirty: bool,
+    saving: bool,
 }
 
 #[derive(Debug, Clone)]
-pub enum Message {
+enum Message {
+    Loaded(Result<SavedState, LoadError>),
+    Saved(Result<(), SaveError>),
     InputChanged(String),
     CreateTask,
     FilterChanged(Filter),
@@ -30,113 +41,175 @@ impl Application for Todos {
     type Message = Message;
 
     fn new() -> (Todos, Command<Message>) {
-        (Todos::default(), Command::none())
+        (Todos::Loading, Command::attempt(load(), Message::Loaded))
     }
 
     fn title(&self) -> String {
-        String::from("Todos - Iced")
+        let dirty = match self {
+            Todos::Loading => false,
+            Todos::Loaded(state) => state.dirty,
+        };
+
+        format!("Todos{} - Iced", if dirty { "*" } else { "" })
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {
-        match message {
-            Message::InputChanged(value) => {
-                self.input_value = value;
-            }
-            Message::CreateTask => {
-                if !self.input_value.is_empty() {
-                    self.tasks.push(Task::new(self.input_value.clone()));
-                    self.input_value.clear();
+        match self {
+            Todos::Loading => {
+                match message {
+                    Message::Loaded(Ok(state)) => {
+                        *self = Todos::Loaded(State {
+                            input_value: state.input_value,
+                            filter: state.filter,
+                            tasks: state.tasks,
+                            ..State::default()
+                        });
+                    }
+                    Message::Loaded(Err(_)) => {
+                        *self = Todos::Loaded(State::default());
+                    }
+                    _ => {}
                 }
+
+                Command::none()
             }
-            Message::FilterChanged(filter) => {
-                self.filter = filter;
-            }
-            Message::TaskMessage(i, TaskMessage::Delete) => {
-                self.tasks.remove(i);
-            }
-            Message::TaskMessage(i, task_message) => {
-                if let Some(task) = self.tasks.get_mut(i) {
-                    task.update(task_message);
+            Todos::Loaded(state) => {
+                let mut saved = false;
+
+                match message {
+                    Message::InputChanged(value) => {
+                        state.input_value = value;
+                    }
+                    Message::CreateTask => {
+                        if !state.input_value.is_empty() {
+                            state
+                                .tasks
+                                .push(Task::new(state.input_value.clone()));
+                            state.input_value.clear();
+                        }
+                    }
+                    Message::FilterChanged(filter) => {
+                        state.filter = filter;
+                    }
+                    Message::TaskMessage(i, TaskMessage::Delete) => {
+                        state.tasks.remove(i);
+                    }
+                    Message::TaskMessage(i, task_message) => {
+                        if let Some(task) = state.tasks.get_mut(i) {
+                            task.update(task_message);
+                        }
+                    }
+                    Message::Saved(_) => {
+                        state.saving = false;
+                        saved = true;
+                    }
+                    _ => {}
+                }
+
+                if !saved {
+                    state.dirty = true;
+                }
+
+                if state.dirty && !state.saving {
+                    state.dirty = false;
+                    state.saving = true;
+
+                    Command::attempt(
+                        save(SavedState {
+                            input_value: state.input_value.clone(),
+                            filter: state.filter,
+                            tasks: state.tasks.clone(),
+                        }),
+                        Message::Saved,
+                    )
+                } else {
+                    Command::none()
                 }
             }
         }
-
-        dbg!(self);
-
-        Command::none()
     }
 
     fn view(&mut self) -> Element<Message> {
-        let Todos {
-            scroll,
-            input,
-            input_value,
-            filter,
-            tasks,
-            controls,
-        } = self;
+        match self {
+            Todos::Loading => loading_message(),
+            Todos::Loaded(State {
+                scroll,
+                input,
+                input_value,
+                filter,
+                tasks,
+                controls,
+                ..
+            }) => {
+                let title = Text::new("todos")
+                    .size(100)
+                    .color([0.5, 0.5, 0.5])
+                    .horizontal_alignment(HorizontalAlignment::Center);
 
-        let title = Text::new("todos")
-            .size(100)
-            .color([0.5, 0.5, 0.5])
-            .horizontal_alignment(HorizontalAlignment::Center);
+                let input = TextInput::new(
+                    input,
+                    "What needs to be done?",
+                    input_value,
+                    Message::InputChanged,
+                )
+                .padding(15)
+                .size(30)
+                .on_submit(Message::CreateTask);
 
-        let input = TextInput::new(
-            input,
-            "What needs to be done?",
-            input_value,
-            Message::InputChanged,
-        )
-        .padding(15)
-        .size(30)
-        .on_submit(Message::CreateTask);
+                let controls = controls.view(&tasks, *filter);
+                let filtered_tasks =
+                    tasks.iter().filter(|task| filter.matches(task));
 
-        let controls = controls.view(&tasks, *filter);
-        let filtered_tasks = tasks.iter().filter(|task| filter.matches(task));
-
-        let tasks: Element<_> =
-            if filtered_tasks.count() > 0 {
-                tasks
-                    .iter_mut()
-                    .enumerate()
-                    .filter(|(_, task)| filter.matches(task))
-                    .fold(Column::new().spacing(20), |column, (i, task)| {
-                        column.push(task.view().map(move |message| {
-                            Message::TaskMessage(i, message)
-                        }))
+                let tasks: Element<_> = if filtered_tasks.count() > 0 {
+                    tasks
+                        .iter_mut()
+                        .enumerate()
+                        .filter(|(_, task)| filter.matches(task))
+                        .fold(Column::new().spacing(20), |column, (i, task)| {
+                            column.push(task.view().map(move |message| {
+                                Message::TaskMessage(i, message)
+                            }))
+                        })
+                        .into()
+                } else {
+                    empty_message(match filter {
+                        Filter::All => "You have not created a task yet...",
+                        Filter::Active => "All your tasks are done! :D",
+                        Filter::Completed => {
+                            "You have not completed a task yet..."
+                        }
                     })
+                };
+
+                let content = Column::new()
+                    .max_width(800)
+                    .spacing(20)
+                    .push(title)
+                    .push(input)
+                    .push(controls)
+                    .push(tasks);
+
+                Scrollable::new(scroll)
+                    .padding(40)
+                    .push(
+                        Container::new(content).width(Length::Fill).center_x(),
+                    )
                     .into()
-            } else {
-                empty_message(match filter {
-                    Filter::All => "You have not created a task yet...",
-                    Filter::Active => "All your tasks are done! :D",
-                    Filter::Completed => "You have not completed a task yet...",
-                })
-            };
-
-        let content = Column::new()
-            .max_width(800)
-            .spacing(20)
-            .push(title)
-            .push(input)
-            .push(controls)
-            .push(tasks);
-
-        Scrollable::new(scroll)
-            .padding(40)
-            .push(Container::new(content).width(Length::Fill).center_x())
-            .into()
+            }
+        }
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct Task {
     description: String,
     completed: bool,
+
+    #[serde(skip)]
     state: TaskState,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TaskState {
     Idle {
         edit_button: button::State,
@@ -145,6 +218,14 @@ pub enum TaskState {
         text_input: text_input::State,
         delete_button: button::State,
     },
+}
+
+impl Default for TaskState {
+    fn default() -> Self {
+        TaskState::Idle {
+            edit_button: button::State::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -255,7 +336,7 @@ impl Task {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Controls {
     all_button: button::State,
     active_button: button::State,
@@ -324,7 +405,7 @@ impl Controls {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Filter {
     All,
     Active,
@@ -345,6 +426,18 @@ impl Filter {
             Filter::Completed => task.completed,
         }
     }
+}
+
+fn loading_message() -> Element<'static, Message> {
+    Container::new(
+        Text::new("Loading...")
+            .horizontal_alignment(HorizontalAlignment::Center)
+            .size(50),
+    )
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .center_y()
+    .into()
 }
 
 fn empty_message(message: &str) -> Element<'static, Message> {
@@ -380,4 +473,79 @@ fn edit_icon() -> Text {
 
 fn delete_icon() -> Text {
     icon('\u{F1F8}')
+}
+
+// Persistence
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SavedState {
+    input_value: String,
+    filter: Filter,
+    tasks: Vec<Task>,
+}
+
+fn save_path() -> std::path::PathBuf {
+    let mut path = if let Some(project_dirs) =
+        directories::ProjectDirs::from("rs", "Iced", "Todos")
+    {
+        project_dirs.data_dir().into()
+    } else {
+        std::env::current_dir()
+            .expect("The current directory is not accessible")
+    };
+
+    path.push("todos.json");
+
+    path
+}
+
+#[derive(Debug, Clone)]
+enum LoadError {
+    FileError,
+    FormatError,
+}
+
+async fn load() -> Result<SavedState, LoadError> {
+    use std::io::Read;
+
+    let mut contents = String::new();
+
+    let mut file =
+        std::fs::File::open(save_path()).map_err(|_| LoadError::FileError)?;
+
+    file.read_to_string(&mut contents)
+        .map_err(|_| LoadError::FileError)?;
+
+    serde_json::from_str(&contents).map_err(|_| LoadError::FormatError)
+}
+
+#[derive(Debug, Clone)]
+enum SaveError {
+    DirectoryError,
+    FileError,
+    WriteError,
+    FormatError,
+}
+
+async fn save(state: SavedState) -> Result<(), SaveError> {
+    use std::io::Write;
+
+    let json = serde_json::to_string_pretty(&state)
+        .map_err(|_| SaveError::FormatError)?;
+
+    let save_path = save_path();
+    let save_dir = save_path.parent().ok_or(SaveError::DirectoryError)?;
+
+    std::fs::create_dir_all(save_dir).map_err(|_| SaveError::DirectoryError)?;
+
+    let mut file =
+        std::fs::File::create(save_path).map_err(|_| SaveError::FileError)?;
+
+    file.write_all(json.as_bytes())
+        .map_err(|_| SaveError::WriteError)?;
+
+    // This is a simple way to save at most once every couple seconds
+    // We will be able to get rid of it once we implement event subscriptions
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    Ok(())
 }

--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -1,13 +1,14 @@
 use iced::{
     button, scrollable, slider, text::HorizontalAlignment, text_input,
-    Application, Background, Button, Checkbox, Color, Column, Container,
-    Element, Image, Length, Radio, Row, Scrollable, Slider, Text, TextInput,
+    Application, Background, Button, Checkbox, Color, Column, Command,
+    Container, Element, Image, Length, Radio, Row, Scrollable, Slider, Text,
+    TextInput,
 };
 
 pub fn main() {
     env_logger::init();
 
-    Tour::new().run()
+    Tour::run()
 }
 
 pub struct Tour {
@@ -18,26 +19,27 @@ pub struct Tour {
     debug: bool,
 }
 
-impl Tour {
-    pub fn new() -> Tour {
-        Tour {
-            steps: Steps::new(),
-            scroll: scrollable::State::new(),
-            back_button: button::State::new(),
-            next_button: button::State::new(),
-            debug: true,
-        }
-    }
-}
-
 impl Application for Tour {
     type Message = Message;
+
+    fn new() -> (Tour, Command<Message>) {
+        (
+            Tour {
+                steps: Steps::new(),
+                scroll: scrollable::State::new(),
+                back_button: button::State::new(),
+                next_button: button::State::new(),
+                debug: true,
+            },
+            Command::none(),
+        )
+    }
 
     fn title(&self) -> String {
         format!("{} - Iced", self.steps.title())
     }
 
-    fn update(&mut self, event: Message) {
+    fn update(&mut self, event: Message) -> Command<Message> {
         match event {
             Message::BackPressed => {
                 self.steps.go_back();
@@ -49,6 +51,8 @@ impl Application for Tour {
                 self.steps.update(step_msg, &mut self.debug);
             }
         }
+
+        Command::none()
     }
 
     fn view(&mut self) -> Element<Message> {

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT"
 repository = "https://github.com/hecrj/iced"
 
 [dependencies]
-iced_core = { version = "0.1.0-alpha", path = "../core" }
+iced_core = { version = "0.1.0-alpha", path = "../core", features = ["command"] }
 twox-hash = "1.5"
 raw-window-handle = "0.3"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -216,7 +216,7 @@ mod size;
 mod user_interface;
 
 pub use iced_core::{
-    Align, Background, Color, Font, Length, Point, Rectangle, Vector,
+    Align, Background, Color, Command, Font, Length, Point, Rectangle, Vector,
 };
 
 pub use element::Element;

--- a/src/winit.rs
+++ b/src/winit.rs
@@ -2,8 +2,8 @@ pub use iced_wgpu::{Primitive, Renderer};
 
 pub use iced_winit::{
     button, scrollable, slider, text, text_input, winit, Align, Background,
-    Checkbox, Color, Font, Image, Length, Radio, Scrollable, Slider, Text,
-    TextInput,
+    Checkbox, Color, Command, Font, Image, Length, Radio, Scrollable, Slider,
+    Text, TextInput,
 };
 
 pub type Element<'a, Message> = iced_winit::Element<'a, Message, Renderer>;

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -13,4 +13,5 @@ debug = []
 [dependencies]
 iced_native = { version = "0.1.0-alpha", path = "../native" }
 winit = { version = "0.20.0-alpha3", git = "https://github.com/rust-windowing/winit", rev = "709808eb4e69044705fcb214bcc30556db761405"}
+futures = { version = "0.3", features = ["thread-pool"] }
 log = "0.4"


### PR DESCRIPTION
Closes #28.

This PR adds first-class support for asynchronous actions (i.e. non-blocking background work) leveraging the recently stabilized `futures`! :tada:

A `Command` can be handed to the runtime for execution. As the futures comprising it finish, the produced messages will be handed back to `Application::update`.

The `todos` example has been improved to showcase this feature. Now, it automatically saves and loads its state using `serde_json`.

## Changelog
### Added
- `Command<T>`, which represents a batch of `futures` producing a result of type `T`.
- `Application::new`, which must return a `(Self, Command<Message>)`. This allows applications to perform an async action at startup.

### Changed
- `Application::update` now must return a `Command<Message>`. `Command::none` can be used if no async action is needed.
- `Application::run` is a static method now, thanks to the new `Application::new` method.