### PR TITLE
Container support for Align::End

### DIFF
--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -77,6 +77,22 @@ where
         self.max_height = max_height;
         self
     }
+    
+    /// Sets the content alignment for the horizontal axis of the [`Container`].
+    ///
+    /// [`Container`]: struct.Container.html
+    pub fn align_x(mut self, alignment: Align) -> Self {
+        self.horizontal_alignment = alignment;
+        self
+    }
+
+    /// Sets the content alignment for the vertical axis of the [`Container`].
+    ///
+    /// [`Container`]: struct.Container.html
+    pub fn align_y(mut self, alignment: Align) -> Self {
+        self.vertical_alignment = alignment;
+        self
+    }
 
     /// Centers the contents in the horizontal axis of the [`Container`].
     ///


### PR DESCRIPTION
Adds two functions `align_x` and `align_y` to the container so that it we may specify Align::End as a possible value. 
It seems to work without any further changes

![Screenshot_20200211_173830](https://user-images.githubusercontent.com/22861550/74288518-7a0c2880-4d24-11ea-8866-9e62e60a391d.png)
<pre><code>
 fn view(&mut self) -> Element<RootMessage> {
        Column::new()
            .width(Length::Units(500))
            .push(
                Container::new(
                    Button::new(&mut self.decrement_button, Text::new("Decrement"))
                        .width(Length::Shrink)
                        .height(Length::Shrink)
                        .on_press(RootMessage::Decrement),
                )
                .width(Length::Fill)
                <b>.align_x(Align::End)</b>,
            )
            .push(Text::new(self.value.to_string()).size(50))
            .push(
                Button::new(&mut self.increment_button, Text::new("Increment"))
                    .width(Length::Shrink)
                    .height(Length::Shrink)
                    .on_press(RootMessage::Increment),
            )
            .into()
    }
</pre>
