### PR TITLE
Remove excess whitespace from end of line to comply with `cargo fmt`.

### DIFF
--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -77,7 +77,7 @@ where
         self.max_height = max_height;
         self
     }
-    
+
     /// Sets the content alignment for the horizontal axis of the [`Container`].
     ///
     /// [`Container`]: struct.Container.html

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -126,7 +126,7 @@ impl Handle {
     }
 
     /// Creates an image [`Handle`] containing the image pixels directly. This
-    /// function expects the input data to be provided as a `Vec<u8>` of BGRA 
+    /// function expects the input data to be provided as a `Vec<u8>` of BGRA
     /// pixels.
     ///
     /// This is useful if you have already decoded your image.


### PR DESCRIPTION
My trivial first commit... I noticed that we are *almost* `cargo fmt` compliant. There's just two lines with extra whitespace at the end. This PR removes that whitespace.