### PR TITLE
Make `Element::hash_layout` public.

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -242,7 +242,10 @@ where
             .draw(renderer, defaults, layout, cursor_position)
     }
 
-    pub(crate) fn hash_layout(&self, state: &mut Hasher) {
+    /// Computes the _layout_ hash of the [`Element`].
+    /// 
+    /// [`Element`]: struct.Element.html
+    pub fn hash_layout(&self, state: &mut Hasher) {
         self.widget.hash_layout(state);
     }
 }


### PR DESCRIPTION
Needed to implement custom widgets like tables for example.