### PR TITLE
Fix sample file path for svg example

### DIFF
--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -22,7 +22,7 @@ impl Sandbox for Tiger {
 
     fn view(&mut self) -> Element<()> {
         let content = Column::new().padding(20).push(
-            Svg::new(format!("{}/tiger.svg", env!("CARGO_MANIFEST_DIR")))
+            Svg::new(format!("{}/resources/tiger.svg", env!("CARGO_MANIFEST_DIR")))
                 .width(Length::Fill)
                 .height(Length::Fill),
         );


### PR DESCRIPTION
Sample tiger.svg is move to resources after directory restructuring. This change is to correct the path