### PR TITLE
Fix flex layout cross-alignment when not filled

### DIFF
--- a/native/src/layout/flex.rs
+++ b/native/src/layout/flex.rs
@@ -77,7 +77,7 @@ where
     let max_cross = axis.cross(limits.max());
 
     let mut fill_sum = 0;
-    let mut cross = axis.cross(limits.min());
+    let mut cross = axis.cross(limits.min()).max(axis.cross(limits.fill()));
     let mut available = axis.main(limits.max()) - total_spacing;
 
     let mut nodes: Vec<Node> = Vec::with_capacity(items.len());

--- a/native/src/layout/limits.rs
+++ b/native/src/layout/limits.rs
@@ -44,6 +44,14 @@ impl Limits {
         self.max
     }
 
+    /// Returns the fill [`Size`] of the [`Limits`].
+    ///
+    /// [`Limits`]: struct.Limits.html
+    /// [`Size`]: ../struct.Size.html
+    pub fn fill(&self) -> Size {
+        self.fill
+    }
+
     /// Applies a width constraint to the current [`Limits`].
     ///
     /// [`Limits`]: struct.Limits.html


### PR DESCRIPTION
This PR fixes a bug in the flex layout alignment algorithm where elements where not aligned properly when the container was not filled by them.