### PR TITLE
Add `Length::FillPortion` variant

### DIFF
--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -4,6 +4,15 @@ pub enum Length {
     /// Fill all the remaining space
     Fill,
 
+    /// Fill a portion of the remaining space relative to other elements.
+    ///
+    /// Let's say we have two elements: one with `FillPortion(2)` and one with
+    /// `FillPortion(3)`. The first will get 2 portions of the available space,
+    /// while the second one would get 3.
+    ///
+    /// `Length::Fill` is equivalent to `Length::FillPortion(1)`.
+    FillPortion(u16),
+
     /// Fill the least amount of space
     Shrink,
 
@@ -22,6 +31,7 @@ impl Length {
     pub fn fill_factor(&self) -> u16 {
         match self {
             Length::Fill => 1,
+            Length::FillPortion(factor) => *factor,
             Length::Shrink => 0,
             Length::Units(_) => 0,
         }

--- a/native/src/layout/limits.rs
+++ b/native/src/layout/limits.rs
@@ -52,7 +52,7 @@ impl Limits {
             Length::Shrink => {
                 self.fill.width = self.min.width;
             }
-            Length::Fill => {
+            Length::Fill | Length::FillPortion(_) => {
                 self.fill.width = self.fill.width.min(self.max.width);
             }
             Length::Units(units) => {
@@ -76,7 +76,7 @@ impl Limits {
             Length::Shrink => {
                 self.fill.height = self.min.height;
             }
-            Length::Fill => {
+            Length::Fill | Length::FillPortion(_) => {
                 self.fill.height = self.fill.height.min(self.max.height);
             }
             Length::Units(units) => {

--- a/web/src/style.rs
+++ b/web/src/style.rs
@@ -139,7 +139,7 @@ pub fn length(length: Length) -> String {
     match length {
         Length::Shrink => String::from("auto"),
         Length::Units(px) => format!("{}px", px),
-        Length::Fill => String::from("100%"),
+        Length::Fill | Length::FillPortion(_) => String::from("100%"),
     }
 }
 

--- a/web/src/widget/image.rs
+++ b/web/src/widget/image.rs
@@ -67,7 +67,7 @@ impl<Message> Widget<Message> for Image {
 
         match self.width {
             Length::Shrink => {}
-            Length::Fill => {
+            Length::Fill | Length::FillPortion(_) => {
                 image = image.attr("width", "100%");
             }
             Length::Units(px) => {


### PR DESCRIPTION
It allows to specify the amount of available space an element should take in relation to other elements.