### PR TITLE
Stop generating empty `Mesh2D` in `canvas::Frame`

### DIFF
--- a/wgpu/src/widget/canvas/frame.rs
+++ b/wgpu/src/widget/canvas/frame.rs
@@ -262,13 +262,15 @@ impl Frame {
     ///
     /// [`Frame`]: struct.Frame.html
     pub fn into_primitive(mut self) -> Primitive {
-        self.primitives.push(Primitive::Mesh2D {
-            origin: Point::ORIGIN,
-            buffers: triangle::Mesh2D {
-                vertices: self.buffers.vertices,
-                indices: self.buffers.indices,
-            },
-        });
+        if !self.buffers.indices.is_empty() {
+            self.primitives.push(Primitive::Mesh2D {
+                origin: Point::ORIGIN,
+                buffers: triangle::Mesh2D {
+                    vertices: self.buffers.vertices,
+                    indices: self.buffers.indices,
+                },
+            });
+        }
 
         Primitive::Group {
             primitives: self.primitives,


### PR DESCRIPTION
This PR stops producing an empty `Primitive::Mesh2D` in `Frame::into_primitive` when nothing is tessellated by `lyon`. This could lead to crashes in some graphics drivers.