### PR TITLE
Rework scaling in clock example

### DIFF
--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -133,7 +133,7 @@ impl canvas::Drawable for LocalTime {
         frame.stroke(
             &hour_and_minute_hands,
             canvas::Stroke {
-                width: 6.0,
+                width: radius / 100. * 3.,
                 color: Color::WHITE,
                 line_cap: canvas::LineCap::Round,
                 ..canvas::Stroke::default()
@@ -148,7 +148,7 @@ impl canvas::Drawable for LocalTime {
         frame.stroke(
             &second_hand,
             canvas::Stroke {
-                width: 3.0,
+                width: radius / 100.,
                 color: Color::WHITE,
                 line_cap: canvas::LineCap::Round,
                 ..canvas::Stroke::default()

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -133,7 +133,7 @@ impl canvas::Drawable for LocalTime {
         frame.stroke(
             &hour_and_minute_hands,
             canvas::Stroke {
-                width: radius / 100. * 3.,
+                width: radius / 100.0 * 3.0,
                 color: Color::WHITE,
                 line_cap: canvas::LineCap::Round,
                 ..canvas::Stroke::default()
@@ -148,7 +148,7 @@ impl canvas::Drawable for LocalTime {
         frame.stroke(
             &second_hand,
             canvas::Stroke {
-                width: radius / 100.,
+                width: radius / 100.0,
                 color: Color::WHITE,
                 line_cap: canvas::LineCap::Round,
                 ..canvas::Stroke::default()


### PR DESCRIPTION
I quite like the clock example as an example of iced's reactivity, but it doesn't directly scale the clock hands at the moment, leading to a strange effect with smaller windows

![The clock at full scale](https://i.imgur.com/CJJljuw.png)
![The clock scaled down, but the hands are the same width](https://i.imgur.com/MkEFu1Z.png)

I scaled the hands with the same factor as the face to make it feel more consistent: 

![A small clock with the same proportions as the full-scale image](https://i.imgur.com/fqgLJvN.png)