### PR TITLE
Improve text input behavior

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `image::Handle` type with `from_path` and `from_memory` methods. [#90]
 - `image::Data` enum representing different kinds of image data. [#90]
+- `text_input::Renderer::measure_value` required method to measure the width of a `TextInput` value. [#108]
+- Click-based cursor positioning for `TextInput`. [#108]
+- `Home` and `End` keys support for `TextInput`. [#108]
 
 ### Changed
 - `Image::new` takes an `Into<image::Handle>` now instead of an `Into<String>`. [#90]
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Image` widget not keeping aspect ratio consistently. [#90]
 
 [#90]: https://github.com/hecrj/iced/pull/90
+[#108]: https://github.com/hecrj/iced/pull/108
 
 ## [0.1.0] - 2019-11-25
 ### Added

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -11,16 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `text_input::Renderer::measure_value` required method to measure the width of a `TextInput` value. [#108]
 - Click-based cursor positioning for `TextInput`. [#108]
 - `Home` and `End` keys support for `TextInput`. [#108]
+- `Ctrl+Left` and `Ctrl+Right` cursor word jump for `TextInput`. [#108]
+- `keyboard::ModifiersState` struct which contains the state of the keyboard modifiers. [#108]
 
 ### Changed
 - `Image::new` takes an `Into<image::Handle>` now instead of an `Into<String>`. [#90]
 - `Button::background` takes an `Into<Background>` now instead of a `Background`.
+- `keyboard::Event::Input` now contains key modifiers state. [#108]
 
 ### Fixed
 - `Image` widget not keeping aspect ratio consistently. [#90]
+- `TextInput` not taking grapheme clusters into account. [#108]
 
 [#90]: https://github.com/hecrj/iced/pull/90
 [#108]: https://github.com/hecrj/iced/pull/108
+
 
 ## [0.1.0] - 2019-11-25
 ### Added

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -11,3 +11,4 @@ repository = "https://github.com/hecrj/iced"
 iced_core = { version = "0.1.0", path = "../core", features = ["command"] }
 twox-hash = "1.5"
 raw-window-handle = "0.3"
+unicode-segmentation = "1.6"

--- a/native/src/input/keyboard.rs
+++ b/native/src/input/keyboard.rs
@@ -1,6 +1,8 @@
 //! Build keyboard events.
 mod event;
 mod key_code;
+mod modifiers_state;
 
 pub use event::Event;
 pub use key_code::KeyCode;
+pub use modifiers_state::ModifiersState;

--- a/native/src/input/keyboard/event.rs
+++ b/native/src/input/keyboard/event.rs
@@ -1,13 +1,13 @@
-use super::KeyCode;
+use super::{KeyCode, ModifiersState};
 use crate::input::ButtonState;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
 /// A keyboard event.
 ///
 /// _**Note:** This type is largely incomplete! If you need to track
 /// additional events, feel free to [open an issue] and share your use case!_
 ///
 /// [open an issue]: https://github.com/hecrj/iced/issues
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {
     /// A keyboard key was pressed or released.
     Input {
@@ -16,6 +16,9 @@ pub enum Event {
 
         /// The key identifier
         key_code: KeyCode,
+
+        /// The state of the modifier keys
+        modifiers: ModifiersState,
     },
 
     /// A unicode character was received.

--- a/native/src/input/keyboard/modifiers_state.rs
+++ b/native/src/input/keyboard/modifiers_state.rs
@@ -1,0 +1,15 @@
+/// The current state of the keyboard modifiers.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ModifiersState {
+    /// Whether a shift key is pressed
+    pub shift: bool,
+
+    /// Whether a control key is pressed
+    pub control: bool,
+
+    /// Whether an alt key is pressed
+    pub alt: bool,
+
+    /// Whether a logo key is pressed (e.g. windows key, command key...)
+    pub logo: bool,
+}

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -89,6 +89,10 @@ impl text_input::Renderer for Null {
         20
     }
 
+    fn measure_value(&self, _value: &str, _size: u16) -> f32 {
+        0.0
+    }
+
     fn draw(
         &mut self,
         _bounds: Rectangle,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -238,6 +238,12 @@ where
                 keyboard::KeyCode::Right => {
                     self.state.move_cursor_right(&self.value);
                 }
+                keyboard::KeyCode::Home => {
+                    self.state.cursor_position = 0;
+                }
+                keyboard::KeyCode::End => {
+                    self.state.move_cursor_to_end(&self.value);
+                }
                 _ => {}
             },
             _ => {}

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -202,6 +202,7 @@ where
             Event::Keyboard(keyboard::Event::Input {
                 key_code,
                 state: ButtonState::Pressed,
+                modifiers,
             }) if self.state.is_focused => match key_code {
                 keyboard::KeyCode::Enter => {
                     if let Some(on_submit) = self.on_submit.clone() {

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -477,7 +477,7 @@ fn find_cursor_position<Renderer: self::Renderer>(
         let prev_width = renderer.measure_value(&prev.to_string(), size);
         let next_width = renderer.measure_value(&next.to_string(), size);
 
-        if (target - next_width).abs() > (target - prev_width).abs() {
+        if next_width - target > target - prev_width {
             return start - 1;
         } else {
             return start;

--- a/wgpu/src/renderer/widget/text_input.rs
+++ b/wgpu/src/renderer/widget/text_input.rs
@@ -12,6 +12,24 @@ impl text_input::Renderer for Renderer {
         20
     }
 
+    fn measure_value(&self, value: &str, size: u16) -> f32 {
+        let (mut width, _) = self.text_pipeline.measure(
+            value,
+            f32::from(size),
+            Font::Default,
+            Size::INFINITY,
+        );
+
+        let spaces_at_the_end = value.len() - value.trim_end().len();
+
+        if spaces_at_the_end > 0 {
+            let space_width = self.text_pipeline.space_width(size as f32);
+            width += spaces_at_the_end as f32 * space_width;
+        }
+
+        width
+    }
+
     fn draw(
         &mut self,
         bounds: Rectangle,
@@ -48,7 +66,6 @@ impl text_input::Renderer for Renderer {
             border_radius: 4,
         };
 
-        let size = f32::from(size);
         let text = value.to_string();
 
         let text_value = Primitive::Text {
@@ -68,7 +85,7 @@ impl text_input::Renderer for Renderer {
                 width: f32::INFINITY,
                 ..text_bounds
             },
-            size,
+            size: f32::from(size),
             horizontal_alignment: HorizontalAlignment::Left,
             vertical_alignment: VerticalAlignment::Center,
         };
@@ -77,20 +94,8 @@ impl text_input::Renderer for Renderer {
             let text_before_cursor =
                 value.until(state.cursor_position(value)).to_string();
 
-            let (mut text_value_width, _) = self.text_pipeline.measure(
-                &text_before_cursor,
-                size,
-                Font::Default,
-                Size::new(f32::INFINITY, text_bounds.height),
-            );
-
-            let spaces_at_the_end =
-                text_before_cursor.len() - text_before_cursor.trim_end().len();
-
-            if spaces_at_the_end > 0 {
-                let space_width = self.text_pipeline.space_width(size);
-                text_value_width += spaces_at_the_end as f32 * space_width;
-            }
+            let text_value_width =
+                self.measure_value(&text_before_cursor, size);
 
             let cursor = Primitive::Quad {
                 bounds: Rectangle {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -319,6 +319,7 @@ pub trait Application: Sized {
                         winit::event::KeyboardInput {
                             virtual_keycode: Some(virtual_keycode),
                             state,
+                            modifiers,
                             ..
                         },
                     ..
@@ -334,6 +335,7 @@ pub trait Application: Sized {
                     events.push(Event::Keyboard(keyboard::Event::Input {
                         key_code: conversion::key_code(virtual_keycode),
                         state: conversion::button_state(state),
+                        modifiers: conversion::modifiers_state(modifiers),
                     }));
                 }
                 WindowEvent::CloseRequested => {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -3,7 +3,10 @@
 //! [`winit`]: https://github.com/rust-windowing/winit
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
 use crate::{
-    input::{keyboard::KeyCode, mouse, ButtonState},
+    input::{
+        keyboard::{KeyCode, ModifiersState},
+        mouse, ButtonState,
+    },
     MouseCursor,
 };
 
@@ -44,6 +47,21 @@ pub fn button_state(element_state: winit::event::ElementState) -> ButtonState {
     match element_state {
         winit::event::ElementState::Pressed => ButtonState::Pressed,
         winit::event::ElementState::Released => ButtonState::Released,
+    }
+}
+
+/// Convert some `ModifiersState` from [`winit`] to an [`iced_native`] modifiers state.
+///
+/// [`winit`]: https://github.com/rust-windowing/winit
+/// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
+pub fn modifiers_state(
+    modifiers: winit::event::ModifiersState,
+) -> ModifiersState {
+    ModifiersState {
+        shift: modifiers.shift,
+        control: modifiers.ctrl,
+        alt: modifiers.alt,
+        logo: modifiers.logo,
     }
 }
 


### PR DESCRIPTION
Fixes #105.

[![Text input behavior](https://thumbs.gfycat.com/FakeUntriedGalah-small.gif)](https://gfycat.com/fakeuntriedgalah)

This PR implements click-based cursor positioning in `TextInput`, using a binary search with the text measure function. Additionally, it adds supports for the `Home` and `End` keys.