### PR TITLE
Event subscriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,16 @@ iced_wgpu = { version = "0.1.0", path = "wgpu" }
 iced_web = { version = "0.1.0", path = "web" }
 
 [dev-dependencies]
+iced_native = { version = "0.1", path = "./native" }
+iced_wgpu = { version = "0.1", path = "./wgpu" }
 env_logger = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 directories = "2.0"
-reqwest = "0.9"
-rand = "0.7"
-chrono = "0.4"
 futures = "0.3"
-iced_native = { version = "0.1", path = "./native" }
-iced_wgpu = { version = "0.1", path = "./wgpu" }
+reqwest = "0.9"
+async-std = { version = "1.3", features = ["unstable"] }
+rand = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = "0.2.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 directories = "2.0"
 futures = "0.3"
-reqwest = "0.9"
 async-std = { version = "1.3", features = ["unstable"] }
+surf = { version = "1.0", git = "https://github.com/http-rs/surf.git", rev = "2ff0f95513e82bdb5ccc56767f9dd0985f2eb8fe" }
 rand = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ serde_json = "1.0"
 directories = "2.0"
 reqwest = "0.9"
 rand = "0.7"
+chrono = "0.4"
+futures = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen = "0.2.51"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/hecrj/iced"
 [features]
 # Exposes a future-based `Command` type
 command = ["futures"]
+# Exposes a future-based `Subscription` type
+subscription = ["futures"]
 
 [dependencies]
 futures = { version = "0.3", optional = true }

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -34,8 +34,8 @@ impl<T> Command<T> {
         }
     }
 
-    /// Creates a [`Command`] that performs the actions of all the givens
-    /// futures.
+    /// Creates a [`Command`] that performs the actions of all the given
+    /// commands.
     ///
     /// Once this command is run, all the futures will be exectued at once.
     ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@
 //! [Iced]: https://github.com/hecrj/iced
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
 //! [`iced_web`]: https://github.com/hecrj/iced/tree/master/web
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![deny(unsafe_code)]
@@ -38,3 +38,9 @@ mod command;
 
 #[cfg(feature = "command")]
 pub use command::Command;
+
+#[cfg(feature = "subscription")]
+pub mod subscription;
+
+#[cfg(feature = "subscription")]
+pub use subscription::Subscription;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@
 //! [Iced]: https://github.com/hecrj/iced
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
 //! [`iced_web`]: https://github.com/hecrj/iced/tree/master/web
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![deny(unsafe_code)]

--- a/core/src/subscription.rs
+++ b/core/src/subscription.rs
@@ -1,0 +1,61 @@
+//! Generate events asynchronously for you application.
+
+/// An event subscription.
+pub struct Subscription<T> {
+    definitions: Vec<Box<dyn Definition<Message = T>>>,
+}
+
+impl<T> Subscription<T> {
+    pub fn none() -> Self {
+        Self {
+            definitions: Vec::new(),
+        }
+    }
+
+    pub fn batch(subscriptions: impl Iterator<Item = Subscription<T>>) -> Self {
+        Self {
+            definitions: subscriptions
+                .flat_map(|subscription| subscription.definitions)
+                .collect(),
+        }
+    }
+
+    pub fn definitions(self) -> Vec<Box<dyn Definition<Message = T>>> {
+        self.definitions
+    }
+}
+
+impl<T, A> From<A> for Subscription<T>
+where
+    A: Definition<Message = T> + 'static,
+{
+    fn from(definition: A) -> Self {
+        Self {
+            definitions: vec![Box::new(definition)],
+        }
+    }
+}
+
+/// The definition of an event subscription.
+pub trait Definition {
+    type Message;
+
+    fn id(&self) -> u64;
+
+    fn stream(
+        &self,
+    ) -> (
+        futures::stream::BoxStream<'static, Self::Message>,
+        Box<dyn Handle>,
+    );
+}
+
+pub trait Handle {
+    fn cancel(&mut self);
+}
+
+impl<T> std::fmt::Debug for Subscription<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command").finish()
+    }
+}

--- a/core/src/subscription.rs
+++ b/core/src/subscription.rs
@@ -115,7 +115,7 @@ where
     ) -> futures::stream::BoxStream<'static, Self::Output> {
         use futures::StreamExt;
 
-        let mapper = self.mapper.clone();
+        let mapper = self.mapper;
 
         self.recipe
             .stream(input)

--- a/core/src/subscription.rs
+++ b/core/src/subscription.rs
@@ -1,60 +1,125 @@
 //! Generate events asynchronously for you application.
 
 /// An event subscription.
