### PR TITLE
Add several missing style attributes in iced_web

### DIFF
--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -130,6 +130,7 @@ where
     ) -> dodrio::Node<'b> {
         use dodrio::builder::*;
 
+        let width = style::length(self.width);
         let padding_class =
             style_sheet.insert(bump, Style::Padding(self.padding));
 
@@ -149,9 +150,10 @@ where
                 "style",
                 bumpalo::format!(
                     in bump,
-                    "background: {}; border-radius: {}px; min-width: {}px",
+                    "background: {}; border-radius: {}px; width:{}; min-width: {}px",
                     background,
                     self.border_radius,
+                    width,
                     self.min_width
                 )
                 .into_bump_str(),

--- a/web/src/widget/column.rs
+++ b/web/src/widget/column.rs
@@ -133,6 +133,8 @@ impl<'a, Message> Widget<Message> for Column<'a, Message> {
         let width = style::length(self.width);
         let height = style::length(self.height);
 
+        let align_items = style::align(self.align_items);
+
         // TODO: Complete styling
         div(bump)
             .attr(
@@ -142,10 +144,12 @@ impl<'a, Message> Widget<Message> for Column<'a, Message> {
             )
             .attr("style", bumpalo::format!(
                     in bump,
-                    "width: {}; height: {}; max-width: {}px",
+                    "width: {}; height: {}; max-width: {}px; max-height: {}px; align-items: {}",
                     width,
                     height,
-                    self.max_width
+                    self.max_width,
+                    self.max_height,
+                    align_items
                 ).into_bump_str()
             )
             .children(children)

--- a/web/src/widget/row.rs
+++ b/web/src/widget/row.rs
@@ -134,6 +134,8 @@ impl<'a, Message> Widget<Message> for Row<'a, Message> {
         let width = style::length(self.width);
         let height = style::length(self.height);
 
+        let justify_content = style::align(self.align_items);
+
         // TODO: Complete styling
         div(bump)
             .attr(
@@ -143,10 +145,12 @@ impl<'a, Message> Widget<Message> for Row<'a, Message> {
             )
             .attr("style", bumpalo::format!(
                     in bump,
-                    "width: {}; height: {}; max-width: {}px",
+                    "width: {}; height: {}; max-width: {}px; max-height: {}px; justify-content: {}",
                     width,
                     height,
-                    self.max_width
+                    self.max_width,
+                    self.max_height,
+                    justify_content
                 ).into_bump_str()
             )
             .children(children)

--- a/web/src/widget/text.rs
+++ b/web/src/widget/text.rs
@@ -119,6 +119,9 @@ impl<'a, Message> Widget<Message> for Text {
         let content = bumpalo::format!(in bump, "{}", self.content);
         let color = style::color(self.color.unwrap_or(Color::BLACK));
 
+        let width = style::length(self.width);
+        let height = style::length(self.height);
+
         let text_align = match self.horizontal_alignment {
             HorizontalAlignment::Left => "left",
             HorizontalAlignment::Center => "center",
@@ -127,7 +130,9 @@ impl<'a, Message> Widget<Message> for Text {
 
         let style = bumpalo::format!(
             in bump,
-            "font-size: {}px; color: {}; text-align: {}",
+            "width: {}; height: {}; font-size: {}px; color: {}; text-align: {}",
+            width,
+            height,
             self.size.unwrap_or(20),
             color,
             text_align

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -128,6 +128,8 @@ where
         use dodrio::builder::*;
         use wasm_bindgen::JsCast;
 
+        let width = style::length(self.width);
+        let max_width = style::length(self.max_width);
         let padding_class =
             style_sheet.insert(bump, Style::Padding(self.padding));
 
@@ -143,7 +145,9 @@ where
                 "style",
                 bumpalo::format!(
                     in bump,
-                    "font-size: {}px",
+                    "width: {}; max-width: {}; font-size: {}px",
+                    width,
+                    max_width,
                     self.size.unwrap_or(20)
                 )
                 .into_bump_str(),


### PR DESCRIPTION
This PR passes several style attributes into the DOM which were missing, resulting in a correct layout for my application (i.e., same layout in native and web). I'm not too familiar with dodrio and web styling, so I mimicked the styles based on the other widgets.