### PR TITLE
Update `winit` to `0.20`

### DIFF
--- a/native/src/renderer/windowed.rs
+++ b/native/src/renderer/windowed.rs
@@ -36,9 +36,9 @@ pub trait Target {
     /// [`Target`]: trait.Target.html
     fn new<W: HasRawWindowHandle>(
         window: &W,
-        width: u16,
-        height: u16,
-        dpi: f32,
+        width: u32,
+        height: u32,
+        scale_factor: f32,
         renderer: &Self::Renderer,
     ) -> Self;
 
@@ -47,9 +47,9 @@ pub trait Target {
     /// [`Target`]: trait.Target.html
     fn resize(
         &mut self,
-        width: u16,
-        height: u16,
-        dpi: f32,
+        width: u32,
+        height: u32,
+        scale_factor: f32,
         renderer: &Self::Renderer,
     );
 }

--- a/native/src/renderer/windowed.rs
+++ b/native/src/renderer/windowed.rs
@@ -38,7 +38,7 @@ pub trait Target {
         window: &W,
         width: u32,
         height: u32,
-        scale_factor: f32,
+        scale_factor: f64,
         renderer: &Self::Renderer,
     ) -> Self;
 
@@ -49,7 +49,7 @@ pub trait Target {
         &mut self,
         width: u32,
         height: u32,
-        scale_factor: f32,
+        scale_factor: f64,
         renderer: &Self::Renderer,
     );
 }

