### PR TITLE
reference feature flags in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ iced_wgpu = { version = "0.2", path = "wgpu" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iced_web = { version = "0.2", path = "web" }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["image", "svg", "canvas"]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -30,3 +30,7 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true

--- a/futures/src/executor/async_std.rs
+++ b/futures/src/executor/async_std.rs
@@ -3,6 +3,7 @@ use crate::Executor;
 use futures::Future;
 
 /// An `async-std` runtime.
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
 #[derive(Debug)]
 pub struct AsyncStd;
 

--- a/futures/src/executor/thread_pool.rs
+++ b/futures/src/executor/thread_pool.rs
@@ -3,6 +3,7 @@ use crate::Executor;
 use futures::Future;
 
 /// A thread pool runtime for futures.
+#[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 pub type ThreadPool = futures::executor::ThreadPool;
 
 impl Executor for futures::executor::ThreadPool {

--- a/futures/src/executor/tokio.rs
+++ b/futures/src/executor/tokio.rs
@@ -3,6 +3,7 @@ use crate::Executor;
 use futures::Future;
 
 /// A `tokio` runtime.
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub type Tokio = tokio::runtime::Runtime;
 
 impl Executor for Tokio {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -4,6 +4,8 @@
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub use futures;
 
 mod command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 mod application;
 mod element;
 mod sandbox;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -18,13 +18,22 @@
 //! [`text_input::State`]: text_input/struct.State.html
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
-    pub use iced_wgpu::widget::*;
+    pub use iced_wgpu::widget::{
+        button, checkbox, container, pane_grid, progress_bar, radio,
+        scrollable, slider, text_input,
+    };
 
+    #[cfg(feature = "canvas")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "canvas")))]
+    pub use iced_wgpu::widget::canvas;
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
     pub mod image {
         //! Display images in your user interface.
         pub use iced_winit::image::{Handle, Image};
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "svg")))]
     pub mod svg {
         //! Display vector graphics in your user interface.
         pub use iced_winit::svg::{Handle, Svg};

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -41,3 +41,7 @@ optional = true
 [dependencies.lyon]
 version = "0.15"
 optional = true
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -25,6 +25,8 @@
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod defaults;
 pub mod settings;
 pub mod triangle;

--- a/wgpu/src/widget.rs
+++ b/wgpu/src/widget.rs
@@ -37,6 +37,7 @@ pub use slider::Slider;
 pub use text_input::TextInput;
 
 #[cfg(feature = "canvas")]
+#[cfg_attr(docsrs, doc(cfg(feature = "canvas")))]
 pub mod canvas;
 
 #[cfg(feature = "canvas")]

--- a/wgpu/src/widget/canvas/frame.rs
+++ b/wgpu/src/widget/canvas/frame.rs
@@ -172,6 +172,7 @@ impl Frame {
     ///
     /// [`Text`]: struct.Text.html
     /// [`Frame`]: struct.Frame.html
+    /// [`Canvas`]: struct.Canvas.html
     pub fn fill_text(&mut self, text: Text) {
         use std::f32;
 


### PR DESCRIPTION
Makes it clearer when browsing docs which feature flags are needed for certain features using a docsrs config flag.

Test locally using:
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --workspace --lib --no-deps --all-features --open
```

eg: 
<img width="561" alt="2020-04-04_02 26 46-e99bc6aa" src="https://user-images.githubusercontent.com/3316789/78415809-1dd6ce00-761c-11ea-98c0-c7fe51953fdf.png">
