### PR TITLE
Application flags

### DIFF
--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -23,8 +23,9 @@ enum Message {
 impl Application for Clock {
     type Executor = executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Self, Command<Message>) {
+    fn new(_flags: ()) -> (Self, Command<Message>) {
         (
             Clock {
                 now: chrono::Local::now().into(),

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -26,8 +26,9 @@ pub enum Message {
 impl Application for Example {
     type Executor = executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Example, Command<Message>) {
+    fn new(_flags: ()) -> (Example, Command<Message>) {
         (
             Example::Idle {
                 button: button::State::new(),

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -22,8 +22,9 @@ enum Message {
 impl Application for Events {
     type Executor = executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Events, Command<Message>) {
+    fn new(_flags: ()) -> (Events, Command<Message>) {
         (Events::default(), Command::none())
     }
 

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -29,8 +29,9 @@ enum Message {
 impl Application for Pokedex {
     type Executor = iced::executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Pokedex, Command<Message>) {
+    fn new(_flags: ()) -> (Pokedex, Command<Message>) {
         (
             Pokedex::Loading,
             Command::perform(Pokemon::search(), Message::PokemonFound),

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -7,8 +7,8 @@
 //!
 //! [1]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations#An_animated_solar_system
 use iced::{
-    canvas, executor, Application, Canvas, Color, Command, Container, Element,
-    Length, Point, Settings, Size, Subscription, Vector,
+    canvas, executor, window, Application, Canvas, Color, Command, Container,
+    Element, Length, Point, Settings, Size, Subscription, Vector,
 };
 
 use std::time::Instant;
@@ -33,8 +33,9 @@ enum Message {
 impl Application for SolarSystem {
     type Executor = executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Self, Command<Message>) {
+    fn new(_flags: ()) -> (Self, Command<Message>) {
         (
             SolarSystem {
                 state: State::new(),
@@ -95,7 +96,7 @@ impl State {
 
     pub fn new() -> State {
         let now = Instant::now();
-        let (width, height) = Settings::default().window.size;
+        let (width, height) = window::Settings::default().size;
 
         State {
             start: now,

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -30,8 +30,9 @@ enum Message {
 impl Application for Stopwatch {
     type Executor = iced_futures::executor::AsyncStd;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Stopwatch, Command<Message>) {
+    fn new(_flags: ()) -> (Stopwatch, Command<Message>) {
         (
             Stopwatch {
                 duration: Duration::default(),

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -40,8 +40,9 @@ enum Message {
 impl Application for Todos {
     type Executor = iced::executor::Default;
     type Message = Message;
+    type Flags = ();
 
-    fn new() -> (Todos, Command<Message>) {
+    fn new(_flags: ()) -> (Todos, Command<Message>) {
         (
             Todos::Loading,
             Command::perform(SavedState::load(), Message::Loaded),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -51,7 +51,11 @@ mod platform {
 
     /// A default cross-platform executor.
     ///
-    /// - On native platforms, it will use `iced_futures::executor::ThreadPool`.
+    /// - On native platforms, it will use:
+    ///   - `iced_futures::executor::Tokio` when the `tokio` feature is enabled.
+    ///   - `iced_futures::executor::AsyncStd` when the `async-std` feature is
+    ///     enabled.
+    ///   - `iced_futures::executor::ThreadPool` otherwise.
     /// - On the Web, it will use `iced_futures::executor::WasmBindgen`.
     #[derive(Debug)]
     pub struct Default(WasmBindgen);
@@ -63,6 +67,10 @@ mod platform {
 
         fn spawn(&self, future: impl futures::Future<Output = ()> + 'static) {
             self.0.spawn(future);
+        }
+
+        fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
+            self.0.enter(f)
         }
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -121,7 +121,7 @@ pub trait Sandbox {
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Sandbox`]: trait.Sandbox.html
-    fn run(settings: Settings)
+    fn run(settings: Settings<()>)
     where
         Self: 'static + Sized,
     {
@@ -134,9 +134,10 @@ where
     T: Sandbox,
 {
     type Executor = executor::Null;
+    type Flags = ();
     type Message = T::Message;
 
-    fn new() -> (Self, Command<T::Message>) {
+    fn new(_flags: ()) -> (Self, Command<T::Message>) {
         (T::new(), Command::none())
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,13 +3,18 @@ use crate::window;
 
 /// The settings of an application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct Settings {
+pub struct Settings<Flags> {
     /// The window settings.
     ///
     /// They will be ignored on the Web.
     ///
     /// [`Window`]: struct.Window.html
     pub window: window::Settings,
+
+    /// The data needed to initialize an [`Application`].
+    ///
+    /// [`Application`]: trait.Application.html
+    pub flags: Flags,
 
     /// The bytes of the font that will be used by default.
     ///
@@ -28,8 +33,8 @@ pub struct Settings {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<Settings> for iced_winit::Settings {
-    fn from(settings: Settings) -> iced_winit::Settings {
+impl<Flags> From<Settings<Flags>> for iced_winit::Settings<Flags> {
+    fn from(settings: Settings<Flags>) -> iced_winit::Settings<Flags> {
         iced_winit::Settings {
             window: iced_winit::settings::Window {
                 size: settings.window.size,
@@ -37,6 +42,7 @@ impl From<Settings> for iced_winit::Settings {
                 decorations: settings.window.decorations,
                 platform_specific: Default::default(),
             },
+            flags: settings.flags,
         }
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -94,11 +94,6 @@ pub use executor::Executor;
 /// An [`Application`](trait.Application.html) can execute asynchronous actions
 /// by returning a [`Command`](struct.Command.html) in some of its methods.
 pub trait Application {
-    /// The type of __messages__ your [`Application`] will produce.
-    ///
-    /// [`Application`]: trait.Application.html
-    type Message: Send;
-
     /// The [`Executor`] that will run commands and subscriptions.
     ///
     /// The [`executor::WasmBindgen`] can be a good choice for the Web.
@@ -106,6 +101,16 @@ pub trait Application {
     /// [`Executor`]: trait.Executor.html
     /// [`executor::Default`]: executor/struct.Default.html
     type Executor: Executor;
+
+    /// The type of __messages__ your [`Application`] will produce.
+    ///
+    /// [`Application`]: trait.Application.html
+    type Message: Send;
+
+    /// The data needed to initialize your [`Application`].
+    ///
+    /// [`Application`]: trait.Application.html
+    type Flags;
 
     /// Initializes the [`Application`].
     ///
@@ -117,7 +122,7 @@ pub trait Application {
     /// request, etc.
     ///
     /// [`Application`]: trait.Application.html
-    fn new() -> (Self, Command<Self::Message>)
+    fn new(flags: Self::Flags) -> (Self, Command<Self::Message>)
     where
         Self: Sized;
 
@@ -165,20 +170,15 @@ pub trait Application {
     /// Runs the [`Application`].
     ///
     /// [`Application`]: trait.Application.html
-    fn run()
+    fn run(flags: Self::Flags)
     where
         Self: 'static + Sized,
     {
         use futures::stream::StreamExt;
 
-        let (app, command) = Self::new();
-
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();
         let body = document.body().unwrap();
-
-        let mut title = app.title();
-        document.set_title(&title);
 
         let (sender, receiver) =
             iced_futures::futures::channel::mpsc::unbounded();
@@ -187,6 +187,12 @@ pub trait Application {
             Self::Executor::new().expect("Create executor"),
             sender.clone(),
         );
+
+        let (app, command) = Self::new(flags);
+
+        let mut title = app.title();
+        document.set_title(&title);
+
         runtime.spawn(command);
 
         let application = Rc::new(RefCell::new(app));

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -1,28 +1,25 @@
 //! Configure your application.
 #[cfg(target_os = "windows")]
-#[path = "windows.rs"]
+#[path = "settings/windows.rs"]
 mod platform;
 #[cfg(not(target_os = "windows"))]
-#[path = "not_windows.rs"]
+#[path = "settings/not_windows.rs"]
 mod platform;
 
 pub use platform::PlatformSpecific;
 
 /// The settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Settings {
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Settings<Flags> {
     /// The [`Window`] settings
     ///
     /// [`Window`]: struct.Window.html
     pub window: Window,
-}
 
-impl Default for Settings {
-    fn default() -> Settings {
-        Settings {
-            window: Window::default(),
-        }
-    }
+    /// The data needed to initialize an [`Application`].
+    ///
+    /// [`Application`]: trait.Application.html
+    pub flags: Flags,
 }
 
 /// The window settings of an application.


### PR DESCRIPTION
Fixes #118 and closes #244.

This PR adds an additional associated type `Flags` to the `Application` trait which allows passing external state to `Application::new` through the new `flags` field in `Settings`.

This is analogous to [flags in Elm](https://guide.elm-lang.org/interop/flags.html).