### PR TITLE
Fix `text_input::Renderer` implementation in `iced_wgpu`

### DIFF
--- a/wgpu/src/renderer/widget/text_input.rs
+++ b/wgpu/src/renderer/widget/text_input.rs
@@ -210,10 +210,20 @@ impl text_input::Renderer for Renderer {
             (text_value, Vector::new(0, 0))
         };
 
-        let contents = Primitive::Clip {
-            bounds: text_bounds,
-            offset,
-            content: Box::new(contents_primitive),
+        let text_width = self.measure_value(
+            if text.is_empty() { placeholder } else { &text },
+            size,
+            font,
+        );
+
+        let contents = if text_width > text_bounds.width {
+            Primitive::Clip {
+                bounds: text_bounds,
+                offset,
+                content: Box::new(contents_primitive),
+            }
+        } else {
+            contents_primitive
         };
 
         (

--- a/wgpu/src/renderer/widget/text_input.rs
+++ b/wgpu/src/renderer/widget/text_input.rs
@@ -23,11 +23,11 @@ impl text_input::Renderer for Renderer {
             Size::INFINITY,
         );
 
-        let spaces_at_the_end = value.len() - value.trim_end().len();
+        let spaces_around = value.len() - value.trim().len();
 
-        if spaces_at_the_end > 0 {
+        if spaces_around > 0 {
             let space_width = self.text_pipeline.space_width(size as f32);
-            width += spaces_at_the_end as f32 * space_width;
+            width += spaces_around as f32 * space_width;
         }
 
         width


### PR DESCRIPTION
This PR fixes and improves the `text_input::Renderer` implementation in `iced_wgpu`. Specifically:

- It fixes the `measure_value` implementation, which was incorrectly measuring text when spaces were present at the start.
- It makes the `draw` implementation only produce a `Clip` primitive when the text value overflows the input. This should improve performance, as `Clip` primitives are currently _very_ expensive.