### PR TITLE
Use cfg and path attribute instead of cfg_attr for IntelliJ Rust support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,11 @@
 #![deny(unsafe_code)]
 #![deny(rust_2018_idioms)]
 mod application;
-#[cfg_attr(target_arch = "wasm32", path = "web.rs")]
-#[cfg_attr(not(target_arch = "wasm32"), path = "native.rs")]
+#[cfg(target_arch = "wasm32")]
+#[path = "web.rs"]
+mod platform;
+#[cfg(not(target_arch = "wasm32"))]
+#[path = "native.rs"]
 mod platform;
 mod sandbox;
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -35,8 +35,11 @@ pub use settings::Settings;
 
 // We disable debug capabilities on release builds unless the `debug` feature
 // is explicitly enabled.
-#[cfg_attr(feature = "debug", path = "debug/basic.rs")]
-#[cfg_attr(not(feature = "debug"), path = "debug/null.rs")]
+#[cfg(feature = "debug")]
+#[path = "debug/basic.rs"]
+mod debug;
+#[cfg(not(feature = "debug"))]
+#[path = "debug/null.rs"]
 mod debug;
 
 use debug::Debug;

--- a/winit/src/settings/mod.rs
+++ b/winit/src/settings/mod.rs
@@ -1,7 +1,10 @@
 //! Configure your application.
 
-#[cfg_attr(target_os = "windows", path = "windows.rs")]
-#[cfg_attr(not(target_os = "windows"), path = "not_windows.rs")]
+#[cfg(target_os = "windows")]
+#[path = "windows.rs"]
+mod platform;
+#[cfg(not(target_os = "windows"))]
+#[path = "not_windows.rs"]
 mod platform;
 
 pub use platform::PlatformSpecific;


### PR DESCRIPTION
PR for IntelliJ Rust plugin support by replacing `cfg_attr` with `cfg` and `path`, as per https://github.com/hecrj/iced/issues/104