### PR TITLE
Remove unnecessary bound in iced_web Container

### DIFF
--- a/web/src/widget/container.rs
+++ b/web/src/widget/container.rs
@@ -134,7 +134,7 @@ where
 
 impl<'a, Message> From<Container<'a, Message>> for Element<'a, Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     fn from(container: Container<'a, Message>) -> Element<'a, Message> {
         Element::new(container)


### PR DESCRIPTION
This PR removes an unnecessary bound from `iced_web`'s `Container`. This bound is not present in `iced_native`: https://github.com/hecrj/iced/blob/master/native/src/widget/container.rs#L172, thereby causing possible compilation problems when switching between web and native. I don't think this bound affects anything, but feel free to close the PR if it is actually necessary.