### PR TITLE
Add `From` impls for `Length`, `Point`, and `Size`

### DIFF
--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -27,3 +27,9 @@ impl Length {
         }
     }
 }
+
+impl From<u16> for Length {
+    fn from(units: u16) -> Self {
+        Length::Units(units)
+    }
+}

--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -19,6 +19,18 @@ impl Point {
     }
 }
 
+impl From<[f32; 2]> for Point {
+    fn from([x, y]: [f32; 2]) -> Self {
+        Point { x, y }
+    }
+}
+
+impl From<[u16; 2]> for Point {
+    fn from([x, y]: [u16; 2]) -> Self {
+        Point::new(x.into(), y.into())
+    }
+}
+
 impl std::ops::Add<Vector> for Point {
     type Output = Self;
 

--- a/native/src/size.rs
+++ b/native/src/size.rs
@@ -37,3 +37,15 @@ impl Size {
         }
     }
 }
+
+impl From<[f32; 2]> for Size {
+    fn from([width, height]: [f32; 2]) -> Self {
+        Size { width, height }
+    }
+}
+
+impl From<[u16; 2]> for Size {
+    fn from([width, height]: [u16; 2]) -> Self {
+        Size::new(width.into(), height.into())
+    }
+}


### PR DESCRIPTION
With these, it might make sense to start accepting `Into<Length>`, `Into<Point>`, and `Into<Size>` as function arguments for simplicity.