### PR TITLE
Avoid Clone bound on Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ impl Counter {
                 // The increment button. We tell it to produce an
                 // `IncrementPressed` message when pressed
                 Button::new(&mut self.increment_button, Text::new("+"))
-                    .on_press(Message::IncrementPressed),
+                    .on_press(|| Message::IncrementPressed),
             )
             .push(
                 // We show the value of the counter here
@@ -128,7 +128,7 @@ impl Counter {
                 // The decrement button. We tell it to produce a
                 // `DecrementPressed` message when pressed
                 Button::new(&mut self.decrement_button, Text::new("-"))
-                    .on_press(Message::DecrementPressed),
+                    .on_press(|| Message::DecrementPressed),
             )
     }
 }

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -353,7 +353,7 @@ impl Sandbox for Example {
             .push(
                 Button::new(&mut self.button_state, Text::new("Clear"))
                     .padding(8)
-                    .on_press(Message::Clear),
+                    .on_press(|| Message::Clear),
             );
 
         Container::new(content)

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -45,12 +45,12 @@ impl Sandbox for Counter {
             .align_items(Align::Center)
             .push(
                 Button::new(&mut self.increment_button, Text::new("Increment"))
-                    .on_press(Message::IncrementPressed),
+                    .on_press(|| Message::IncrementPressed),
             )
             .push(Text::new(self.value.to_string()).size(50))
             .push(
                 Button::new(&mut self.decrement_button, Text::new("Decrement"))
-                    .on_press(Message::DecrementPressed),
+                    .on_press(|| Message::DecrementPressed),
             )
             .into()
     }

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -87,13 +87,13 @@ impl Application for Pokedex {
                 .align_items(Align::End)
                 .push(pokemon.view())
                 .push(
-                    button(search, "Keep searching!").on_press(Message::Search),
+                    button(search, "Keep searching!").on_press(|| Message::Search),
                 ),
             Pokedex::Errored { try_again, .. } => Column::new()
                 .spacing(20)
                 .align_items(Align::End)
                 .push(Text::new("Whoops! Something went wrong...").size(40))
-                .push(button(try_again, "Try again").on_press(Message::Search)),
+                .push(button(try_again, "Try again").on_press(|| Message::Search)),
         };
 
         Container::new(content)

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -115,12 +115,12 @@ impl Application for Stopwatch {
                 State::Ticking { .. } => ("Stop", style::Button::Destructive),
             };
 
-            button(&mut self.toggle, label, color).on_press(Message::Toggle)
+            button(&mut self.toggle, label, color).on_press(|| Message::Toggle)
         };
 
         let reset_button =
             button(&mut self.reset, "Reset", style::Button::Secondary)
-                .on_press(Message::Reset);
+                .on_press(|| Message::Reset);
 
         let controls = Row::new()
             .spacing(20)

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -78,7 +78,7 @@ impl Sandbox for Styling {
 
         let button = Button::new(&mut self.button, Text::new("Submit"))
             .padding(10)
-            .on_press(Message::ButtonPressed)
+            .on_press(|| Message::ButtonPressed)
             .style(self.theme);
 
         let slider = Slider::new(

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -295,7 +295,7 @@ impl Task {
                     .push(checkbox)
                     .push(
                         Button::new(edit_button, edit_icon())
-                            .on_press(TaskMessage::Edit)
+                            .on_press(|| TaskMessage::Edit)
                             .padding(10)
                             .style(style::Button::Icon),
                     )
@@ -326,7 +326,7 @@ impl Task {
                                 .push(delete_icon())
                                 .push(Text::new("Delete")),
                         )
-                        .on_press(TaskMessage::Delete)
+                        .on_press(|| TaskMessage::Delete)
                         .padding(10)
                         .style(style::Button::Destructive),
                     )
@@ -360,7 +360,7 @@ impl Controls {
                     selected: filter == current_filter,
                 });
 
-            button.on_press(Message::FilterChanged(filter)).padding(8)
+            button.on_press(|| Message::FilterChanged(filter)).padding(8)
         };
 
         Row::new()

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -160,7 +160,7 @@ impl Application for Todos {
                 )
                 .padding(15)
                 .size(30)
-                .on_submit(Message::CreateTask);
+                .on_submit(|| Message::CreateTask);
 
                 let controls = controls.view(&tasks, *filter);
                 let filtered_tasks =
@@ -311,7 +311,7 @@ impl Task {
                     &self.description,
                     TaskMessage::DescriptionEdited,
                 )
-                .on_submit(TaskMessage::FinishEdition)
+                .on_submit(|| TaskMessage::FinishEdition)
                 .padding(10);
 
                 Row::new()
@@ -360,7 +360,7 @@ impl Controls {
                     selected: filter == current_filter,
                 });
 
