### PR TITLE
Move `Debugger` and `Windowed` traits

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -1,6 +1,5 @@
 use crate::{
-    layout, renderer, Clipboard, Color, Event, Hasher, Layout, Length, Point,
-    Widget,
+    layout, Clipboard, Color, Event, Hasher, Layout, Length, Point, Widget,
 };
 
 /// A generic [`Widget`].
@@ -195,7 +194,7 @@ where
     ) -> Element<'a, Message, Renderer>
     where
         Message: 'static,
-        Renderer: 'a + renderer::Debugger,
+        Renderer: 'a + layout::Debugger,
     {
         Element {
             widget: Box::new(Explain::new(self, color.into())),
@@ -348,7 +347,7 @@ where
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Explain<'a, Message, Renderer>
 where
-    Renderer: crate::Renderer + renderer::Debugger,
+    Renderer: crate::Renderer + layout::Debugger,
 {
     fn width(&self) -> Length {
         self.element.widget.width()

--- a/native/src/layout.rs
+++ b/native/src/layout.rs
@@ -1,9 +1,11 @@
 //! Position your widgets properly.
+mod debugger;
 mod limits;
 mod node;
 
 pub mod flex;
 
+pub use debugger::Debugger;
 pub use limits::Limits;
 pub use node::Node;
 

--- a/native/src/layout/debugger.rs
+++ b/native/src/layout/debugger.rs
@@ -1,9 +1,9 @@
-use crate::{Color, Layout, Point, Widget};
+use crate::{Color, Layout, Point, Renderer, Widget};
 
 /// A renderer able to graphically explain a [`Layout`].
 ///
-/// [`Layout`]: ../struct.Layout.html
-pub trait Debugger: super::Renderer {
+/// [`Layout`]: struct.Layout.html
+pub trait Debugger: Renderer {
     /// Explains the [`Layout`] of an [`Element`] for debugging purposes.
     ///
     /// This will be called when [`Element::explain`] has been used. It should
@@ -13,8 +13,8 @@ pub trait Debugger: super::Renderer {
     /// [`Layout`] and its children.
     ///
     /// [`Layout`]: struct.Layout.html
-    /// [`Element`]: struct.Element.html
-    /// [`Element::explain`]: struct.Element.html#method.explain
+    /// [`Element`]: ../struct.Element.html
+    /// [`Element::explain`]: ../struct.Element.html#method.explain
     fn explain<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -14,7 +14,7 @@
 //! - A [`Widget`] trait, which is used to implement new widgets: from layout
 //!   requirements to event and drawing logic.
 //! - A bunch of `Renderer` traits, meant to keep the crate renderer-agnostic.
-//! - A [`Windowed`] trait, leveraging [`raw-window-handle`], which can be
+//! - A [`window::Renderer`] trait, leveraging [`raw-window-handle`], which can be
 //!   implemented by graphical renderers that target _windows_. Window-based
 //!   shells (like [`iced_winit`]) can use this trait to stay renderer-agnostic.
 //!
@@ -31,7 +31,7 @@
 //! [`druid`]: https://github.com/xi-editor/druid
 //! [`raw-window-handle`]: https://github.com/rust-windowing/raw-window-handle
 //! [`Widget`]: widget/trait.Widget.html
-//! [`Windowed`]: renderer/trait.Windowed.html
+//! [`window::Renderer`]: window/trait.Renderer.html
 //! [`UserInterface`]: struct.UserInterface.html
 //! [renderer]: renderer/index.html
 #![deny(missing_docs)]

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -20,12 +20,6 @@
 //! [`Checkbox`]: ../widget/checkbox/struct.Checkbox.html
 //! [`checkbox::Renderer`]: ../widget/checkbox/trait.Renderer.html
 
-mod debugger;
-mod windowed;
-
-pub use debugger::Debugger;
-pub use windowed::{Target, Windowed};
-
 #[cfg(debug_assertions)]
 mod null;
 #[cfg(debug_assertions)]

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -1,4 +1,6 @@
 //! Build window-based GUI applications.
 mod event;
+mod renderer;
 
 pub use event::Event;
+pub use renderer::{Renderer, Target};

--- a/native/src/window/renderer.rs
+++ b/native/src/window/renderer.rs
@@ -3,16 +3,16 @@ use crate::MouseCursor;
 use raw_window_handle::HasRawWindowHandle;
 
 /// A renderer that can target windows.
-pub trait Windowed: super::Renderer + Sized {
+pub trait Renderer: crate::Renderer + Sized {
     /// The settings of the renderer.
     type Settings: Default;
 
     /// The type of target.
     type Target: Target<Renderer = Self>;
 
-    /// Creates a new [`Windowed`] renderer.
+    /// Creates a new window [`Renderer`].
     ///
-    /// [`Windowed`]: trait.Windowed.html
+    /// [`Renderer`]: trait.Renderer.html
     fn new(settings: Self::Settings) -> Self;
 
     /// Performs the drawing operations described in the output on the given

--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -3,8 +3,8 @@ use crate::{
     Transformation,
 };
 use iced_native::{
-    renderer::{Debugger, Windowed},
-    Background, Color, Layout, MouseCursor, Point, Rectangle, Vector, Widget,
+    layout, window, Background, Color, Layout, MouseCursor, Point, Rectangle,
+    Vector, Widget,
 };
 use std::sync::Arc;
 use wgpu::{
@@ -454,7 +454,7 @@ impl iced_native::Renderer for Renderer {
     }
 }
 
-impl Windowed for Renderer {
+impl window::Renderer for Renderer {
     type Settings = Settings;
     type Target = Target;
 
@@ -472,7 +472,7 @@ impl Windowed for Renderer {
     }
 }
 
-impl Debugger for Renderer {
+impl layout::Debugger for Renderer {
     fn explain<Message>(
         &mut self,
         defaults: &Defaults,

--- a/wgpu/src/renderer/target.rs
+++ b/wgpu/src/renderer/target.rs
@@ -1,4 +1,5 @@
 use crate::{Renderer, Transformation};
+use iced_native::window;
 
 use raw_window_handle::HasRawWindowHandle;
 
@@ -31,7 +32,7 @@ impl Target {
     }
 }
 
-impl iced_native::renderer::Target for Target {
+impl window::Target for Target {
     type Renderer = Renderer;
 
     fn new<W: HasRawWindowHandle>(

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -1,7 +1,6 @@
 use crate::{
     container, conversion,
     input::{keyboard, mouse},
-    renderer::{Target, Windowed},
     subscription, window, Cache, Clipboard, Command, Container, Debug, Element,
     Event, Length, MouseCursor, Settings, Subscription, UserInterface,
 };
@@ -18,7 +17,7 @@ pub trait Application: Sized {
     /// The renderer to use to draw the [`Application`].
     ///
     /// [`Application`]: trait.Application.html
-    type Renderer: Windowed + container::Renderer;
+    type Renderer: window::Renderer + container::Renderer;
 
     /// The type of __messages__ your [`Application`] will produce.
     ///
@@ -83,10 +82,11 @@ pub trait Application: Sized {
     /// [`Application`]: trait.Application.html
     fn run(
         settings: Settings,
-        renderer_settings: <Self::Renderer as Windowed>::Settings,
+        renderer_settings: <Self::Renderer as window::Renderer>::Settings,
     ) where
         Self: 'static,
     {
+        use window::{Renderer as _, Target as _};
         use winit::{
             event::{self, WindowEvent},
             event_loop::{ControlFlow, EventLoop},
@@ -147,7 +147,7 @@ pub trait Application: Sized {
         let mut target = {
             let (width, height) = to_physical(size, dpi);
 
-            <Self::Renderer as Windowed>::Target::new(
+            <Self::Renderer as window::Renderer>::Target::new(
                 &window, width, height, dpi as f32, &renderer,
             )
         };


### PR DESCRIPTION
Depends on #149.

We move `renderer::Debugger` to `layout::Debugger` and `renderer::Windowed` to `window::Renderer`.