### PR TITLE
Cull images and free VRAM

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -16,6 +16,18 @@ pub struct Rectangle<T = f32> {
     pub height: T,
 }
 
+impl<T: std::ops::Add<Output = T> + PartialOrd + Copy> Rectangle<T> {
+    /// Returns true if the current [`Rectangle`] intersects with the given one.
+    ///
+    /// [`Rectangle`]: struct.Rectangle.html
+    pub fn intersects(&self, b: &Rectangle<T>) -> bool {
+        self.x < b.x + b.width
+            && self.x + self.width > b.x
+            && self.y < b.y + b.height
+            && self.y + self.height > b.y
+    }
+}
+
 impl Rectangle<f32> {
     /// Returns true if the given [`Point`] is contained in the [`Rectangle`].
     ///

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -252,9 +252,8 @@ impl Pipeline {
             let uploaded_texture = match &image.handle {
                 Handle::Raster(handle) => {
                     let mut cache = self.raster_cache.borrow_mut();
-                    let memory = cache.load(&handle);
 
-                    memory.upload(device, encoder, &self.texture_layout)
+                    cache.upload(handle, device, encoder, &self.texture_layout)
                 }
                 Handle::Vector(_handle) => {
                     #[cfg(feature = "svg")]

--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -50,6 +50,15 @@ impl<'a> Layer<'a> {
             meshes: Vec::new(),
         }
     }
+
+    pub fn visible_bounds(&self) -> Rectangle {
+        Rectangle {
+            x: (self.bounds.x + self.offset.x) as f32,
+            y: (self.bounds.y + self.offset.y) as f32,
+            width: self.bounds.width as f32,
+            height: self.bounds.height as f32,
+        }
+    }
 }
 
 impl Renderer {
@@ -244,11 +253,13 @@ impl Renderer {
                 });
             }
             Primitive::Image { handle, bounds } => {
-                layer.images.push(Image {
-                    handle: image::Handle::Raster(handle.clone()),
-                    position: [bounds.x, bounds.y],
-                    scale: [bounds.width, bounds.height],
-                });
+                if bounds.intersects(&layer.visible_bounds()) {
+                    layer.images.push(Image {
+                        handle: image::Handle::Raster(handle.clone()),
+                        position: [bounds.x, bounds.y],
+                        scale: [bounds.width, bounds.height],
+                    });
+                }
             }
             Primitive::Svg { handle, bounds } => {
                 layer.images.push(Image {


### PR DESCRIPTION
Fixes #160.

This PR changes the `iced_wgpu::image::raster::Cache` to unload images from the GPU when they are no longer visible and new ones have been uploaded.

The change may cause applications to block more oftenly when hiding/displaying different images (like a scrolling image gallery). However, they are much less likely to crash due to running out of video memory. We should be able to improve this strategy in #154 by trying to deallocate before creating a new layer instead.

In the long run, we should load and upload images asynchronously to avoid dropping frames.