### PR TITLE
Remove Clone bound on Application::Message

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -171,7 +171,7 @@ where
     /// ```
     pub fn map<F, B>(self, f: F) -> Element<'a, B, Renderer>
     where
-        Message: 'static + Clone,
+        Message: 'static,
         Renderer: 'a,
         B: 'static,
         F: 'static + Fn(Message) -> B,
@@ -269,7 +269,6 @@ impl<'a, A, B, Renderer> Map<'a, A, B, Renderer> {
 
 impl<'a, A, B, Renderer> Widget<B, Renderer> for Map<'a, A, B, Renderer>
 where
-    A: Clone,
     Renderer: crate::Renderer,
 {
     fn width(&self) -> Length {
@@ -309,8 +308,7 @@ where
         );
 
         original_messages
-            .iter()
-            .cloned()
+            .drain(..)
             .for_each(|message| messages.push((self.mapper)(message)));
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -83,7 +83,7 @@ pub trait Application: Sized {
     /// The type of __messages__ your [`Application`] will produce.
     ///
     /// [`Application`]: trait.Application.html
-    type Message: std::fmt::Debug + Send + Clone;
+    type Message: std::fmt::Debug + Send;
 
     /// Initializes the [`Application`].
     ///

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -81,7 +81,7 @@ pub trait Sandbox {
     /// The type of __messages__ your [`Sandbox`] will produce.
     ///
     /// [`Sandbox`]: trait.Sandbox.html
-    type Message: std::fmt::Debug + Send + Clone;
+    type Message: std::fmt::Debug + Send;
 
     /// Initializes the [`Sandbox`].
     ///

--- a/web/src/bus.rs
+++ b/web/src/bus.rs
@@ -8,9 +8,16 @@ use std::rc::Rc;
 ///
 /// [`Application`]: trait.Application.html
 #[allow(missing_debug_implementations)]
-#[derive(Clone)]
 pub struct Bus<Message> {
     publish: Rc<Box<dyn Fn(Message, &mut dyn dodrio::RootRender)>>,
+}
+
+impl<Message> Clone for Bus<Message> {
+    fn clone(&self) -> Self {
+        Self {
+            publish: Rc::clone(&self.publish),
+        }
+    }
 }
 
 impl<Message> Bus<Message>

--- a/web/src/bus.rs
+++ b/web/src/bus.rs
@@ -15,7 +15,7 @@ pub struct Bus<Message> {
 
 impl<Message> Bus<Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     pub(crate) fn new() -> Self {
         Self {

--- a/web/src/element.rs
+++ b/web/src/element.rs
@@ -38,8 +38,8 @@ impl<'a, Message> Element<'a, Message> {
     /// [`Element`]: struct.Element.html
     pub fn map<F, B>(self, f: F) -> Element<'a, B>
     where
-        Message: 'static + Clone,
-        B: 'static + Clone,
+        Message: 'static,
+        B: 'static,
         F: 'static + Fn(Message) -> B,
     {
         Element {
@@ -82,8 +82,8 @@ impl<'a, A, B> Map<'a, A, B> {
 
 impl<'a, A, B> Widget<B> for Map<'a, A, B>
 where
-    A: 'static + Clone,
-    B: 'static + Clone,
+    A: 'static,
+    B: 'static,
 {
     fn node<'b>(
         &self,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -91,7 +91,7 @@ pub trait Application {
     /// The type of __messages__ your [`Application`] will produce.
     ///
     /// [`Application`]: trait.Application.html
-    type Message: Clone;
+    type Message;
 
     /// Initializes the [`Application`].
     ///
@@ -148,16 +148,26 @@ pub trait Application {
     }
 }
 
-#[derive(Clone)]
+
 struct Instance<Message> {
     title: String,
     ui: Rc<RefCell<Box<dyn Application<Message = Message>>>>,
     vdom: Rc<RefCell<Option<dodrio::VdomWeak>>>,
 }
 
+impl<Message> Clone for Instance<Message> {
+    fn clone(&self) -> Self {
+        Self {
+            title: self.title.clone(),
+            ui: Rc::clone(&self.ui),
+            vdom: Rc::clone(&self.vdom),
+        }
+    }
+}
+
 impl<Message> Instance<Message>
 where
-    Message: 'static + Clone,
+    Message: 'static
 {
     fn new(ui: impl Application<Message = Message> + 'static) -> Self {
         Self {
@@ -221,7 +231,7 @@ where
 
 impl<Message> dodrio::Render for Instance<Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     fn render<'a, 'bump>(
         &'a self,

--- a/web/src/widget/scrollable.rs
+++ b/web/src/widget/scrollable.rs
@@ -134,7 +134,7 @@ where
 
 impl<'a, Message> From<Scrollable<'a, Message>> for Element<'a, Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     fn from(scrollable: Scrollable<'a, Message>) -> Element<'a, Message> {
         Element::new(scrollable)

--- a/web/src/widget/slider.rs
+++ b/web/src/widget/slider.rs
@@ -82,7 +82,7 @@ impl<'a, Message> Slider<'a, Message> {
 
 impl<'a, Message> Widget<Message> for Slider<'a, Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     fn node<'b>(
         &self,
@@ -130,7 +130,7 @@ where
 
 impl<'a, Message> From<Slider<'a, Message>> for Element<'a, Message>
 where
-    Message: 'static + Clone,
+    Message: 'static,
 {
     fn from(slider: Slider<'a, Message>) -> Element<'a, Message> {
         Element::new(slider)

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -82,7 +82,7 @@ impl<'a, Message> TextInput<'a, Message> {
         self.is_secure = true;
         self
     }
-    
+
     /// Sets the width of the [`TextInput`].
     ///
     /// [`TextInput`]: struct.TextInput.html


### PR DESCRIPTION
I'm currently writing an application where I want to create a message that should not be cloned.

It's a `Box<RenderState>` where `RenderState` contains a bunch of wgpu handles to GPU resources. I *could* wrap it in `Arc<Mutex<>>` and pass it through a message that way, but being able to pass it as a box achieves the same thing more clearly.

I can't do this in master, because the Message associated type has a bound on Clone. But it turns out that nothing actually takes advantage of this bound, and IMO it's logical that the system should only ever be moving messages, not cloning them.

This change will put a greater restriction on how Message is used, but it's a restriction that the system appears to be currently handling fine.