### PR TITLE
Window file events

### DIFF
--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -9,7 +9,7 @@ use crate::{
 /// additional events, feel free to [open an issue] and share your use case!_
 ///
 /// [open an issue]: https://github.com/hecrj/iced/issues
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Event {
     /// A keyboard event
     Keyboard(keyboard::Event),

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -159,7 +159,7 @@ where
         self.children.iter_mut().zip(layout.children()).for_each(
             |(child, layout)| {
                 child.widget.on_event(
-                    event,
+                    event.clone(),
                     layout,
                     cursor_position,
                     messages,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -160,7 +160,7 @@ where
         self.children.iter_mut().zip(layout.children()).for_each(
             |(child, layout)| {
                 child.widget.on_event(
-                    event,
+                    event.clone(),
                     layout,
                     cursor_position,
                     messages,

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -1,5 +1,7 @@
+use std::path::PathBuf;
+
 /// A window-related event.
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Event {
     /// A window was resized
     Resized {
@@ -9,4 +11,22 @@ pub enum Event {
         /// The new height of the window (in units)
         height: u32,
     },
+
+    /// A file is being hovered over the window.
+    ///
+    /// When the user hovers multiple files at once, this event will be emitted
+    /// for each file separately.
+    FileHovered(PathBuf),
+
+    /// A file has beend dropped into the window.
+    ///
+    /// When the user drops multiple files at once, this event will be emitted
+    /// for each file separately.
+    FileDropped(PathBuf),
+
+    /// A file was hovered, but has exited the window.
+    ///
+    /// There will be a single `FilesLeft` event triggered even if multiple
+    /// files were hovered.
+    FilesLeft,
 }

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -26,7 +26,7 @@ pub enum Event {
 
     /// A file was hovered, but has exited the window.
     ///
-    /// There will be a single `FilesLeft` event triggered even if multiple
-    /// files were hovered.
-    FilesLeft,
+    /// There will be a single `FilesHoveredLeft` event triggered even if
+    /// multiple files were hovered.
+    FilesHoveredLeft,
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -302,6 +302,18 @@ pub trait Application: Sized {
                 event: window_event,
                 ..
             } => match window_event {
+                WindowEvent::Resized(new_size) => {
+                    events.push(Event::Window(window::Event::Resized {
+                        width: new_size.width.round() as u32,
+                        height: new_size.height.round() as u32,
+                    }));
+
+                    size = new_size;
+                    resized = true;
+                }
+                WindowEvent::CloseRequested => {
+                    *control_flow = ControlFlow::Exit;
+                }
                 WindowEvent::CursorMoved { position, .. } => {
                     events.push(Event::Mouse(mouse::Event::CursorMoved {
                         x: position.x as f32,
@@ -370,17 +382,16 @@ pub trait Application: Sized {
                         modifiers: conversion::modifiers_state(modifiers),
                     }));
                 }
-                WindowEvent::CloseRequested => {
-                    *control_flow = ControlFlow::Exit;
+                WindowEvent::HoveredFile(path) => {
+                    events
+                        .push(Event::Window(window::Event::FileHovered(path)));
                 }
-                WindowEvent::Resized(new_size) => {
-                    events.push(Event::Window(window::Event::Resized {
-                        width: new_size.width.round() as u32,
-                        height: new_size.height.round() as u32,
-                    }));
-
-                    size = new_size;
-                    resized = true;
+                WindowEvent::DroppedFile(path) => {
+                    events
+                        .push(Event::Window(window::Event::FileDropped(path)));
+                }
+                WindowEvent::HoveredFileCancelled => {
+                    events.push(Event::Window(window::Event::FilesHoveredLeft));
                 }
                 _ => {}
             },

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -192,9 +192,10 @@ pub trait Application: Sized {
                 );
 
                 debug.event_processing_started();
-                events.iter().for_each(|event| {
-                    subscription_pool.broadcast_event(*event)
-                });
+                events
+                    .iter()
+                    .cloned()
+                    .for_each(|event| subscription_pool.broadcast_event(event));
 
                 let mut messages = user_interface.update(
                     &renderer,

--- a/winit/src/subscription.rs
+++ b/winit/src/subscription.rs
@@ -86,7 +86,7 @@ impl Pool {
             .values_mut()
             .filter_map(|connection| connection.listener.as_mut())
             .for_each(|listener| {
-                if let Err(error) = listener.try_send(event) {
+                if let Err(error) = listener.try_send(event.clone()) {
                     log::error!(
                         "Error sending event to subscription: {:?}",
                         error


### PR DESCRIPTION
Fixes #158.

This PR adds `FileHovered`, `FileDropped`, and `FilesHoveredLeft` variants to `iced_native::window::Event`. This change forces `Event` to drop `Copy`.

Accordingly, `iced_winit` now produces these events as defined in [`winit`](https://docs.rs/winit/0.20.0/winit/event/enum.WindowEvent.html#variant.HoveredFile).