--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -90,7 +90,7 @@ impl Renderer {
         log::debug!("Drawing");
 
         let (width, height) = target.dimensions();
-        let dpi = target.dpi();
+        let scale_factor = target.scale_factor();
         let transformation = target.transformation();
         let frame = target.next_frame();
 
@@ -130,7 +130,13 @@ impl Renderer {
         self.draw_overlay(overlay, &mut layers);
 
         for layer in layers {
-            self.flush(dpi, transformation, &layer, &mut encoder, &frame.view);
+            self.flush(
+                scale_factor,
+                transformation,
+                &layer,
+                &mut encoder,
+                &frame.view,
+            );
         }
 
         self.queue.submit(&[encoder.finish()]);
@@ -324,19 +330,19 @@ impl Renderer {
 
     fn flush(
         &mut self,
-        dpi: f32,
+        scale_factor: f32,
         transformation: Transformation,
         layer: &Layer<'_>,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
     ) {
-        let bounds = layer.bounds * dpi;
+        let bounds = layer.bounds * scale_factor;
 
         if layer.meshes.len() > 0 {
             let translated = transformation
                 * Transformation::translate(
-                    -(layer.offset.x as f32) * dpi,
-                    -(layer.offset.y as f32) * dpi,
+                    -(layer.offset.x as f32) * scale_factor,
+                    -(layer.offset.y as f32) * scale_factor,
                 );
 
             self.triangle_pipeline.draw(
@@ -344,7 +350,7 @@ impl Renderer {
                 encoder,
                 target,
                 translated,
-                dpi,
+                scale_factor,
                 &layer.meshes,
                 bounds,
             );
@@ -356,7 +362,7 @@ impl Renderer {
                 encoder,
                 &layer.quads,
                 transformation,
-                dpi,
+                scale_factor,
                 bounds,
                 target,
             );
@@ -364,7 +370,7 @@ impl Renderer {
 
         if layer.images.len() > 0 {
             let translated_and_scaled = transformation
-                * Transformation::scale(dpi, dpi)
+                * Transformation::scale(scale_factor, scale_factor)
                 * Transformation::translate(
                     -(layer.offset.x as f32),
                     -(layer.offset.y as f32),
@@ -377,7 +383,7 @@ impl Renderer {
                 translated_and_scaled,
                 bounds,
                 target,
-                dpi,
+                scale_factor,
             );
         }
 
@@ -390,25 +396,25 @@ impl Renderer {
                     // bit "jumpy". We may be able to do better once we improve
                     // our text rendering/caching pipeline.
                     screen_position: (
-                        (text.screen_position.0 * dpi).round(),
-                        (text.screen_position.1 * dpi).round(),
+                        (text.screen_position.0 * scale_factor).round(),
+                        (text.screen_position.1 * scale_factor).round(),
                     ),
-                    // TODO: Fix precision issues with some DPI factors.
+                    // TODO: Fix precision issues with some scale factors.
                     //
                     // The `ceil` here can cause some words to render on the
                     // same line when they should not.
                     //
                     // Ideally, `wgpu_glyph` should be able to compute layout
                     // using logical positions, and then apply the proper
-                    // DPI scaling. This would ensure that both measuring and
-                    // rendering follow the same layout rules.
+                    // scaling when rendering. This would ensure that both
+                    // measuring and rendering follow the same layout rules.
                     bounds: (
-                        (text.bounds.0 * dpi).ceil(),
-                        (text.bounds.1 * dpi).ceil(),
+                        (text.bounds.0 * scale_factor).ceil(),
+                        (text.bounds.1 * scale_factor).ceil(),
                     ),
                     scale: wgpu_glyph::Scale {
-                        x: text.scale.x * dpi,
-                        y: text.scale.y * dpi,
+                        x: text.scale.x * scale_factor,
+                        y: text.scale.y * scale_factor,
                     },
                     ..*text
                 };

--- a/wgpu/src/renderer/target.rs
+++ b/wgpu/src/renderer/target.rs
@@ -6,20 +6,20 @@ use raw_window_handle::HasRawWindowHandle;
 #[derive(Debug)]
 pub struct Target {
     surface: wgpu::Surface,
-    width: u16,
-    height: u16,
-    dpi: f32,
+    width: u32,
+    height: u32,
+    scale_factor: f32,
     transformation: Transformation,
     swap_chain: wgpu::SwapChain,
 }
 
 impl Target {
-    pub(crate) fn dimensions(&self) -> (u16, u16) {
+    pub(crate) fn dimensions(&self) -> (u32, u32) {
         (self.width, self.height)
     }
 
-    pub(crate) fn dpi(&self) -> f32 {
-        self.dpi
+    pub(crate) fn scale_factor(&self) -> f32 {
+        self.scale_factor
     }
 
     pub(crate) fn transformation(&self) -> Transformation {
@@ -36,9 +36,9 @@ impl iced_native::renderer::Target for Target {
 
     fn new<W: HasRawWindowHandle>(
         window: &W,
-        width: u16,
-        height: u16,
-        dpi: f32,
+        width: u32,
+        height: u32,
+        scale_factor: f32,
         renderer: &Renderer,
     ) -> Target {
         let surface = wgpu::Surface::create(window);
@@ -49,7 +49,7 @@ impl iced_native::renderer::Target for Target {
             surface,
             width,
             height,
-            dpi,
+            scale_factor,
             transformation: Transformation::orthographic(width, height),
             swap_chain,
         }
@@ -57,14 +57,14 @@ impl iced_native::renderer::Target for Target {
 
     fn resize(
         &mut self,
-        width: u16,
-        height: u16,
-        dpi: f32,
+        width: u32,
+        height: u32,
+        scale_factor: f32,
         renderer: &Renderer,
     ) {
         self.width = width;
         self.height = height;
-        self.dpi = dpi;
+        self.scale_factor = scale_factor;
         self.transformation = Transformation::orthographic(width, height);
         self.swap_chain =
             new_swap_chain(&self.surface, width, height, &renderer.device);
@@ -73,8 +73,8 @@ impl iced_native::renderer::Target for Target {
 
 fn new_swap_chain(
     surface: &wgpu::Surface,
-    width: u16,
-    height: u16,
+    width: u32,
+    height: u32,
     device: &wgpu::Device,
 ) -> wgpu::SwapChain {
     device.create_swap_chain(
@@ -82,8 +82,8 @@ fn new_swap_chain(
         &wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             format: wgpu::TextureFormat::Bgra8UnormSrgb,
-            width: u32::from(width),
-            height: u32::from(height),
+            width,
+            height,
             present_mode: wgpu::PresentMode::Vsync,
         },
     )

--- a/wgpu/src/renderer/target.rs
+++ b/wgpu/src/renderer/target.rs
@@ -38,7 +38,7 @@ impl iced_native::renderer::Target for Target {
         window: &W,
         width: u32,
         height: u32,
-        scale_factor: f32,
+        scale_factor: f64,
         renderer: &Renderer,
     ) -> Target {
         let surface = wgpu::Surface::create(window);
@@ -49,7 +49,7 @@ impl iced_native::renderer::Target for Target {
             surface,
             width,
             height,
-            scale_factor,
+            scale_factor: scale_factor as f32,
             transformation: Transformation::orthographic(width, height),
             swap_chain,
         }
@@ -59,12 +59,12 @@ impl iced_native::renderer::Target for Target {
         &mut self,
         width: u32,
         height: u32,
-        scale_factor: f32,
+        scale_factor: f64,
         renderer: &Renderer,
     ) {
         self.width = width;
         self.height = height;
-        self.scale_factor = scale_factor;
+        self.scale_factor = scale_factor as f32;
         self.transformation = Transformation::orthographic(width, height);
         self.swap_chain =
             new_swap_chain(&self.surface, width, height, &renderer.device);

--- a/wgpu/src/transformation.rs
+++ b/wgpu/src/transformation.rs
@@ -13,10 +13,10 @@ impl Transformation {
 
     /// Creates an orthographic projection.
     #[rustfmt::skip]
-    pub fn orthographic(width: u16, height: u16) -> Transformation {
+    pub fn orthographic(width: u32, height: u32) -> Transformation {
         Transformation(Mat4::from_cols(
-            Vec4::new(2.0 / f32::from(width), 0.0, 0.0, 0.0),
-            Vec4::new(0.0, 2.0 / f32::from(height), 0.0, 0.0),
+            Vec4::new(2.0 / width as f32, 0.0, 0.0, 0.0),
+            Vec4::new(0.0, 2.0 / height as f32, 0.0, 0.0),
             Vec4::new(0.0, 0.0, -1.0, 0.0),
             Vec4::new(-1.0, -1.0, 0.0, 1.0)
         ))

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -12,7 +12,7 @@ debug = []
 
 [dependencies]
 iced_native = { version = "0.1.0-alpha", path = "../native" }
-winit = { version = "0.20.0-alpha3", git = "https://github.com/hecrj/winit", rev = "709808eb4e69044705fcb214bcc30556db761405"}
+winit = "0.20"
 window_clipboard = { git = "https://github.com/hecrj/window_clipboard", rev = "22c6dd6c04cd05d528029b50a30c56417cd4bebf" }
 futures = { version = "0.3", features = ["thread-pool"] }
 log = "0.4"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -145,7 +145,7 @@ pub trait Application: Sized {
                 &window,
                 physical_size.width,
                 physical_size.height,
-                size.scale_factor() as f32,
+                size.scale_factor(),
                 &renderer,
             )
         };
@@ -272,7 +272,7 @@ pub trait Application: Sized {
                     target.resize(
                         physical_size.width,
                         physical_size.height,
-                        size.scale_factor() as f32,
+                        size.scale_factor(),
                         &renderer,
                     );
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -450,7 +450,6 @@ fn spawn<Message: std::fmt::Debug + Send>(
 }
 
 // As defined in: http://www.unicode.org/faq/private_use.html
-// TODO: Remove once https://github.com/rust-windowing/winit/pull/1254 lands
 fn is_private_use_character(c: char) -> bool {
     match c {
         '\u{E000}'..='\u{F8FF}'

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -59,10 +59,10 @@ pub fn modifiers_state(
     modifiers: winit::event::ModifiersState,
 ) -> ModifiersState {
     ModifiersState {
-        shift: modifiers.shift,
-        control: modifiers.ctrl,
-        alt: modifiers.alt,
-        logo: modifiers.logo,
+        shift: modifiers.shift(),
+        control: modifiers.ctrl(),
+        alt: modifiers.alt(),
+        logo: modifiers.logo(),
     }
 }
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -30,6 +30,7 @@ pub mod settings;
 
 mod application;
 mod clipboard;
+mod size;
 mod subscription;
 
 // We disable debug capabilities on release builds unless the `debug` feature
@@ -46,3 +47,4 @@ pub use settings::Settings;
 
 use clipboard::Clipboard;
 use debug::Debug;
+use size::Size;

--- a/winit/src/size.rs
+++ b/winit/src/size.rs
@@ -1,0 +1,30 @@
+pub struct Size {
+    physical: winit::dpi::PhysicalSize<u32>,
+    logical: winit::dpi::LogicalSize<f64>,
+    scale_factor: f64,
+}
+
+impl Size {
+    pub fn new(
+        physical: winit::dpi::PhysicalSize<u32>,
+        scale_factor: f64,
+    ) -> Size {
+        Size {
+            logical: physical.to_logical(scale_factor),
+            physical,
+            scale_factor,
+        }
+    }
+
+    pub fn physical(&self) -> winit::dpi::PhysicalSize<u32> {
+        self.physical
+    }
+
+    pub fn logical(&self) -> winit::dpi::LogicalSize<f64> {
+        self.logical
+    }
+
+    pub fn scale_factor(&self) -> f64 {
+        self.scale_factor
+    }
+}

--- a/winit/src/subscription.rs
+++ b/winit/src/subscription.rs
@@ -17,7 +17,7 @@ impl Pool {
         }
     }
 
-    pub fn update<Message: Send>(
+    pub fn update<Message: std::fmt::Debug + Send>(
         &mut self,
         subscription: Subscription<Message>,
         thread_pool: &mut futures::executor::ThreadPool,


### PR DESCRIPTION
This PR updates `winit` to `0.20` in `iced_winit`.

There is currently an issue on macOS where the `CursorMoved` event is reporting a logical coordinate instead of a physical one (https://github.com/rust-windowing/winit/issues/1371).

# Pending work
- [x] https://github.com/rust-windowing/winit/issues/1371
- [x] https://github.com/rust-windowing/winit/pull/1378