### PR TITLE
Instantiate Column and Row with children

### DIFF
--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -42,10 +42,12 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         }
     }
 
-    /// Creates a [`Column`] with children.
+    /// Creates a [`Column`] with the given elements.
     ///
     /// [`Column`]: struct.Column.html
-    pub fn new_with_children(children: Vec<Element<'a, Message, Renderer>>) -> Self {
+    pub fn with_children(
+        children: Vec<Element<'a, Message, Renderer>>,
+    ) -> Self {
         Column {
             spacing: 0,
             padding: 0,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -30,16 +30,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
     ///
     /// [`Column`]: struct.Column.html
     pub fn new() -> Self {
-        Column {
-            spacing: 0,
-            padding: 0,
-            width: Length::Shrink,
-            height: Length::Shrink,
-            max_width: u32::MAX,
-            max_height: u32::MAX,
-            align_items: Align::Start,
-            children: Vec::new(),
-        }
+        Self::with_children(Vec::new())
     }
 
     /// Creates a [`Column`] with the given elements.

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -42,6 +42,22 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         }
     }
 
+    /// Creates a [`Column`] with children.
+    ///
+    /// [`Column`]: struct.Column.html
+    pub fn new_with_children(children: Vec<Element<'a, Message, Renderer>>) -> Self {
+        Column {
+            spacing: 0,
+            padding: 0,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            max_width: u32::MAX,
+            max_height: u32::MAX,
+            align_items: Align::Start,
+            children,
+        }
+    }
+
     /// Sets the vertical spacing _between_ elements.
     ///
     /// Custom margins per element do not exist in Iced. You should use this

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -42,6 +42,22 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         }
     }
 
+    /// Creates a [`Row`] with children.
+    ///
+    /// [`Row`]: struct.Row.html
+    pub fn new_with_children(children: Vec<Element<'a, Message, Renderer>>) -> Self {
+        Row {
+            spacing: 0,
+            padding: 0,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            max_width: u32::MAX,
+            max_height: u32::MAX,
+            align_items: Align::Start,
+            children,
+        }
+    }
+
     /// Sets the horizontal spacing _between_ elements.
     ///
     /// Custom margins per element do not exist in Iced. You should use this

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -30,16 +30,7 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
     ///
     /// [`Row`]: struct.Row.html
     pub fn new() -> Self {
-        Row {
-            spacing: 0,
-            padding: 0,
-            width: Length::Shrink,
-            height: Length::Shrink,
-            max_width: u32::MAX,
-            max_height: u32::MAX,
-            align_items: Align::Start,
-            children: Vec::new(),
-        }
+        Self::with_children(Vec::new())
     }
 
     /// Creates a [`Row`] with the given elements.

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -42,10 +42,12 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         }
     }
 
-    /// Creates a [`Row`] with children.
+    /// Creates a [`Row`] with the given elements.
     ///
     /// [`Row`]: struct.Row.html
-    pub fn new_with_children(children: Vec<Element<'a, Message, Renderer>>) -> Self {
+    pub fn with_children(
+        children: Vec<Element<'a, Message, Renderer>>,
+    ) -> Self {
         Row {
             spacing: 0,
             padding: 0,

--- a/web/src/widget/column.rs
+++ b/web/src/widget/column.rs
@@ -25,22 +25,13 @@ impl<'a, Message> Column<'a, Message> {
     ///
     /// [`Column`]: struct.Column.html
     pub fn new() -> Self {
-        Column {
-            spacing: 0,
-            padding: 0,
-            width: Length::Fill,
-            height: Length::Shrink,
-            max_width: u32::MAX,
-            max_height: u32::MAX,
-            align_items: Align::Start,
-            children: Vec::new(),
-        }
+        Self::with_children(Vec::new())
     }
 
-    /// Creates a [`Column`] with children.
+    /// Creates a [`Column`] with the given elements.
     ///
     /// [`Column`]: struct.Column.html
-    pub fn new_with_children(children: Vec<Element<'a, Message>>) -> Self {
+    pub fn with_children(children: Vec<Element<'a, Message>>) -> Self {
         Column {
             spacing: 0,
             padding: 0,

--- a/web/src/widget/column.rs
+++ b/web/src/widget/column.rs
@@ -37,6 +37,22 @@ impl<'a, Message> Column<'a, Message> {
         }
     }
 
+    /// Creates a [`Column`] with children.
+    ///
+    /// [`Column`]: struct.Column.html
+    pub fn new_with_children(children: Vec<Element<'a, Message>>) -> Self {
+        Column {
+            spacing: 0,
+            padding: 0,
+            width: Length::Fill,
+            height: Length::Shrink,
+            max_width: u32::MAX,
+            max_height: u32::MAX,
+            align_items: Align::Start,
+            children,
+        }
+    }
+
     /// Sets the vertical spacing _between_ elements.
     ///
     /// Custom margins per element do not exist in Iced. You should use this

--- a/web/src/widget/row.rs
+++ b/web/src/widget/row.rs
@@ -25,22 +25,13 @@ impl<'a, Message> Row<'a, Message> {
     ///
     /// [`Row`]: struct.Row.html
     pub fn new() -> Self {
-        Row {
-            spacing: 0,
-            padding: 0,
-            width: Length::Fill,
-            height: Length::Shrink,
-            max_width: u32::MAX,
-            max_height: u32::MAX,
-            align_items: Align::Start,
-            children: Vec::new(),
-        }
+        Self::with_children(Vec::new())
     }
 
-    /// Creates a [`Row`] with children.
+    /// Creates a [`Row`] with the given elements.
     ///
     /// [`Row`]: struct.Row.html
-    pub fn new_with_children(children: Vec<Element<'a, Message>>) -> Self {
+    pub fn with_children(children: Vec<Element<'a, Message>>) -> Self {
         Row {
             spacing: 0,
             padding: 0,

--- a/web/src/widget/row.rs
+++ b/web/src/widget/row.rs
@@ -37,6 +37,22 @@ impl<'a, Message> Row<'a, Message> {
         }
     }
 
+    /// Creates a [`Row`] with children.
+    ///
+    /// [`Row`]: struct.Row.html
+    pub fn new_with_children(children: Vec<Element<'a, Message>>) -> Self {
+        Row {
+            spacing: 0,
+            padding: 0,
+            width: Length::Fill,
+            height: Length::Shrink,
+            max_width: u32::MAX,
+            max_height: u32::MAX,
+            align_items: Align::Start,
+            children,
+        }
+    }
+
     /// Sets the horizontal spacing _between_ elements.
     ///
     /// Custom margins per element do not exist in Iced. You should use this


### PR DESCRIPTION
Instantiate a Column or a Row with children. A compliment to the existing `push` functions.

Duplicates the default values of the `new` function, save for `children`.