### PR TITLE
Fix `Clip` primitive intersection in `iced_wgpu`

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -27,6 +27,34 @@ impl Rectangle<f32> {
             && self.y <= point.y
             && point.y <= self.y + self.height
     }
+
+    /// Computes the intersection with the given [`Rectangle`].
+    ///
+    /// [`Rectangle`]: struct.Rectangle.html
+    pub fn intersection(
+        &self,
+        other: &Rectangle<f32>,
+    ) -> Option<Rectangle<f32>> {
+        let x = self.x.max(other.x);
+        let y = self.y.max(other.y);
+
+        let lower_right_x = (self.x + self.width).min(other.x + other.width);
+        let lower_right_y = (self.y + self.height).min(other.y + other.height);
+
+        let width = lower_right_x - x;
+        let height = lower_right_y - y;
+
+        if width > 0.0 && height > 0.0 {
+            Some(Rectangle {
+                x,
+                y,
+                width,
+                height,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl std::ops::Mul<f32> for Rectangle<u32> {
@@ -38,6 +66,28 @@ impl std::ops::Mul<f32> for Rectangle<u32> {
             y: (self.y as f32 * scale).round() as u32,
             width: (self.width as f32 * scale).round() as u32,
             height: (self.height as f32 * scale).round() as u32,
+        }
+    }
+}
+
+impl From<Rectangle<u32>> for Rectangle<f32> {
+    fn from(rectangle: Rectangle<u32>) -> Rectangle<f32> {
+        Rectangle {
+            x: rectangle.x as f32,
+            y: rectangle.y as f32,
+            width: rectangle.width as f32,
+            height: rectangle.height as f32,
+        }
+    }
+}
+
+impl From<Rectangle<f32>> for Rectangle<u32> {
+    fn from(rectangle: Rectangle<f32>) -> Rectangle<u32> {
+        Rectangle {
+            x: rectangle.x as u32,
+            y: rectangle.y as u32,
+            width: rectangle.width.ceil() as u32,
+            height: rectangle.height.ceil() as u32,
         }
     }
 }

--- a/wgpu/src/renderer.rs
+++ b/wgpu/src/renderer.rs
@@ -240,25 +240,18 @@ impl Renderer {
                 offset,
                 content,
             } => {
-                let x = bounds.x - layer.offset.x as f32;
-                let y = bounds.y - layer.offset.y as f32;
-                let width = (bounds.width + x).min(bounds.width);
-                let height = (bounds.height + y).min(bounds.height);
+                let layer_bounds: Rectangle<f32> = layer.bounds.into();
 
-                // Only draw visible content on-screen
-                // TODO: Also, check for parent layer bounds to avoid further
-                // drawing in some circumstances.
-                if width > 0.0 && height > 0.0 {
-                    let clip_layer = Layer::new(
-                        Rectangle {
-                            x: x.max(0.0).floor() as u32,
-                            y: y.max(0.0).floor() as u32,
-                            width: width.ceil() as u32,
-                            height: height.ceil() as u32,
-                        },
-                        layer.offset + *offset,
-                    );
+                let clip = Rectangle {
+                    x: bounds.x - layer.offset.x as f32,
+                    y: bounds.y - layer.offset.y as f32,
+                    ..*bounds
+                };
 
+                // Only draw visible content
+                if let Some(clip_bounds) = layer_bounds.intersection(&clip) {
+                    let clip_layer =
+                        Layer::new(clip_bounds.into(), layer.offset + *offset);
                     let new_layer = Layer::new(layer.bounds, layer.offset);
 
                     layers.push(clip_layer);


### PR DESCRIPTION
Fixes [an issue reported on Zulip](https://iced.zulipchat.com/#narrow/stream/213316-general/topic/text.20in.20text.20input.20rendered.20on.20top.20of.20other.20content).

Basically, we were only clamping the width and height of nested clippables instead of computing a proper rectangle intersection.