### PR TITLE
Avoid rasterizing SVG when a dimension is 0

### DIFF
--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -91,6 +91,10 @@ impl Cache {
 
         match self.load(handle) {
             Svg::Loaded { tree } => {
+                if width == 0 || height == 0 {
+                    return None;
+                }
+
                 let extent = wgpu::Extent3d {
                     width,
                     height,


### PR DESCRIPTION
Fixes #133.