### PR TITLE
impl default for canvas cache

### DIFF
--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -29,7 +29,7 @@ impl Application for Clock {
         (
             Clock {
                 now: chrono::Local::now().into(),
-                clock: canvas::layer::Cache::new(),
+                clock: Default::default(),
             },
             Command::none(),
         )

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -39,7 +39,7 @@ impl Application for SolarSystem {
         (
             SolarSystem {
                 state: State::new(),
-                solar_system: canvas::layer::Cache::new(),
+                solar_system: Default::default(),
             },
             Command::none(),
         )

--- a/wgpu/src/widget/canvas/layer/cache.rs
+++ b/wgpu/src/widget/canvas/layer/cache.rs
@@ -6,6 +6,19 @@ use crate::{
 use iced_native::Size;
 use std::{cell::RefCell, marker::PhantomData, sync::Arc};
 
+enum State {
+    Empty,
+    Filled {
+        bounds: Size,
+        primitive: Arc<Primitive>,
+    },
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Empty
+    }
+}
 /// A simple cache that stores generated geometry to avoid recomputation.
 ///
 /// A [`Cache`] will not redraw its geometry unless the dimensions of its layer
@@ -19,12 +32,16 @@ pub struct Cache<T: Drawable> {
     state: RefCell<State>,
 }
 
-enum State {
-    Empty,
-    Filled {
-        bounds: Size,
-        primitive: Arc<Primitive>,
-    },
+impl<T> Default for Cache<T>
+where
+    T: Drawable,
+{
+    fn default() -> Self {
+        Self {
+            input: PhantomData,
+            state: Default::default(),
+        }
+    }
 }
 
 impl<T> Cache<T>
@@ -37,7 +54,7 @@ where
     pub fn new() -> Self {
         Cache {
             input: PhantomData,
-            state: RefCell::new(State::Empty),
+            state: Default::default(),
         }
     }
 


### PR DESCRIPTION
Previously needed to write the full Default implementation:

```rust
#[derive(Debug)]
pub struct AppState {
    all_data: State,
    current_frame_data: D,
    current_frame_canvas_cache: canvas::layer::Cache<D>,
}

impl Default for AppState {
    fn default() -> Self {
        Self {
            all_data: Default::default(),
            current_frame_data: Default::default(),
            current_frame_canvas_cache: iced::widget::canvas::layer::Cache::new(),
        }
    }
}
```

Now deriving a default application state is possible:
```rust
#[derive(Debug, Default)]
pub struct AppState {
    all_data: State,
    current_frame_data: D,
    current_frame_canvas_cache: canvas::layer::Cache<D>,
}
```