-pub struct Subscription<I, O> {
-    connections: Vec<Box<dyn Connection<Input = I, Output = O>>>,
+pub struct Subscription<Hasher, Input, Output> {
+    recipes: Vec<Box<dyn Recipe<Hasher, Input, Output = Output>>>,
 }
 
-impl<I, O> Subscription<I, O> {
+impl<H, I, O> Subscription<H, I, O>
+where
+    H: std::hash::Hasher,
+{
     pub fn none() -> Self {
         Self {
-            connections: Vec::new(),
+            recipes: Vec::new(),
+        }
+    }
+
+    pub fn from_recipe(
+        recipe: impl Recipe<H, I, Output = O> + 'static,
+    ) -> Self {
+        Self {
+            recipes: vec![Box::new(recipe)],
         }
     }
 
     pub fn batch(
-        subscriptions: impl Iterator<Item = Subscription<I, O>>,
+        subscriptions: impl Iterator<Item = Subscription<H, I, O>>,
     ) -> Self {
         Self {
-            connections: subscriptions
-                .flat_map(|subscription| subscription.connections)
+            recipes: subscriptions
+                .flat_map(|subscription| subscription.recipes)
                 .collect(),
         }
     }
 
-    pub fn connections(
-        self,
-    ) -> Vec<Box<dyn Connection<Input = I, Output = O>>> {
-        self.connections
+    pub fn recipes(self) -> Vec<Box<dyn Recipe<H, I, Output = O>>> {
+        self.recipes
     }
-}
 
-impl<I, O, T> From<T> for Subscription<I, O>
-where
-    T: Connection<Input = I, Output = O> + 'static,
-{
-    fn from(handle: T) -> Self {
-        Self {
-            connections: vec![Box::new(handle)],
+    pub fn map<A>(
+        mut self,
+        f: impl Fn(O) -> A + Send + Sync + 'static,
+    ) -> Subscription<H, I, A>
+    where
+        H: 'static,
+        I: 'static,
+        O: 'static,
+        A: 'static,
+    {
+        let function = std::sync::Arc::new(f);
+
+        Subscription {
+            recipes: self
+                .recipes
+                .drain(..)
+                .map(|recipe| {
+                    Box::new(Map::new(recipe, function.clone()))
+                        as Box<dyn Recipe<H, I, Output = A>>
+                })
+                .collect(),
         }
     }
 }
 
+impl<I, O, H> std::fmt::Debug for Subscription<I, O, H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Subscription").finish()
+    }
+}
+
 /// The connection of an event subscription.
-pub trait Connection {
-    type Input;
+pub trait Recipe<Hasher: std::hash::Hasher, Input> {
     type Output;
 
-    fn id(&self) -> u64;
+    fn hash(&self, state: &mut Hasher);
 
     fn stream(
         &self,
-        input: Self::Input,
+        input: Input,
     ) -> futures::stream::BoxStream<'static, Self::Output>;
 }
 
-impl<I, O> std::fmt::Debug for Subscription<I, O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Subscription").finish()
+struct Map<Hasher, Input, A, B> {
+    recipe: Box<dyn Recipe<Hasher, Input, Output = A>>,
+    mapper: std::sync::Arc<dyn Fn(A) -> B + Send + Sync>,
+}
+
+impl<H, I, A, B> Map<H, I, A, B> {
+    fn new(
+        recipe: Box<dyn Recipe<H, I, Output = A>>,
+        mapper: std::sync::Arc<dyn Fn(A) -> B + Send + Sync + 'static>,
+    ) -> Self {
+        Map { recipe, mapper }
+    }
+}
+
+impl<H, I, A, B> Recipe<H, I> for Map<H, I, A, B>
+where
+    A: 'static,
+    B: 'static,
+    H: std::hash::Hasher,
+{
+    type Output = B;
+
+    fn hash(&self, state: &mut H) {
+        use std::hash::Hash;
+
+        std::any::TypeId::of::<B>().hash(state);
+        self.recipe.hash(state);
+    }
+
+    fn stream(
+        &self,
+        input: I,
+    ) -> futures::stream::BoxStream<'static, Self::Output> {
+        use futures::StreamExt;
+
+        let mapper = self.mapper.clone();
+
+        self.recipe
+            .stream(input)
+            .map(move |element| mapper(element))
+            .boxed()
     }
 }

--- a/core/src/subscription.rs
+++ b/core/src/subscription.rs
@@ -1,51 +1,59 @@
 //! Generate events asynchronously for you application.
 
 /// An event subscription.
-pub struct Subscription<T> {
-    handles: Vec<Box<dyn Handle<Output = T>>>,
+pub struct Subscription<I, O> {
+    connections: Vec<Box<dyn Connection<Input = I, Output = O>>>,
 }
 
-impl<T> Subscription<T> {
+impl<I, O> Subscription<I, O> {
     pub fn none() -> Self {
         Self {
-            handles: Vec::new(),
+            connections: Vec::new(),
         }
     }
 
-    pub fn batch(subscriptions: impl Iterator<Item = Subscription<T>>) -> Self {
+    pub fn batch(
+        subscriptions: impl Iterator<Item = Subscription<I, O>>,
+    ) -> Self {
         Self {
-            handles: subscriptions
-                .flat_map(|subscription| subscription.handles)
+            connections: subscriptions
+                .flat_map(|subscription| subscription.connections)
                 .collect(),
         }
     }
 
-    pub fn handles(self) -> Vec<Box<dyn Handle<Output = T>>> {
-        self.handles
+    pub fn connections(
+        self,
+    ) -> Vec<Box<dyn Connection<Input = I, Output = O>>> {
+        self.connections
     }
 }
 
-impl<T, A> From<A> for Subscription<T>
+impl<I, O, T> From<T> for Subscription<I, O>
 where
-    A: Handle<Output = T> + 'static,
+    T: Connection<Input = I, Output = O> + 'static,
 {
-    fn from(handle: A) -> Self {
+    fn from(handle: T) -> Self {
         Self {
-            handles: vec![Box::new(handle)],
+            connections: vec![Box::new(handle)],
         }
     }
 }
 
-/// The handle of an event subscription.
-pub trait Handle {
+/// The connection of an event subscription.
+pub trait Connection {
+    type Input;
     type Output;
 
     fn id(&self) -> u64;
 
-    fn stream(&self) -> futures::stream::BoxStream<'static, Self::Output>;
+    fn stream(
+        &self,
+        input: Self::Input,
+    ) -> futures::stream::BoxStream<'static, Self::Output>;
 }
 
-impl<T> std::fmt::Debug for Subscription<T> {
+impl<I, O> std::fmt::Debug for Subscription<I, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Subscription").finish()
     }

--- a/core/src/subscription.rs
+++ b/core/src/subscription.rs
@@ -75,7 +75,7 @@ pub trait Recipe<Hasher: std::hash::Hasher, Input> {
     fn hash(&self, state: &mut Hasher);
 
     fn stream(
-        &self,
+        self: Box<Self>,
         input: Input,
     ) -> futures::stream::BoxStream<'static, Self::Output>;
 }
@@ -110,7 +110,7 @@ where
     }
 
     fn stream(
-        &self,
+        self: Box<Self>,
         input: I,
     ) -> futures::stream::BoxStream<'static, Self::Output> {
         use futures::StreamExt;

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -4,6 +4,8 @@ use iced::{
 };
 
 pub fn main() {
+    env_logger::init();
+
     Clock::run(Settings::default())
 }
 
@@ -108,30 +110,26 @@ mod time {
         >,
     }
 
-    impl<Message> iced::subscription::Handle for Tick<Message>
+    impl<Message> iced_native::subscription::Connection for Tick<Message>
     where
         Message: 'static,
     {
+        type Input = iced_native::subscription::Input;
         type Output = Message;
 
         fn id(&self) -> u64 {
             0
         }
 
-        fn stream(&self) -> futures::stream::BoxStream<'static, Message> {
+        fn stream(
+            &self,
+            input: iced_native::subscription::Input,
+        ) -> futures::stream::BoxStream<'static, Message> {
             use futures::StreamExt;
 
-            let duration = self.duration.clone();
             let function = self.message.clone();
 
-            let stream =
-                futures::stream::iter(std::iter::repeat(())).map(move |_| {
-                    std::thread::sleep(duration);
-
-                    function(chrono::Local::now())
-                });
-
-            stream.boxed()
+            input.map(move |_| function(chrono::Local::now())).boxed()
         }
     }
 }

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,0 +1,166 @@
+use iced::{
+    Align, Application, Checkbox, Column, Command, Container, Element, Length,
+    Settings, Subscription, Text,
+};
+
+pub fn main() {
+    Clock::run(Settings::default())
+}
+
+#[derive(Debug)]
+struct Clock {
+    time: chrono::DateTime<chrono::Local>,
+    enabled: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Ticked(chrono::DateTime<chrono::Local>),
+    Toggled(bool),
+}
+
+impl Application for Clock {
+    type Message = Message;
+
+    fn new() -> (Clock, Command<Message>) {
+        (
+            Clock {
+                time: chrono::Local::now(),
+                enabled: false,
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Clock - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Ticked(time) => {
+                self.time = time;
+            }
+            Message::Toggled(enabled) => {
+                self.enabled = enabled;
+            }
+        };
+
+        Command::none()
+    }
+
+    fn subscriptions(&self) -> Subscription<Message> {
+        if self.enabled {
+            time::every(std::time::Duration::from_millis(500), Message::Ticked)
+        } else {
+            Subscription::none()
+        }
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        let clock = Text::new(format!("{}", self.time.format("%H:%M:%S")))
+            .size(40)
+            .width(Length::Shrink);
+
+        let toggle = Checkbox::new(self.enabled, "Enabled", Message::Toggled)
+            .width(Length::Shrink);
+
+        let content = Column::new()
+            .width(Length::Shrink)
+            .align_items(Align::Center)
+            .spacing(20)
+            .push(clock)
+            .push(toggle);
+
+        Container::new(content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
+    }
+}
+
+mod time {
+    use std::sync::{Arc, Mutex};
+
+    pub fn every<Message>(
+        duration: std::time::Duration,
+        f: impl Fn(chrono::DateTime<chrono::Local>) -> Message
+            + 'static
+            + Send
+            + Sync,
+    ) -> iced::Subscription<Message>
+    where
+        Message: Send + 'static,
+    {
+        Tick {
+            duration,
+            message: Arc::new(f),
+        }
+        .into()
+    }
+
+    struct Tick<Message> {
+        duration: std::time::Duration,
+        message: Arc<
+            dyn Fn(chrono::DateTime<chrono::Local>) -> Message + Send + Sync,
+        >,
+    }
+
+    struct TickState {
+        alive: Arc<Mutex<bool>>,
+    }
+
+    impl iced::subscription::Handle for TickState {
+        fn cancel(&mut self) {
+            match self.alive.lock() {
+                Ok(mut guard) => *guard = false,
+                _ => {}
+            }
+        }
+    }
+
+    impl<Message> iced::subscription::Definition for Tick<Message>
+    where
+        Message: 'static,
+    {
+        type Message = Message;
+
+        fn id(&self) -> u64 {
+            0
+        }
+
+        fn stream(
+            &self,
+        ) -> (
+            futures::stream::BoxStream<'static, Message>,
+            Box<dyn iced::subscription::Handle>,
+        ) {
+            use futures::StreamExt;
+
+            let duration = self.duration.clone();
+            let function = self.message.clone();
+            let alive = Arc::new(Mutex::new(true));
+
+            let state = TickState {
+                alive: alive.clone(),
+            };
+
+            let stream = futures::stream::poll_fn(move |_| {
+                std::thread::sleep(duration);
+
+                if !*alive.lock().unwrap() {
+                    return std::task::Poll::Ready(None);
+                }
+
+                let now = chrono::Local::now();
+
+                std::task::Poll::Ready(Some(now))
+            })
+            .map(move |time| function(time));
+
+            (stream.boxed(), Box::new(state))
+        }
+    }
+}

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -47,7 +47,7 @@ impl Application for Events {
         Command::none()
     }
 
-    fn subscriptions(&self) -> Subscription<Message> {
+    fn subscription(&self) -> Subscription<Message> {
         if self.enabled {
             iced_native::subscription::events().map(Message::EventOccurred)
         } else {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -95,15 +95,15 @@ mod events {
 
     struct All;
 
-    impl<H>
-        iced_native::subscription::Recipe<H, iced_native::subscription::Input>
-        for All
-    where
-        H: std::hash::Hasher,
+    impl
+        iced_native::subscription::Recipe<
+            iced_native::Hasher,
+            iced_native::subscription::Input,
+        > for All
     {
         type Output = iced_native::Event;
 
-        fn hash(&self, state: &mut H) {
+        fn hash(&self, state: &mut iced_native::Hasher) {
             use std::hash::Hash;
 
             std::any::TypeId::of::<All>().hash(state);

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -4,8 +4,6 @@ use iced::{
 };
 
 pub fn main() {
-    env_logger::init();
-
     Events::run(Settings::default())
 }
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -49,7 +49,7 @@ impl Application for Events {
 
     fn subscriptions(&self) -> Subscription<Message> {
         if self.enabled {
-            events::all().map(Message::EventOccurred)
+            iced_native::subscription::events().map(Message::EventOccurred)
         } else {
             Subscription::none()
         }
@@ -67,8 +67,12 @@ impl Application for Events {
             },
         );
 
-        let toggle = Checkbox::new(self.enabled, "Enabled", Message::Toggled)
-            .width(Length::Shrink);
+        let toggle = Checkbox::new(
+            self.enabled,
+            "Listen to runtime events",
+            Message::Toggled,
+        )
+        .width(Length::Shrink);
 
         let content = Column::new()
             .width(Length::Shrink)
@@ -83,37 +87,5 @@ impl Application for Events {
             .center_x()
             .center_y()
             .into()
-    }
-}
-
-mod events {
-    pub fn all() -> iced::Subscription<iced_native::Event> {
-        iced::Subscription::from_recipe(All)
-    }
-
-    struct All;
-
-    impl
-        iced_native::subscription::Recipe<
-            iced_native::Hasher,
-            iced_native::subscription::Input,
-        > for All
-    {
-        type Output = iced_native::Event;
-
-        fn hash(&self, state: &mut iced_native::Hasher) {
-            use std::hash::Hash;
-
-            std::any::TypeId::of::<All>().hash(state);
-        }
-
-        fn stream(
-            self: Box<Self>,
-            input: iced_native::subscription::Input,
-        ) -> futures::stream::BoxStream<'static, Self::Output> {
-            use futures::StreamExt;
-
-            input.boxed()
-        }
     }
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -108,7 +108,7 @@ mod events {
         }
 
         fn stream(
-            &self,
+            self: Box<Self>,
             input: iced_native::subscription::Input,
         ) -> futures::stream::BoxStream<'static, Self::Output> {
             use futures::StreamExt;

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -155,12 +155,13 @@ mod time {
 
     struct Every(std::time::Duration);
 
-    impl<Input> iced_native::subscription::Recipe<iced_native::Hasher, Input>
-        for Every
+    impl<Hasher, Input> iced_native::subscription::Recipe<Hasher, Input> for Every
+    where
+        Hasher: std::hash::Hasher,
     {
         type Output = std::time::Instant;
 
-        fn hash(&self, state: &mut iced_native::Hasher) {
+        fn hash(&self, state: &mut Hasher) {
             use std::hash::Hash;
 
             std::any::TypeId::of::<Self>().hash(state);

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -6,10 +6,10 @@ use iced::{
 use std::time::{Duration, Instant};
 
 pub fn main() {
-    Timer::run(Settings::default())
+    Stopwatch::run(Settings::default())
 }
 
-struct Timer {
+struct Stopwatch {
     duration: Duration,
     state: State,
     toggle: button::State,
@@ -28,12 +28,12 @@ enum Message {
     Tick(Instant),
 }
 
-impl Application for Timer {
+impl Application for Stopwatch {
     type Message = Message;
 
-    fn new() -> (Timer, Command<Message>) {
+    fn new() -> (Stopwatch, Command<Message>) {
         (
-            Timer {
+            Stopwatch {
                 duration: Duration::default(),
                 state: State::Idle,
                 toggle: button::State::new(),
@@ -44,7 +44,7 @@ impl Application for Timer {
     }
 
     fn title(&self) -> String {
-        String::from("Timer - Iced")
+        String::from("Stopwatch - Iced")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -74,7 +74,7 @@ impl Application for Stopwatch {
         Command::none()
     }
 
-    fn subscriptions(&self) -> Subscription<Message> {
+    fn subscription(&self) -> Subscription<Message> {
         match self.state {
             State::Idle => Subscription::none(),
             State::Ticking { .. } => {

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -167,7 +167,7 @@ mod time {
         }
 
         fn stream(
-            &self,
+            self: Box<Self>,
             _input: Input,
         ) -> futures::stream::BoxStream<'static, Self::Output> {
             use futures::stream::StreamExt;

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -155,13 +155,13 @@ mod time {
 
     struct Every(std::time::Duration);
 
-    impl<Hasher, Input> iced_native::subscription::Recipe<Hasher, Input> for Every
+    impl<H, I> iced_native::subscription::Recipe<H, I> for Every
     where
-        Hasher: std::hash::Hasher,
+        H: std::hash::Hasher,
     {
         type Output = std::time::Instant;
 
-        fn hash(&self, state: &mut Hasher) {
+        fn hash(&self, state: &mut H) {
             use std::hash::Hash;
 
             std::any::TypeId::of::<Self>().hash(state);
@@ -170,7 +170,7 @@ mod time {
 
         fn stream(
             self: Box<Self>,
-            _input: Input,
+            _input: I,
         ) -> futures::stream::BoxStream<'static, Self::Output> {
             use futures::stream::StreamExt;
 

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -165,6 +165,7 @@ mod time {
             use std::hash::Hash;
 
             std::any::TypeId::of::<Self>().hash(state);
+            self.0.hash(state);
         }
 
         fn stream(

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -92,7 +92,7 @@ impl Application for Timer {
         let duration = Text::new(format!(
             "{:0>2}:{:0>2}:{:0>2}.{:0>2}",
             seconds / HOUR,
-            seconds / MINUTE,
+            (seconds % HOUR) / MINUTE,
             seconds % MINUTE,
             self.duration.subsec_millis() / 10,
         ))

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,0 +1,180 @@
+use iced::{
+    button, Align, Application, Background, Button, Color, Column, Command,
+    Container, Element, HorizontalAlignment, Length, Row, Settings,
+    Subscription, Text,
+};
+use std::time::{Duration, Instant};
+
+pub fn main() {
+    Timer::run(Settings::default())
+}
+
+struct Timer {
+    duration: Duration,
+    state: State,
+    toggle: button::State,
+    reset: button::State,
+}
+
+enum State {
+    Idle,
+    Ticking { last_tick: Instant },
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Toggle,
+    Reset,
+    Tick(Instant),
+}
+
+impl Application for Timer {
+    type Message = Message;
+
+    fn new() -> (Timer, Command<Message>) {
+        (
+            Timer {
+                duration: Duration::default(),
+                state: State::Idle,
+                toggle: button::State::new(),
+                reset: button::State::new(),
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Timer - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Toggle => match self.state {
+                State::Idle => {
+                    self.state = State::Ticking {
+                        last_tick: Instant::now(),
+                    };
+                }
+                State::Ticking { .. } => {
+                    self.state = State::Idle;
+                }
+            },
+            Message::Tick(now) => match &mut self.state {
+                State::Ticking { last_tick } => {
+                    self.duration += now - *last_tick;
+                    *last_tick = now;
+                }
+                _ => {}
+            },
+            Message::Reset => {
+                self.duration = Duration::default();
+            }
+        }
+
+        Command::none()
+    }
+
+    fn subscriptions(&self) -> Subscription<Message> {
+        match self.state {
+            State::Idle => Subscription::none(),
+            State::Ticking { .. } => {
+                time::every(Duration::from_millis(10)).map(Message::Tick)
+            }
+        }
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        const MINUTE: u64 = 60;
+        const HOUR: u64 = 60 * MINUTE;
+
+        let seconds = self.duration.as_secs();
+
+        let duration = Text::new(format!(
+            "{:0>2}:{:0>2}:{:0>2}.{:0>2}",
+            seconds / HOUR,
+            seconds / MINUTE,
+            seconds % MINUTE,
+            self.duration.subsec_millis() / 10,
+        ))
+        .width(Length::Shrink)
+        .size(40);
+
+        let button = |state, label, color: [f32; 3]| {
+            Button::new(
+                state,
+                Text::new(label)
+                    .color(Color::WHITE)
+                    .horizontal_alignment(HorizontalAlignment::Center),
+            )
+            .min_width(80)
+            .background(Background::Color(color.into()))
+            .border_radius(10)
+            .padding(10)
+        };
+
+        let toggle_button = {
+            let (label, color) = match self.state {
+                State::Idle => ("Start", [0.11, 0.42, 0.87]),
+                State::Ticking { .. } => ("Stop", [0.9, 0.4, 0.4]),
+            };
+
+            button(&mut self.toggle, label, color).on_press(Message::Toggle)
+        };
+
+        let reset_button = button(&mut self.reset, "Reset", [0.7, 0.7, 0.7])
+            .on_press(Message::Reset);
+
+        let controls = Row::new()
+            .width(Length::Shrink)
+            .spacing(20)
+            .push(toggle_button)
+            .push(reset_button);
+
+        let content = Column::new()
+            .width(Length::Shrink)
+            .align_items(Align::Center)
+            .spacing(20)
+            .push(duration)
+            .push(controls);
+
+        Container::new(content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
+    }
+}
+
+mod time {
+    pub fn every(
+        duration: std::time::Duration,
+    ) -> iced::Subscription<std::time::Instant> {
+        iced::Subscription::from_recipe(Every(duration))
+    }
+
+    struct Every(std::time::Duration);
+
+    impl<Input> iced_native::subscription::Recipe<iced_native::Hasher, Input>
+        for Every
+    {
+        type Output = std::time::Instant;
+
+        fn hash(&self, state: &mut iced_native::Hasher) {
+            use std::hash::Hash;
+
+            std::any::TypeId::of::<Self>().hash(state);
+        }
+
+        fn stream(
+            &self,
+            _input: Input,
+        ) -> futures::stream::BoxStream<'static, Self::Output> {
+            use futures::stream::StreamExt;
+
+            async_std::stream::interval(self.0)
+                .map(|_| std::time::Instant::now())
+                .boxed()
+        }
+    }
+}

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT"
 repository = "https://github.com/hecrj/iced"
 
 [dependencies]
-iced_core = { version = "0.1.0", path = "../core", features = ["command"] }
+iced_core = { version = "0.1.0", path = "../core", features = ["command", "subscription"] }
 twox-hash = "1.5"
 raw-window-handle = "0.3"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -12,3 +12,4 @@ iced_core = { version = "0.1.0", path = "../core", features = ["command", "subsc
 twox-hash = "1.5"
 raw-window-handle = "0.3"
 unicode-segmentation = "1.6"
+futures = "0.3"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -34,7 +34,7 @@
 //! [`Windowed`]: renderer/trait.Windowed.html
 //! [`UserInterface`]: struct.UserInterface.html
 //! [renderer]: renderer/index.html
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![deny(unsafe_code)]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -34,7 +34,7 @@
 //! [`Windowed`]: renderer/trait.Windowed.html
 //! [`UserInterface`]: struct.UserInterface.html
 //! [renderer]: renderer/index.html
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![deny(unsafe_code)]
@@ -42,6 +42,7 @@
 pub mod input;
 pub mod layout;
 pub mod renderer;
+pub mod subscription;
 pub mod widget;
 
 mod element;
@@ -52,8 +53,8 @@ mod size;
 mod user_interface;
 
 pub use iced_core::{
-    subscription, Align, Background, Color, Command, Font, HorizontalAlignment,
-    Length, Point, Rectangle, Subscription, Vector, VerticalAlignment,
+    Align, Background, Color, Command, Font, HorizontalAlignment, Length,
+    Point, Rectangle, Vector, VerticalAlignment,
 };
 
 pub use element::Element;
@@ -63,5 +64,6 @@ pub use layout::Layout;
 pub use mouse_cursor::MouseCursor;
 pub use renderer::Renderer;
 pub use size::Size;
+pub use subscription::Subscription;
 pub use user_interface::{Cache, UserInterface};
 pub use widget::*;

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -52,8 +52,8 @@ mod size;
 mod user_interface;
 
 pub use iced_core::{
-    Align, Background, Color, Command, Font, HorizontalAlignment, Length,
-    Point, Rectangle, Vector, VerticalAlignment,
+    subscription, Align, Background, Color, Command, Font, HorizontalAlignment,
+    Length, Point, Rectangle, Subscription, Vector, VerticalAlignment,
 };
 
 pub use element::Element;

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,6 +1,6 @@
-use crate::Event;
+use crate::{Event, Hasher};
 
-pub type Subscription<T> = iced_core::Subscription<Input, T>;
+pub type Subscription<T> = iced_core::Subscription<Hasher, Input, T>;
 pub type Input = futures::channel::mpsc::Receiver<Event>;
 
-pub use iced_core::subscription::Connection;
+pub use iced_core::subscription::Recipe;

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -4,3 +4,28 @@ pub type Subscription<T> = iced_core::Subscription<Hasher, Input, T>;
 pub type Input = futures::channel::mpsc::Receiver<Event>;
 
 pub use iced_core::subscription::Recipe;
+
+pub fn events() -> Subscription<Event> {
+    Subscription::from_recipe(Events)
+}
+
+struct Events;
+
+impl Recipe<Hasher, Input> for Events {
+    type Output = Event;
+
+    fn hash(&self, state: &mut Hasher) {
+        use std::hash::Hash;
+
+        std::any::TypeId::of::<Self>().hash(state);
+    }
+
+    fn stream(
+        self: Box<Self>,
+        input: Input,
+    ) -> futures::stream::BoxStream<'static, Self::Output> {
+        use futures::StreamExt;
+
+        input.boxed()
+    }
+}

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,0 +1,6 @@
+use crate::Event;
+
+pub type Subscription<T> = iced_core::Subscription<Input, T>;
+pub type Input = futures::channel::mpsc::Receiver<Event>;
+
+pub use iced_core::subscription::Connection;

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,31 +1,16 @@
 use crate::{Event, Hasher};
+use futures::stream::BoxStream;
 
-pub type Subscription<T> = iced_core::Subscription<Hasher, Input, T>;
-pub type Input = futures::channel::mpsc::Receiver<Event>;
+pub type EventStream = BoxStream<'static, Event>;
+
+pub type Subscription<T> = iced_core::Subscription<Hasher, EventStream, T>;
 
 pub use iced_core::subscription::Recipe;
 
+mod events;
+
+use events::Events;
+
 pub fn events() -> Subscription<Event> {
     Subscription::from_recipe(Events)
-}
-
-struct Events;
-
-impl Recipe<Hasher, Input> for Events {
-    type Output = Event;
-
-    fn hash(&self, state: &mut Hasher) {
-        use std::hash::Hash;
-
-        std::any::TypeId::of::<Self>().hash(state);
-    }
-
-    fn stream(
-        self: Box<Self>,
-        input: Input,
-    ) -> futures::stream::BoxStream<'static, Self::Output> {
-        use futures::StreamExt;
-
-        input.boxed()
-    }
 }

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,9 +1,28 @@
+//! Listen to external events in your application.
 use crate::{Event, Hasher};
 use futures::stream::BoxStream;
 
-pub type EventStream = BoxStream<'static, Event>;
-
+/// A request to listen to external events.
+///
+/// Besides performing async actions on demand with [`Command`], most
+/// applications also need to listen to external events passively.
+///
+/// A [`Subscription`] is normally provided to some runtime, like a [`Command`],
+/// and it will generate events as long as the user keeps requesting it.
+///
+/// For instance, you can use a [`Subscription`] to listen to a WebSocket
+/// connection, keyboard presses, mouse events, time ticks, etc.
+///
+/// [`Command`]: ../struct.Command.html
+/// [`Subscription`]: struct.Subscription.html
 pub type Subscription<T> = iced_core::Subscription<Hasher, EventStream, T>;
+
+/// A stream of runtime events.
+///
+/// It is the input of a [`Subscription`] in the native runtime.
+///
+/// [`Subscription`]: type.Subscription.html
+pub type EventStream = BoxStream<'static, Event>;
 
 pub use iced_core::subscription::Recipe;
 
@@ -11,6 +30,13 @@ mod events;
 
 use events::Events;
 
+/// Returns a [`Subscription`] to all the runtime events.
+///
+/// This subscription will notify your application of any [`Event`] handled by
+/// the runtime.
+///
+/// [`Subscription`]: type.Subscription.html
+/// [`Event`]: ../enum.Event.html
 pub fn events() -> Subscription<Event> {
     Subscription::from_recipe(Events)
 }

--- a/native/src/subscription/events.rs
+++ b/native/src/subscription/events.rs
@@ -1,0 +1,23 @@
+use crate::{
+    subscription::{EventStream, Recipe},
+    Event, Hasher,
+};
+
+pub struct Events;
+
+impl Recipe<Hasher, EventStream> for Events {
+    type Output = Event;
+
+    fn hash(&self, state: &mut Hasher) {
+        use std::hash::Hash;
+
+        std::any::TypeId::of::<Self>().hash(state);
+    }
+
+    fn stream(
+        self: Box<Self>,
+        event_stream: EventStream,
+    ) -> futures::stream::BoxStream<'static, Self::Output> {
+        event_stream
+    }
+}

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -80,7 +80,7 @@ where
     Renderer: self::Renderer + text::Renderer + row::Renderer,
 {
     fn width(&self) -> Length {
-        Length::Shrink
+        self.width
     }
 
     fn height(&self) -> Length {

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -31,6 +31,7 @@ pub struct Checkbox<Message> {
     on_toggle: Box<dyn Fn(bool) -> Message>,
     label: String,
     label_color: Option<Color>,
+    width: Length,
 }
 
 impl<Message> Checkbox<Message> {
@@ -53,6 +54,7 @@ impl<Message> Checkbox<Message> {
             on_toggle: Box::new(f),
             label: String::from(label),
             label_color: None,
+            width: Length::Fill,
         }
     }
 
@@ -63,6 +65,14 @@ impl<Message> Checkbox<Message> {
         self.label_color = Some(color.into());
         self
     }
+
+    /// Sets the width of the [`Checkbox`].
+    ///
+    /// [`Checkbox`]: struct.Checkbox.html
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
 }
 
 impl<Message, Renderer> Widget<Message, Renderer> for Checkbox<Message>
@@ -70,7 +80,7 @@ where
     Renderer: self::Renderer + text::Renderer + row::Renderer,
 {
     fn width(&self) -> Length {
-        Length::Fill
+        Length::Shrink
     }
 
     fn height(&self) -> Length {
@@ -85,6 +95,7 @@ where
         let size = self::Renderer::default_size(renderer);
 
         Row::<(), Renderer>::new()
+            .width(self.width)
             .spacing(15)
             .align_items(Align::Center)
             .push(
@@ -92,7 +103,7 @@ where
                     .width(Length::Units(size as u16))
                     .height(Length::Units(size as u16)),
             )
-            .push(Text::new(&self.label))
+            .push(Text::new(&self.label).width(self.width))
             .layout(renderer, limits)
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,4 @@
-use crate::{Command, Element, Settings};
+use crate::{Command, Element, Settings, Subscription};
 
 /// An interactive cross-platform application.
 ///
@@ -117,6 +117,11 @@ pub trait Application: Sized {
     /// [`Command`]: struct.Command.html
     fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
 
+    /// TODO
+    fn subscriptions(&self) -> Subscription<Self::Message> {
+        Subscription::none()
+    }
+
     /// Returns the widgets to display in the [`Application`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
@@ -166,6 +171,10 @@ where
 
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         self.0.update(message)
+    }
+
+    fn subscriptions(&self) -> Subscription<Self::Message> {
+        self.0.subscriptions()
     }
 
     fn view(&mut self) -> Element<'_, Self::Message> {

--- a/src/application.rs
+++ b/src/application.rs
@@ -117,8 +117,17 @@ pub trait Application: Sized {
     /// [`Command`]: struct.Command.html
     fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
 
-    /// TODO
-    fn subscriptions(&self) -> Subscription<Self::Message> {
+    /// Returns the event [`Subscription`] for the current state of the
+    /// application.
+    ///
+    /// A [`Subscription`] will be kept alive as long as you keep returning it,
+    /// and the __messages__ produced will be handled by
+    /// [`update`](#tymethod.update).
+    ///
+    /// By default, this method returns an empty [`Subscription`].
+    ///
+    /// [`Subscription`]: struct.Subscription.html
+    fn subscription(&self) -> Subscription<Self::Message> {
         Subscription::none()
     }
 
@@ -173,8 +182,8 @@ where
         self.0.update(message)
     }
 
-    fn subscriptions(&self) -> Subscription<Self::Message> {
-        self.0.subscriptions()
+    fn subscription(&self) -> Subscription<Self::Message> {
+        self.0.subscription()
     }
 
     fn view(&mut self) -> Element<'_, Self::Message> {

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,6 +1,6 @@
 pub use iced_winit::{
-    subscription, Align, Background, Color, Command, Font, HorizontalAlignment,
-    Length, Subscription, VerticalAlignment,
+    Align, Background, Color, Command, Font, HorizontalAlignment, Length,
+    Subscription, VerticalAlignment,
 };
 
 pub mod widget {

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,6 +1,6 @@
 pub use iced_winit::{
-    Align, Background, Color, Command, Font, HorizontalAlignment, Length,
-    VerticalAlignment,
+    subscription, Align, Background, Color, Command, Font, HorizontalAlignment,
+    Length, Subscription, VerticalAlignment,
 };
 
 pub mod widget {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -149,7 +149,7 @@ where
         Command::none()
     }
 
-    fn subscriptions(&self) -> Subscription<T::Message> {
+    fn subscription(&self) -> Subscription<T::Message> {
         Subscription::none()
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,4 +1,4 @@
-use crate::{Application, Command, Element, Settings};
+use crate::{Application, Command, Element, Settings, Subscription};
 
 /// A sandboxed [`Application`].
 ///
@@ -147,6 +147,10 @@ where
         T::update(self, message);
 
         Command::none()
+    }
+
+    fn subscriptions(&self) -> Subscription<T::Message> {
+        Subscription::none()
     }
 
     fn view(&mut self) -> Element<'_, T::Message> {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -469,17 +469,12 @@ impl Subscriptions {
                     futures::channel::mpsc::channel(100);
 
                 let stream = recipe.stream(event_receiver);
-
-                // TODO: Find out how to avoid using a mutex here
-                let proxy =
-                    std::sync::Arc::new(std::sync::Mutex::new(proxy.clone()));
+                let proxy = proxy.clone();
 
                 let future = futures::future::select(
                     cancelled,
                     stream.for_each(move |message| {
                         proxy
-                            .lock()
-                            .expect("Acquire event loop proxy lock")
                             .send_event(message)
                             .expect("Send subscription result to event loop");
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -470,6 +470,7 @@ impl Subscriptions {
 
                 let stream = recipe.stream(event_receiver);
 
+                // TODO: Find out how to avoid using a mutex here
                 let proxy =
                     std::sync::Arc::new(std::sync::Mutex::new(proxy.clone()));
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -468,7 +468,7 @@ impl Subscriptions {
                 let (event_sender, event_receiver) =
                     futures::channel::mpsc::channel(100);
 
-                let stream = recipe.stream(event_receiver);
+                let stream = recipe.stream(event_receiver.boxed());
                 let proxy = proxy.clone();
 
                 let future = futures::future::select(

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -29,6 +29,7 @@ pub mod conversion;
 pub mod settings;
 
 mod application;
+mod subscription;
 
 pub use application::Application;
 pub use settings::Settings;

--- a/winit/src/subscription.rs
+++ b/winit/src/subscription.rs
@@ -87,7 +87,7 @@ impl Pool {
             .filter_map(|connection| connection.listener.as_mut())
             .for_each(|listener| {
                 if let Err(error) = listener.try_send(event) {
-                    log::warn!(
+                    log::error!(
                         "Error sending event to subscription: {:?}",
                         error
                     );

--- a/winit/src/subscription.rs
+++ b/winit/src/subscription.rs
@@ -1,0 +1,97 @@
+use iced_native::{Event, Hasher, Subscription};
+use std::collections::HashMap;
+
+pub struct Pool {
+    alive: HashMap<u64, Handle>,
+}
+
+pub struct Handle {
+    _cancel: futures::channel::oneshot::Sender<()>,
+    listener: Option<futures::channel::mpsc::Sender<Event>>,
+}
+
+impl Pool {
+    pub fn new() -> Self {
+        Self {
+            alive: HashMap::new(),
+        }
+    }
+
+    pub fn update<Message: Send>(
+        &mut self,
+        subscription: Subscription<Message>,
+        thread_pool: &mut futures::executor::ThreadPool,
+        proxy: &winit::event_loop::EventLoopProxy<Message>,
+    ) {
+        use futures::{future::FutureExt, stream::StreamExt};
+
+        let recipes = subscription.recipes();
+        let mut alive = std::collections::HashSet::new();
+
+        for recipe in recipes {
+            let id = {
+                use std::hash::Hasher as _;
+
+                let mut hasher = Hasher::default();
+                recipe.hash(&mut hasher);
+
+                hasher.finish()
+            };
+
+            let _ = alive.insert(id);
+
+            if !self.alive.contains_key(&id) {
+                let (cancel, cancelled) = futures::channel::oneshot::channel();
+
+                // TODO: Use bus if/when it supports async
+                let (event_sender, event_receiver) =
+                    futures::channel::mpsc::channel(100);
+
+                let stream = recipe.stream(event_receiver.boxed());
+                let proxy = proxy.clone();
+
+                let future = futures::future::select(
+                    cancelled,
+                    stream.for_each(move |message| {
+                        proxy
+                            .send_event(message)
+                            .expect("Send subscription result to event loop");
+
+                        futures::future::ready(())
+                    }),
+                )
+                .map(|_| ());
+
+                thread_pool.spawn_ok(future);
+
+                let _ = self.alive.insert(
+                    id,
+                    Handle {
+                        _cancel: cancel,
+                        listener: if event_sender.is_closed() {
+                            None
+                        } else {
+                            Some(event_sender)
+                        },
+                    },
+                );
+            }
+        }
+
+        self.alive.retain(|id, _| alive.contains(&id));
+    }
+
+    pub fn broadcast_event(&mut self, event: Event) {
+        self.alive
+            .values_mut()
+            .filter_map(|connection| connection.listener.as_mut())
+            .for_each(|listener| {
+                if let Err(error) = listener.try_send(event) {
+                    log::warn!(
+                        "Error sending event to subscription: {:?}",
+                        error
+                    );
+                }
+            });
+    }
+}


### PR DESCRIPTION
Closes #29, closes #109, and fixes #123.

<p align="center">
<a href="https://gfycat.com/granularenviousgoitered-rust-gui"><img alt="Stopwatch - Iced" src="https://thumbs.gfycat.com/GranularEnviousGoitered-small.gif"></a>
</p>

This PR adds support for event subscriptions. Event subscriptions are inspired by [Elm's subscriptions](https://guide.elm-lang.org/effects/time.html) and can be used to listen to external events that do not necessarily occur as a response to some interaction or command. For instance, you can use event subscriptions to create a websocket connection, listen to incoming messages, and even handle reconnects graciously.

Event subscriptions are built on top of [`futures::stream::Stream`](https://docs.rs/futures/0.3.1/futures/stream/trait.Stream.html). The messages produced by a subscription are provided to `Application::update` and, of course, can be used to change the state of the `Application`.

The `iced_winit` shell keeps a subscription alive as long as the user returns it in the new `Application::subscription` method. Therefore, unsubscribing simply consists in not returning the subscription anymore.

Moreover, subscriptions can be created by libraries and/or end-users using the new `subscription::Recipe` trait (name subject to change), which requires just a couple of methods.

For now, there is only one built-in `Subscription` in `iced_native`: `subscription::events`. This subscription will notify an application of all the runtime events that occur, producing [`Event`](https://docs.rs/iced_native/0.1.0/iced_native/enum.Event.html) values. It can be useful if you want to listen to keyboard or mouse events (and most likely window events soon):

<p align="center">
<a href="https://gfycat.com/littlesilkyalabamamapturtle"><img alt="Events - Iced" src="https://thumbs.gfycat.com/LittleSilkyAlabamamapturtle-small.gif"></a>
</p>

Two examples have been added that showcase event subscriptions:

- `events`, which uses the new built-in `subscription::events`.
- `stopwatch`, which showcases a custom event subscription that produces messages periodically at a configurable time interval.