### PR TITLE
Update `wgpu` to `0.5` in `iced_wgpu`

### DIFF
--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -69,10 +69,12 @@ fn build_pipeline(
 
     let bind_group_layout =
         device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: None,
             bindings: &[],
         });
 
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
         layout: &bind_group_layout,
         bindings: &[],
     });
@@ -108,8 +110,10 @@ fn build_pipeline(
                 write_mask: wgpu::ColorWrite::ALL,
             }],
             depth_stencil_state: None,
-            index_format: wgpu::IndexFormat::Uint16,
-            vertex_buffers: &[],
+            vertex_state: wgpu::VertexStateDescriptor {
+                index_format: wgpu::IndexFormat::Uint16,
+                vertex_buffers: &[],
+            },
             sample_count: 1,
             sample_mask: !0,
             alpha_to_coverage_enabled: false,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -12,8 +12,9 @@ svg = ["resvg"]
 canvas = ["lyon"]
 
 [dependencies]
-wgpu = "0.4"
-wgpu_glyph = "0.7"
+wgpu = "0.5"
+wgpu_glyph = { version = "0.8", git = "https://github.com/hecrj/wgpu_glyph.git", branch = "update-wgpu" }
+zerocopy = "0.3"
 glyph_brush = "0.6"
 raw-window-handle = "0.3"
 glam = "0.8"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -13,7 +13,7 @@ canvas = ["lyon"]
 
 [dependencies]
 wgpu = "0.5"
-wgpu_glyph = { version = "0.8", git = "https://github.com/hecrj/wgpu_glyph.git", branch = "update-wgpu" }
+wgpu_glyph = "0.8"
 zerocopy = "0.3"
 glyph_brush = "0.6"
 raw-window-handle = "0.3"

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -2,6 +2,8 @@ use crate::image::atlas::{self, Atlas};
 use iced_native::svg;
 use std::collections::{HashMap, HashSet};
 
+use zerocopy::AsBytes;
+
 pub enum Svg {
     Loaded(resvg::usvg::Tree),
     NotFound,
@@ -117,7 +119,7 @@ impl Cache {
                 let allocation = texture_atlas.upload(
                     width,
                     height,
-                    canvas.get_data(),
+                    canvas.get_data().as_bytes(),
                     device,
                     encoder,
                 )?;

--- a/wgpu/src/transformation.rs
+++ b/wgpu/src/transformation.rs
@@ -16,9 +16,9 @@ impl Transformation {
     pub fn orthographic(width: u32, height: u32) -> Transformation {
         Transformation(Mat4::from_cols(
             Vec4::new(2.0 / width as f32, 0.0, 0.0, 0.0),
-            Vec4::new(0.0, 2.0 / height as f32, 0.0, 0.0),
+            Vec4::new(0.0, -2.0 / height as f32, 0.0, 0.0),
             Vec4::new(0.0, 0.0, -1.0, 0.0),
-            Vec4::new(-1.0, -1.0, 0.0, 1.0)
+            Vec4::new(-1.0, 1.0, 0.0, 1.0)
         ))
     }
 

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -25,20 +25,22 @@ impl Blit {
             mipmap_filter: wgpu::FilterMode::Linear,
             lod_min_clamp: -100.0,
             lod_max_clamp: 100.0,
-            compare_function: wgpu::CompareFunction::Always,
+            compare: wgpu::CompareFunction::Always,
         });
 
         let constant_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                bindings: &[wgpu::BindGroupLayoutBinding {
+                label: None,
+                bindings: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler,
+                    ty: wgpu::BindingType::Sampler { comparison: false },
                 }],
             });
 
         let constant_bind_group =
             device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
                 layout: &constant_layout,
                 bindings: &[wgpu::Binding {
                     binding: 0,
@@ -48,12 +50,14 @@ impl Blit {
 
         let texture_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                bindings: &[wgpu::BindGroupLayoutBinding {
+                label: None,
+                bindings: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture {
-                        multisampled: false,
                         dimension: wgpu::TextureViewDimension::D2,
+                        component_type: wgpu::TextureComponentType::Float,
+                        multisampled: false,
                     },
                 }],
             });
@@ -109,8 +113,10 @@ impl Blit {
                     write_mask: wgpu::ColorWrite::ALL,
                 }],
                 depth_stencil_state: None,
-                index_format: wgpu::IndexFormat::Uint16,
-                vertex_buffers: &[],
+                vertex_state: wgpu::VertexStateDescriptor {
+                    index_format: wgpu::IndexFormat::Uint16,
+                    vertex_buffers: &[],
+                },
                 sample_count: 1,
                 sample_mask: !0,
                 alpha_to_coverage_enabled: false,
@@ -222,6 +228,7 @@ impl Targets {
         };
 
         let attachment = device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
             size: extent,
             array_layer_count: 1,
             mip_level_count: 1,
@@ -232,6 +239,7 @@ impl Targets {
         });
 
         let resolve = device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
             size: extent,
             array_layer_count: 1,
             mip_level_count: 1,
@@ -246,6 +254,7 @@ impl Targets {
         let resolve = resolve.create_default_view();
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
             layout: texture_layout,
             bindings: &[wgpu::Binding {
                 binding: 0,

--- a/wgpu/src/widget/canvas/frame.rs
+++ b/wgpu/src/widget/canvas/frame.rs
@@ -244,7 +244,7 @@ impl Frame {
             .transforms
             .current
             .raw
-            .pre_rotate(lyon::math::Angle::radians(-angle));
+            .pre_rotate(lyon::math::Angle::radians(angle));
         self.transforms.current.is_identity = false;
     }
 

--- a/wgpu/src/window/swap_chain.rs
+++ b/wgpu/src/window/swap_chain.rs
@@ -32,8 +32,12 @@ impl SwapChain {
     ///
     /// [`SwapChain`]: struct.SwapChain.html
     /// [`Viewport`]: ../struct.Viewport.html
-    pub fn next_frame(&mut self) -> (wgpu::SwapChainOutput<'_>, &Viewport) {
-        (self.raw.get_next_texture(), &self.viewport)
+    pub fn next_frame(
+        &mut self,
+    ) -> Result<(wgpu::SwapChainOutput, &Viewport), wgpu::TimeOut> {
+        let viewport = &self.viewport;
+
+        self.raw.get_next_texture().map(|output| (output, viewport))
     }
 }
 
@@ -51,7 +55,7 @@ fn new_swap_chain(
             format,
             width,
             height,
-            present_mode: wgpu::PresentMode::Vsync,
+            present_mode: wgpu::PresentMode::Mailbox,
         },
     )
 }


### PR DESCRIPTION
This PR updates [`wgpu`] in [`iced_wgpu`] to [the latest release](https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#v05-06-04-2020).

The most notable changes are:

- Obtaining an adapter, device, and queue now leverages async/await.
- The Y-axis in NDC space was flipped.
- The [`zerocopy`] dependency is now explicit.

[`wgpu`]: https://github.com/gfx-rs/wgpu-rs
[`iced_wgpu`]: https://github.com/hecrj/iced/tree/master/wgpu
[`zerocopy`]: https://crates.io/crates/zerocopy