-            button.on_press(|| Message::FilterChanged(filter)).padding(8)
+            button.on_press(move || Message::FilterChanged(filter)).padding(8)
         };
 
         Row::new()

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -63,7 +63,7 @@ impl Sandbox for Tour {
         if steps.has_previous() {
             controls = controls.push(
                 button(back_button, "Back")
-                    .on_press(Message::BackPressed)
+                    .on_press(|| Message::BackPressed)
                     .style(style::Button::Secondary),
             );
         }
@@ -73,7 +73,7 @@ impl Sandbox for Tour {
         if steps.can_continue() {
             controls = controls.push(
                 button(next_button, "Next")
-                    .on_press(Message::NextPressed)
+                    .on_press(|| Message::NextPressed)
                     .style(style::Button::Primary),
             );
         }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -49,7 +49,7 @@ pub struct TextInput<'a, Message, Renderer: self::Renderer> {
     padding: u16,
     size: Option<u16>,
     on_change: Box<dyn Fn(String) -> Message>,
-    on_submit: Option<Message>,
+    on_submit: Option<Box<dyn Fn() -> Message>,>,
     style: Renderer::Style,
 }
 
@@ -141,8 +141,10 @@ impl<'a, Message, Renderer: self::Renderer> TextInput<'a, Message, Renderer> {
     /// focused and the enter key is pressed.
     ///
     /// [`TextInput`]: struct.TextInput.html
-    pub fn on_submit(mut self, message: Message) -> Self {
-        self.on_submit = Some(message);
+    pub fn on_submit<F>(mut self, on_submit: F) -> Self
+        where F: 'static + Fn() -> Message
+    {
+        self.on_submit = Some(Box::new(on_submit));
         self
     }
 
@@ -159,7 +161,7 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
     for TextInput<'a, Message, Renderer>
 where
     Renderer: 'static + self::Renderer,
-    Message: Clone + std::fmt::Debug,
+    Message: std::fmt::Debug,
 {
     fn width(&self) -> Length {
         self.width
@@ -261,8 +263,8 @@ where
                 modifiers,
             }) if self.state.is_focused => match key_code {
                 keyboard::KeyCode::Enter => {
-                    if let Some(on_submit) = self.on_submit.clone() {
-                        messages.push(on_submit);
+                    if let Some(on_submit) = self.on_submit.as_ref() {
+                        messages.push(on_submit());
                     }
                 }
                 keyboard::KeyCode::Backspace => {
@@ -484,7 +486,7 @@ impl<'a, Message, Renderer> From<TextInput<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
     Renderer: 'static + self::Renderer,
-    Message: 'static + Clone + std::fmt::Debug,
+    Message: 'static + std::fmt::Debug,
 {
     fn from(
         text_input: TextInput<'a, Message, Renderer>,

--- a/src/application.rs
+++ b/src/application.rs
@@ -67,14 +67,14 @@ use crate::{window, Command, Element, Executor, Settings, Subscription};
 ///         Column::new()
 ///             .push(
 ///                 Button::new(&mut self.increment_button, Text::new("Increment"))
-///                     .on_press(Message::IncrementPressed),
+///                     .on_press(|| Message::IncrementPressed),
 ///             )
 ///             .push(
 ///                 Text::new(self.value.to_string()).size(50),
 ///             )
 ///             .push(
 ///                 Button::new(&mut self.decrement_button, Text::new("Decrement"))
-///                     .on_press(Message::DecrementPressed),
+///                     .on_press(|| Message::DecrementPressed),
 ///             )
 ///             .into()
 ///     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@
 //!                 // The increment button. We tell it to produce an
 //!                 // `IncrementPressed` message when pressed
 //!                 Button::new(&mut self.increment_button, Text::new("+"))
-//!                     .on_press(Message::IncrementPressed),
+//!                     .on_press(|| Message::IncrementPressed),
 //!             )
 //!             .push(
 //!                 // We show the value of the counter here
@@ -115,7 +115,7 @@
 //!                 // The decrement button. We tell it to produce a
 //!                 // `DecrementPressed` message when pressed
 //!                 Button::new(&mut self.decrement_button, Text::new("-"))
-//!                     .on_press(Message::DecrementPressed),
+//!                     .on_press(|| Message::DecrementPressed),
 //!             )
 //!     }
 //! }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -64,14 +64,14 @@ use crate::{executor, Application, Command, Element, Settings, Subscription};
 ///         Column::new()
 ///             .push(
 ///                 Button::new(&mut self.increment_button, Text::new("Increment"))
-///                     .on_press(Message::IncrementPressed),
+///                     .on_press(|| Message::IncrementPressed),
 ///             )
 ///             .push(
 ///                 Text::new(self.value.to_string()).size(50),
 ///             )
 ///             .push(
 ///                 Button::new(&mut self.decrement_button, Text::new("Decrement"))
-///                     .on_press(Message::DecrementPressed),
+///                     .on_press(|| Message::DecrementPressed),
 ///             )
 ///             .into()
 ///     }


### PR DESCRIPTION
As dmarcuse mentioned in #77 if you have some message variants with uncloneable contents you currently end up having to wrap things in Arc which isn't very ergonomic. Having widgets accept Fn instead of Message avoids this issue.