### PR TITLE
remove explicit lifetimes in integration example

### DIFF
--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -29,10 +29,7 @@ impl Controls {
         }
     }
 
-    pub fn view<'a>(
-        &'a mut self,
-        scene: &Scene,
-    ) -> Element<'a, Message, Renderer> {
+    pub fn view(&mut self, scene: &Scene) -> Element<Message, Renderer> {
         let [r, g, b] = &mut self.sliders;
         let background_color = scene.background_color;
 


### PR DESCRIPTION
Clippy was complaining about this. 

(I can create another pull request for more code cleanups if desired )