### PR TITLE
Checkbox label is now `Into<String>`

### DIFF
--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -528,10 +528,9 @@ impl<'a> Step {
             .push(Language::all().iter().cloned().fold(
                 Column::new().padding(10).spacing(20),
                 |choices, language| {
-                    let label: &str = language.into();
                     choices.push(Radio::new(
                         language,
-                        label,
+                        language,
                         selection,
                         StepMessage::LanguageSelected,
                     ))
@@ -730,16 +729,16 @@ impl Language {
     }
 }
 
-impl From<Language> for &str {
-    fn from(language: Language) -> &'static str {
-        match language {
+impl From<Language> for String {
+    fn from(language: Language) -> String {
+        String::from(match language {
             Language::Rust => "Rust",
             Language::Elm => "Elm",
             Language::Ruby => "Ruby",
             Language::Haskell => "Haskell",
             Language::C => "C",
             Language::Other => "Other",
-        }
+        })
     }
 }
 

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -528,9 +528,10 @@ impl<'a> Step {
             .push(Language::all().iter().cloned().fold(
                 Column::new().padding(10).spacing(20),
                 |choices, language| {
+                    let label: &str = language.into();
                     choices.push(Radio::new(
                         language,
-                        language.into(),
+                        label,
                         selection,
                         StepMessage::LanguageSelected,
                     ))

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -50,14 +50,14 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     ///     `Message`.
     ///
     /// [`Checkbox`]: struct.Checkbox.html
-    pub fn new<F>(is_checked: bool, label: &str, f: F) -> Self
+    pub fn new<F>(is_checked: bool, label: impl Into<String>, f: F) -> Self
     where
         F: 'static + Fn(bool) -> Message,
     {
         Checkbox {
             is_checked,
             on_toggle: Box::new(f),
-            label: String::from(label),
+            label: label.into(),
             width: Length::Shrink,
             size: <Renderer as self::Renderer>::DEFAULT_SIZE,
             spacing: Renderer::DEFAULT_SPACING,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -53,7 +53,12 @@ impl<Message, Renderer: self::Renderer> Radio<Message, Renderer> {
     ///   receives the value of the radio and must produce a `Message`.
     ///
     /// [`Radio`]: struct.Radio.html
-    pub fn new<F, V>(value: V, label: &str, selected: Option<V>, f: F) -> Self
+    pub fn new<F, V>(
+        value: V,
+        label: impl Into<String>,
+        selected: Option<V>,
+        f: F,
+    ) -> Self
     where
         V: Eq + Copy,
         F: 'static + Fn(V) -> Message,
@@ -61,7 +66,7 @@ impl<Message, Renderer: self::Renderer> Radio<Message, Renderer> {
         Radio {
             is_selected: Some(value) == selected,
             on_click: f(value),
-            label: String::from(label),
+            label: label.into(),
             style: Renderer::Style::default(),
         }
     }


### PR DESCRIPTION
This PR allows checkbox labels to be dynamically modified depending on the business logic.

For example:
![image](https://user-images.githubusercontent.com/3784017/78420478-c8310e80-7679-11ea-92d8-d9ef84c8c23f.png)

```rust
use iced::{Sandbox, Settings, Text, Align, Column};

fn main() {
    CheckUi::run(Settings::default());
}

#[derive(Default)]
struct CheckUi {
    checks: Vec<bool>,
}

#[derive(Debug, Copy, Clone)]
enum CheckMessage {
    InputChecked(usize, bool),
}

impl Sandbox for CheckUi {
    type Message = CheckMessage;

    fn new() -> Self {
        Self {
            checks: (0..10).map(|_| false).collect(),
            ..Default::default()
        }
    }
    
    fn title(&self) -> String { "Dynamic checkbox label".into() }
    
    fn update(&mut self, message: Self::Message) {
        match message {
            CheckMessage::InputChecked(index, value) => self.checks[index] = value,
        }
    }

    fn view(&mut self) -> iced::Element<'_, Self::Message> {
        let mut inputs = Column::new()
            .height(iced::Length::Fill)
            .width(iced::Length::Fill)
            .align_items(Align::Start);

        for (index, checked) in self.checks.iter().enumerate() {
            inputs = inputs.push(
                iced::Checkbox::new(
                    *checked,
                    format!("Checkbox {}", index),
                    move |state| CheckMessage::InputChecked(index, state)
                )
                .width(iced::Length::Fill)
            );
        }

        inputs.into()
    }
}
```
