### PR TITLE
Added path to image hash so it updates when path changes

### DIFF
--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -100,6 +100,7 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
+        self.path.hash(state);
         self.width.hash(state);
         self.height.hash(state);
     }


### PR DESCRIPTION
Fixes #100. Image widget should now update its size when given a new image path.