### PR TITLE
Password input

### DIFF
--- a/examples/tour.rs
+++ b/examples/tour.rs
@@ -280,7 +280,6 @@ impl<'a> Step {
                     *value = new_value;
                 }
             }
-
             StepMessage::ToggleSecureInput(toggle) => {
                 if let Step::TextInput { is_secure, .. } = self {
                     *is_secure = toggle;

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Home` and `End` keys support for `TextInput`. [#108]
 - `Ctrl+Left` and `Ctrl+Right` cursor word jump for `TextInput`. [#108]
 - `keyboard::ModifiersState` struct which contains the state of the keyboard modifiers. [#108]
+- `TextInput::password` method to enable secure password input mode. [#113]
 
 ### Changed
 - `Image::new` takes an `Into<image::Handle>` now instead of an `Into<String>`. [#90]
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#90]: https://github.com/hecrj/iced/pull/90
 [#108]: https://github.com/hecrj/iced/pull/108
+[#113]: https://github.com/hecrj/iced/pull/113
 
 
 ## [0.1.0] - 2019-11-25

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -254,14 +254,26 @@ where
                     }
                 }
                 keyboard::KeyCode::Left => {
-                    if modifiers.control && !self.is_secure {
+                    let jump_modifier_pressed = if cfg!(target_os = "macos") {
+                        modifiers.alt
+                    } else {
+                        modifiers.control
+                    };
+
+                    if jump_modifier_pressed && !self.is_secure {
                         self.state.move_cursor_left_by_words(&self.value);
                     } else {
                         self.state.move_cursor_left(&self.value);
                     }
                 }
                 keyboard::KeyCode::Right => {
-                    if modifiers.control && !self.is_secure {
+                    let jump_modifier_pressed = if cfg!(target_os = "macos") {
+                        modifiers.alt
+                    } else {
+                        modifiers.control
+                    };
+
+                    if jump_modifier_pressed && !self.is_secure {
                         self.state.move_cursor_right_by_words(&self.value);
                     } else {
                         self.state.move_cursor_right(&self.value);


### PR DESCRIPTION
[![Password input - Iced](https://thumbs.gfycat.com/PreciousHardBlackrhino-small.gif)](https://gfycat.com/precioushardblackrhino)

This PR implements a `TextInput::password` method which can be used to allow users to input passwords securely.

When using password mode, the real value of a `TextInput` is not provided to its `Renderer` implementation. Therefore, it's impossible for a `Renderer` to draw it or leak it by mistake.