### PR TITLE
Allow `Application` configuration with `Settings`

### DIFF
--- a/examples/todos.rs
+++ b/examples/todos.rs
@@ -1,12 +1,12 @@
 use iced::{
     button, scrollable, text_input, Align, Application, Background, Button,
     Checkbox, Color, Column, Command, Container, Element, Font,
-    HorizontalAlignment, Length, Row, Scrollable, Text, TextInput,
+    HorizontalAlignment, Length, Row, Scrollable, Settings, Text, TextInput,
 };
 use serde::{Deserialize, Serialize};
 
 pub fn main() {
-    Todos::run()
+    Todos::run(Settings::default())
 }
 
 #[derive(Debug)]

--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -1,13 +1,13 @@
 use iced::{
     button, scrollable, slider, text_input, Background, Button, Checkbox,
     Color, Column, Container, Element, HorizontalAlignment, Image, Length,
-    Radio, Row, Sandbox, Scrollable, Slider, Text, TextInput,
+    Radio, Row, Sandbox, Scrollable, Settings, Slider, Text, TextInput,
 };
 
 pub fn main() {
     env_logger::init();
 
-    Tour::run()
+    Tour::run(Settings::default())
 }
 
 pub struct Tour {

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,4 @@
-use crate::{Command, Element};
+use crate::{Command, Element, Settings};
 
 /// An interactive cross-platform application.
 ///
@@ -19,10 +19,10 @@ use crate::{Command, Element};
 /// before](index.html#overview). We just need to fill in the gaps:
 ///
 /// ```no_run
-/// use iced::{button, Application, Button, Column, Command, Element, Text};
+/// use iced::{button, Application, Button, Column, Command, Element, Settings, Text};
 ///
 /// pub fn main() {
-///     Counter::run()
+///     Counter::run(Settings::default())
 /// }
 ///
 /// #[derive(Default)]
@@ -132,12 +132,12 @@ pub trait Application: Sized {
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Application`]: trait.Application.html
-    fn run()
+    fn run(settings: Settings)
     where
         Self: 'static,
     {
         #[cfg(not(target_arch = "wasm32"))]
-        <Instance<Self> as iced_winit::Application>::run();
+        <Instance<Self> as iced_winit::Application>::run(settings.into());
 
         #[cfg(target_arch = "wasm32")]
         <Instance<Self> as iced_web::Application>::run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ mod application;
 mod platform;
 mod sandbox;
 
+pub mod settings;
+
 pub use application::Application;
 pub use platform::*;
 pub use sandbox::Sandbox;
+pub use settings::Settings;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,4 +1,4 @@
-use crate::{Application, Command, Element};
+use crate::{Application, Command, Element, Settings};
 
 /// A sandboxed [`Application`].
 ///
@@ -19,10 +19,10 @@ use crate::{Application, Command, Element};
 /// to remove the use of [`Command`]:
 ///
 /// ```no_run
-/// use iced::{button, Button, Column, Element, Sandbox, Text};
+/// use iced::{button, Button, Column, Element, Sandbox, Settings, Text};
 ///
 /// pub fn main() {
-///     Counter::run()
+///     Counter::run(Settings::default())
 /// }
 ///
 /// #[derive(Default)]
@@ -121,11 +121,11 @@ pub trait Sandbox {
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Sandbox`]: trait.Sandbox.html
-    fn run()
+    fn run(settings: Settings)
     where
         Self: 'static + Sized,
     {
-        <Self as Application>::run()
+        <Self as Application>::run(settings)
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,43 @@
+//! Configure your application.
+
+/// The settings of an application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Settings {
+    /// The [`Window`] settings.
+    ///
+    /// They will be ignored on the Web.
+    ///
+    /// [`Window`]: struct.Window.html
+    pub window: Window,
+}
+
+/// The window settings of an application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Window {
+    /// The size of the window.
+    pub size: (u32, u32),
+
+    /// Whether the window should be resizable or not.
+    pub resizable: bool,
+}
+
+impl Default for Window {
+    fn default() -> Window {
+        Window {
+            size: (1024, 768),
+            resizable: true,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<Settings> for iced_winit::Settings {
+    fn from(settings: Settings) -> iced_winit::Settings {
+        iced_winit::Settings {
+            window: iced_winit::settings::Window {
+                size: settings.window.size,
+                resizable: settings.window.resizable,
+            },
+        }
+    }
+}

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -3,7 +3,7 @@ use crate::{
     input::{keyboard, mouse},
     renderer::{Target, Windowed},
     Cache, Command, Container, Debug, Element, Event, Length, MouseCursor,
-    UserInterface,
+    Settings, UserInterface,
 };
 
 /// An interactive, native cross-platform application.
@@ -72,7 +72,7 @@ pub trait Application: Sized {
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Application`]: trait.Application.html
-    fn run()
+    fn run(settings: Settings)
     where
         Self: 'static,
     {
@@ -96,13 +96,15 @@ pub trait Application: Sized {
 
         let mut title = application.title();
 
-        // TODO: Ask for window settings and configure this properly
+        let (width, height) = settings.window.size;
+
         let window = WindowBuilder::new()
             .with_title(&title)
             .with_inner_size(winit::dpi::LogicalSize {
-                width: 1280.0,
-                height: 1024.0,
+                width: f64::from(width),
+                height: f64::from(height),
             })
+            .with_resizable(settings.window.resizable)
             .build(&event_loop)
             .expect("Open window");
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -26,10 +26,12 @@ pub use iced_native::*;
 pub use winit;
 
 pub mod conversion;
+pub mod settings;
 
 mod application;
 
 pub use application::Application;
+pub use settings::Settings;
 
 // We disable debug capabilities on release builds unless the `debug` feature
 // is explicitly enabled.

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -1,0 +1,29 @@
+//! Configure your application.
+
+/// The settings of an application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Settings {
+    /// The [`Window`] settings
+    ///
+    /// [`Window`]: struct.Window.html
+    pub window: Window,
+}
+
+/// The window settings of an application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Window {
+    /// The size of the window.
+    pub size: (u32, u32),
+
+    /// Whether the window should be resizable or not.
+    pub resizable: bool,
+}
+
+impl Default for Window {
+    fn default() -> Window {
+        Window {
+            size: (1024, 768),
+            resizable: true,
+        }
+    }
+}


### PR DESCRIPTION
This PR allows basic configuration (just the window size, for now) of an `Application` using the new `Settings` type.