### PR TITLE
Schedule render after `Command` futures finish in `iced_web`

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Render not being scheduled after `Command` futures finishing.
 
 ## [0.1.0] - 2019-11-25
 ### Added


### PR DESCRIPTION
This PR fixes the futures of a `Command` no triggering a render in `iced_web` when finished.

The fix is a bit dirty, as there is a dependency loop. It'd be great if `dodrio` could notify a `Render` implementor of being mounted in a `Vdom`.