### PR TITLE
Window resized event

### DIFF
--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -1,4 +1,7 @@
-use crate::input::{keyboard, mouse};
+use crate::{
+    input::{keyboard, mouse},
+    window,
+};
 
 /// A user interface event.
 ///
@@ -13,4 +16,7 @@ pub enum Event {
 
     /// A mouse event
     Mouse(mouse::Event),
+
+    /// A window event
+    Window(window::Event),
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -44,6 +44,7 @@ pub mod layout;
 pub mod renderer;
 pub mod subscription;
 pub mod widget;
+pub mod window;
 
 mod clipboard;
 mod element;

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -1,0 +1,4 @@
+//! Build window-based GUI applications.
+mod event;
+
+pub use event::Event;

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -1,0 +1,12 @@
+/// A window-related event.
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum Event {
+    /// A window was resized
+    Resized {
+        /// The new width of the window (in units)
+        width: u32,
+
+        /// The new height of the window (in units)
+        height: u32,
+    },
+}

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -2,8 +2,8 @@ use crate::{
     container, conversion,
     input::{keyboard, mouse},
     renderer::{Target, Windowed},
-    subscription, Cache, Clipboard, Command, Container, Debug, Element, Event,
-    Length, MouseCursor, Settings, Subscription, UserInterface,
+    subscription, window, Cache, Clipboard, Command, Container, Debug, Element,
+    Event, Length, MouseCursor, Settings, Subscription, UserInterface,
 };
 
 /// An interactive, native cross-platform application.
@@ -373,10 +373,13 @@ pub trait Application: Sized {
                     *control_flow = ControlFlow::Exit;
                 }
                 WindowEvent::Resized(new_size) => {
+                    events.push(Event::Window(window::Event::Resized {
+                        width: new_size.width.round() as u32,
+                        height: new_size.height.round() as u32,
+                    }));
+
                     size = new_size;
                     resized = true;
-
-                    log::debug!("Resized: {:?}", new_size);
                 }
                 _ => {}
             },


### PR DESCRIPTION
This PR adds a new `window::Event` enum with just a `Resized` variant for now. Also, a `Window` variant has been added to `Event` accordingly and `iced_winit` has been changed to produce the `Resized` event.

This new event can be used in conjunction with a `Subscription` to keep track of the window dimensions, which can in turn be used to change layout in a fully responsive application.