### PR TITLE
Make `image` support optional in `iced_wgpu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
+# Enables the Image widget
+image = ["iced_wgpu/image"]
+# Enables the Svg widget
+svg = ["iced_wgpu/svg"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug"]
-# Enables support for SVG rendering
-svg = ["iced_wgpu/svg"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/examples/pokedex/Cargo.toml
+++ b/examples/pokedex/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-iced = { path = "../.." }
+iced = { path = "../..", features = ["image"] }
 iced_futures = { path = "../../futures", features = ["async-std"] }
 surf = "1.0"
 rand = "0.7"

--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-iced = { path = "../..", features = ["debug"] }
+iced = { path = "../..", features = ["image", "debug"] }
 env_logger = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -17,8 +17,8 @@ wgpu = "0.4"
 glyph_brush = "0.6"
 wgpu_glyph = { version = "0.7", git = "https://github.com/hecrj/wgpu_glyph", branch = "fix/font-load-panic" }
 raw-window-handle = "0.3"
-image = "0.22"
 glam = "0.8"
 font-kit = "0.4"
 log = "0.4"
 resvg = { version = "0.8", features = ["raqote-backend"], optional = true }
+image = { version = "0.22", optional = true }

--- a/wgpu/src/renderer/widget.rs
+++ b/wgpu/src/renderer/widget.rs
@@ -2,7 +2,6 @@ mod button;
 mod checkbox;
 mod column;
 mod container;
-mod image;
 mod progress_bar;
 mod radio;
 mod row;
@@ -14,3 +13,6 @@ mod text_input;
 
 #[cfg(feature = "svg")]
 mod svg;
+
+#[cfg(feature = "image")]
+mod image;


### PR DESCRIPTION
Depends on #164.

This PR makes image rendering support optional, allowing us to turn `image` into an optional dependency in `iced_wgpu`.

An application needs to enable the new `image` feature before being able to use an `Image` widget. As a consequence, the compilation time and binary size of applications that do not need image rendering is reduced.

For instance, the `counter` example has seen a reduction of `1.3M` in binary size on my Linux environment.