### PR TITLE
Add support for setting window icon

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@
 use crate::window;
 
 /// The settings of an application.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Settings<Flags> {
     /// The window settings.
     ///

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@
 use crate::window;
 
 /// The settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Settings<Flags> {
     /// The window settings.
     ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,5 +2,8 @@
 mod mode;
 mod settings;
 
+pub mod icon;
+
+pub use icon::Icon;
 pub use mode::Mode;
 pub use settings::Settings;

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -1,0 +1,132 @@
+//! Attach an icon to the window of your application.
+use std::fmt;
+use std::io;
+
+/// The icon of a window.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct Icon(iced_winit::winit::window::Icon);
+
+/// The icon of a window.
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+pub struct Icon;
+
+impl Icon {
+    /// Creates an icon from 32bpp RGBA data.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_rgba(
+        rgba: Vec<u8>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, Error> {
+        let raw =
+            iced_winit::winit::window::Icon::from_rgba(rgba, width, height)?;
+
+        Ok(Icon(raw))
+    }
+
+    /// Creates an icon from 32bpp RGBA data.
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_rgba(
+        _rgba: Vec<u8>,
+        _width: u32,
+        _height: u32,
+    ) -> Result<Self, Error> {
+        Ok(Icon)
+    }
+}
+
+/// An error produced when using `Icon::from_rgba` with invalid arguments.
+#[derive(Debug)]
+pub enum Error {
+    /// The provided RGBA data isn't divisble by 4.
+    ///
+    /// Therefore, it cannot be safely interpreted as 32bpp RGBA pixels.
+    InvalidData {
+        /// The length of the provided RGBA data.
+        byte_count: usize,
+    },
+
+    /// The number of RGBA pixels does not match the provided dimensions.
+    DimensionsMismatch {
+        /// The provided width.
+        width: u32,
+        /// The provided height.
+        height: u32,
+        /// The amount of pixels of the provided RGBA data.
+        pixel_count: usize,
+    },
+
+    /// The underlying OS failed to create the icon.
+    OsError(io::Error),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<iced_winit::winit::window::BadIcon> for Error {
+    fn from(error: iced_winit::winit::window::BadIcon) -> Self {
+        use iced_winit::winit::window::BadIcon;
+
+        match error {
+            BadIcon::ByteCountNotDivisibleBy4 { byte_count } => {
+                Error::InvalidData { byte_count }
+            }
+            BadIcon::DimensionsVsPixelCount {
+                width,
+                height,
+                pixel_count,
+                ..
+            } => Error::DimensionsMismatch {
+                width,
+                height,
+                pixel_count,
+            },
+            BadIcon::OsError(os_error) => Error::OsError(os_error),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<Icon> for iced_winit::winit::window::Icon {
+    fn from(icon: Icon) -> Self {
+        icon.0
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidData { byte_count } => {
+                write!(f,
+                "The provided RGBA data (with length {:?}) isn't divisble by \
+                4. Therefore, it cannot be safely interpreted as 32bpp RGBA \
+                pixels.",
+                byte_count,
+            )
+            }
+            Error::DimensionsMismatch {
+                width,
+                height,
+                pixel_count,
+            } => {
+                write!(f,
+                "The number of RGBA pixels ({:?}) does not match the provided \
+                dimensions ({:?}x{:?}).",
+                width, height, pixel_count,
+            )
+            }
+            Error::OsError(e) => write!(
+                f,
+                "The underlying OS failed to create the window \
+                icon: {:?}",
+                e
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self)
+    }
+}

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,5 +1,5 @@
 /// The window settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Settings {
     /// The initial size of the window.
     pub size: (u32, u32),
@@ -15,6 +15,9 @@ pub struct Settings {
 
     /// Whether the window should have a border, a title bar, etc. or not.
     pub decorations: bool,
+
+    /// The window icon, which is also usually used in the taskbar
+    pub icon: Option<iced_winit::settings::Icon>,
 }
 
 impl Default for Settings {
@@ -25,6 +28,7 @@ impl Default for Settings {
             max_size: None,
             resizable: true,
             decorations: true,
+            icon: None,
         }
     }
 }
@@ -38,6 +42,7 @@ impl From<Settings> for iced_winit::settings::Window {
             max_size: settings.max_size,
             resizable: settings.resizable,
             decorations: settings.decorations,
+            icon: settings.icon,
             platform_specific: Default::default(),
         }
     }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,5 +1,7 @@
+use crate::window::Icon;
+
 /// The window settings of an application.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// The initial size of the window.
     pub size: (u32, u32),
@@ -16,8 +18,8 @@ pub struct Settings {
     /// Whether the window should have a border, a title bar, etc. or not.
     pub decorations: bool,
 
-    /// The window icon, which is also usually used in the taskbar
-    pub icon: Option<iced_winit::settings::Icon>,
+    /// The icon of the window.
+    pub icon: Option<Icon>,
 }
 
 impl Default for Settings {
@@ -42,7 +44,7 @@ impl From<Settings> for iced_winit::settings::Window {
             max_size: settings.max_size,
             resizable: settings.resizable,
             decorations: settings.decorations,
-            icon: settings.icon,
+            icon: settings.icon.map(Icon::into),
             platform_specific: Default::default(),
         }
     }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -38,5 +38,6 @@ pub use clipboard::Clipboard;
 pub use mode::Mode;
 pub use proxy::Proxy;
 pub use settings::Settings;
+pub use settings::Icon;
 
 pub use iced_graphics::Viewport;

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -38,6 +38,5 @@ pub use clipboard::Clipboard;
 pub use mode::Mode;
 pub use proxy::Proxy;
 pub use settings::Settings;
-pub use settings::Icon;
 
 pub use iced_graphics::Viewport;

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -14,7 +14,7 @@ use winit::monitor::MonitorHandle;
 use winit::window::WindowBuilder;
 
 /// The settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Settings<Flags> {
     /// The [`Window`] settings
     ///
@@ -28,7 +28,7 @@ pub struct Settings<Flags> {
 }
 
 /// The window settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Window {
     /// The size of the window.
     pub size: (u32, u32),
@@ -44,6 +44,9 @@ pub struct Window {
 
     /// Whether the window should have a border, a title bar, etc.
     pub decorations: bool,
+
+    /// The window icon, which is also usually used in the taskbar
+    pub icon: Option<Icon>,
 
     /// Platform specific settings.
     pub platform_specific: platform::PlatformSpecific,
@@ -66,6 +69,7 @@ impl Window {
             .with_inner_size(winit::dpi::LogicalSize { width, height })
             .with_resizable(self.resizable)
             .with_decorations(self.decorations)
+            .with_window_icon(self.icon.map(Icon::into))
             .with_fullscreen(conversion::fullscreen(primary_monitor, mode));
 
         if let Some((width, height)) = self.min_size {
@@ -99,7 +103,38 @@ impl Default for Window {
             max_size: None,
             resizable: true,
             decorations: true,
+            icon: None,
             platform_specific: Default::default(),
         }
+    }
+}
+
+/// An Icon
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Icon {
+    rgba: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+impl Icon {
+    ///
+    pub fn new(rgba: &[u8], width: u32, height: u32) -> Self {
+        Self {
+            rgba: rgba.to_vec(),
+            width,
+            height,
+        }
+    }
+}
+
+impl Into<winit::window::Icon> for Icon {
+    fn into(self) -> winit::window::Icon {
+        winit::window::Icon::from_rgba(
+            self.rgba.to_vec(),
+            self.width,
+            self.height,
+        )
+        .unwrap()
     }
 }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -14,7 +14,7 @@ use winit::monitor::MonitorHandle;
 use winit::window::WindowBuilder;
 
 /// The settings of an application.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Settings<Flags> {
     /// The [`Window`] settings
     ///
@@ -28,7 +28,7 @@ pub struct Settings<Flags> {
 }
 
 /// The window settings of an application.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Window {
     /// The size of the window.
     pub size: (u32, u32),
@@ -46,7 +46,7 @@ pub struct Window {
     pub decorations: bool,
 
     /// The window icon, which is also usually used in the taskbar
-    pub icon: Option<Icon>,
+    pub icon: Option<winit::window::Icon>,
 
     /// Platform specific settings.
     pub platform_specific: platform::PlatformSpecific,
@@ -69,7 +69,7 @@ impl Window {
             .with_inner_size(winit::dpi::LogicalSize { width, height })
             .with_resizable(self.resizable)
             .with_decorations(self.decorations)
-            .with_window_icon(self.icon.map(Icon::into))
+            .with_window_icon(self.icon)
             .with_fullscreen(conversion::fullscreen(primary_monitor, mode));
 
         if let Some((width, height)) = self.min_size {
@@ -106,35 +106,5 @@ impl Default for Window {
             icon: None,
             platform_specific: Default::default(),
         }
-    }
-}
-
-/// An Icon
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Icon {
-    rgba: Vec<u8>,
-    width: u32,
-    height: u32,
-}
-
-impl Icon {
-    ///
-    pub fn new(rgba: &[u8], width: u32, height: u32) -> Self {
-        Self {
-            rgba: rgba.to_vec(),
-            width,
-            height,
-        }
-    }
-}
-
-impl Into<winit::window::Icon> for Icon {
-    fn into(self) -> winit::window::Icon {
-        winit::window::Icon::from_rgba(
-            self.rgba.to_vec(),
-            self.width,
-            self.height,
-        )
-        .unwrap()
     }
 }


### PR DESCRIPTION
This PR is just to start the discussion around this topic, the code is currently a hack, the naming is not final and I just added it somewhere, not even in the right place. But since this is my first contribution to the library and my experience with Rust is not extensive, I would like if somebody more experienced can have a look an tell me if I'm on the right track. 

This adds a new property from `Settings::window::icon` and an `Icon` struct which can be converted to `winit::window::Icon`.

It also adds code to display this icon in `Application::run`.

Due to the fact that the Icon struct cannot be copied, I had to remove the Copy trait from all Settings,
both in `iced` and `iced_winit`. This is an API breaking change.

Currently, I'm able to set an icon with the code:
![image](https://user-images.githubusercontent.com/1306195/79044946-a0592200-7c08-11ea-9c6f-1194aa2c249b.png)
 
Thanks to `winit` it gets correctly displayed also on the taskbar:
![image](https://user-images.githubusercontent.com/1306195/79044967-be268700-7c08-11ea-8cd7-7fda3553f8fa.png)

And of course in the window switcher (alt+tab).

Fixes #433.
