### PR TITLE
Update `winit` to `0.22`

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -10,7 +10,7 @@ use iced_wgpu::{
 use iced_winit::{winit, Cache, Clipboard, MouseCursor, Size, UserInterface};
 
 use winit::{
-    event::{DeviceEvent, Event, ModifiersState, WindowEvent},
+    event::{Event, ModifiersState, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
 };
 
@@ -66,14 +66,11 @@ pub fn main() {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::DeviceEvent {
-                event: DeviceEvent::ModifiersChanged(new_modifiers),
-                ..
-            } => {
-                modifiers = new_modifiers;
-            }
             Event::WindowEvent { event, .. } => {
                 match event {
+                    WindowEvent::ModifiersChanged(new_modifiers) => {
+                        modifiers = new_modifiers;
+                    }
                     WindowEvent::Resized(new_size) => {
                         logical_size =
                             new_size.to_logical(window.scale_factor());
@@ -82,6 +79,7 @@ pub fn main() {
                     WindowEvent::CloseRequested => {
                         *control_flow = ControlFlow::Exit;
                     }
+
                     _ => {}
                 }
 

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 debug = []
 
 [dependencies]
-winit = "0.21"
+winit = "0.22"
 log = "0.4"
 
 [dependencies.iced_native]

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -347,6 +347,9 @@ pub trait Application: Sized {
                     WindowEvent::CloseRequested => {
                         *control_flow = ControlFlow::Exit;
                     }
+                    WindowEvent::ModifiersChanged(new_modifiers) => {
+                        modifiers = new_modifiers;
+                    }
                     #[cfg(target_os = "macos")]
                     WindowEvent::KeyboardInput {
                         input:
@@ -381,12 +384,6 @@ pub trait Application: Sized {
                 ) {
                     events.push(event);
                 }
-            }
-            event::Event::DeviceEvent {
-                event: event::DeviceEvent::ModifiersChanged(new_modifiers),
-                ..
-            } => {
-                modifiers = new_modifiers;
             }
             _ => {
                 *control_flow = ControlFlow::Wait;


### PR DESCRIPTION
Fixes #188.

This PR updates `winit` to [the latest release](https://github.com/rust-windowing/winit/releases/tag/v0.22.0).