### PR TITLE
Remove unnecessary 'static lifetimes on `Renderer` traits

### DIFF
--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -234,8 +234,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct ButtonWidget;
-        std::any::TypeId::of::<ButtonWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.content.hash_layout(state);

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -143,7 +143,7 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Button<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
     Message: Clone,
 {
     fn width(&self) -> Length {
@@ -234,7 +234,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Button<'_, (), Renderer>>().hash(state);
+        struct ButtonWidget;
+        std::any::TypeId::of::<ButtonWidget>().hash(state);
 
         self.width.hash(state);
         self.content.hash_layout(state);
@@ -276,7 +277,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<Button<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a + Clone,
 {
     fn from(

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -205,8 +205,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct CheckboxWidget;
-        std::any::TypeId::of::<CheckboxWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.label.hash(state);
     }

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -110,7 +110,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
 impl<Message, Renderer> Widget<Message, Renderer>
     for Checkbox<Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + text::Renderer + row::Renderer,
+    Renderer: self::Renderer + text::Renderer + row::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -205,7 +205,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Checkbox<(), Renderer>>().hash(state);
+        struct CheckboxWidget;
+        std::any::TypeId::of::<CheckboxWidget>().hash(state);
 
         self.label.hash(state);
     }
@@ -254,7 +255,7 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<Checkbox<Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + text::Renderer + row::Renderer,
+    Renderer: 'a + self::Renderer + text::Renderer + row::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -124,7 +124,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Column<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -190,7 +190,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Column<'_, (), Renderer>>().hash(state);
+        struct ColumnWidget;
+        std::any::TypeId::of::<ColumnWidget>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);
@@ -234,7 +235,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<Column<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -190,8 +190,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct ColumnWidget;
-        std::any::TypeId::of::<ColumnWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -203,8 +203,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct ContainerWidget;
-        std::any::TypeId::of::<ContainerWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.padding.hash(state);
         self.width.hash(state);

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -132,7 +132,7 @@ where
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Container<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -203,7 +203,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Container<'_, (), Renderer>>().hash(state);
+        struct ContainerWidget;
+        std::any::TypeId::of::<ContainerWidget>().hash(state);
 
         self.padding.hash(state);
         self.width.hash(state);
@@ -243,7 +244,7 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<Container<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -102,7 +102,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Image>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.handle.hash(state);
         self.width.hash(state);

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -597,8 +597,8 @@ where
 
     fn hash_layout(&self, state: &mut Hasher) {
         use std::hash::Hash;
-        struct PaneGridWidget;
-        std::any::TypeId::of::<PaneGridWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -356,7 +356,7 @@ pub struct KeyPressEvent {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for PaneGrid<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -597,8 +597,9 @@ where
 
     fn hash_layout(&self, state: &mut Hasher) {
         use std::hash::Hash;
+        struct PaneGridWidget;
+        std::any::TypeId::of::<PaneGridWidget>().hash(state);
 
-        std::any::TypeId::of::<PaneGrid<'_, (), Renderer>>().hash(state);
         self.width.hash(state);
         self.height.hash(state);
         self.state.hash_layout(state);
@@ -643,7 +644,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<PaneGrid<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -114,8 +114,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct ProgressBarWidget;
-        std::any::TypeId::of::<ProgressBarWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -72,7 +72,7 @@ impl<Renderer: self::Renderer> ProgressBar<Renderer> {
 
 impl<Message, Renderer> Widget<Message, Renderer> for ProgressBar<Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -114,7 +114,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<ProgressBar<Renderer>>().hash(state);
+        struct ProgressBarWidget;
+        std::any::TypeId::of::<ProgressBarWidget>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);
@@ -159,7 +160,7 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<ProgressBar<Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -82,7 +82,7 @@ impl<Message, Renderer: self::Renderer> Radio<Message, Renderer> {
 
 impl<Message, Renderer> Widget<Message, Renderer> for Radio<Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + text::Renderer + row::Renderer,
+    Renderer: self::Renderer + text::Renderer + row::Renderer,
     Message: Clone,
 {
     fn width(&self) -> Length {
@@ -174,7 +174,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Radio<(), Renderer>>().hash(state);
+        struct RadioWidget;
+        std::any::TypeId::of::<RadioWidget>().hash(state);
 
         self.label.hash(state);
     }
@@ -218,7 +219,7 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<Radio<Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + row::Renderer + text::Renderer,
+    Renderer: 'a + self::Renderer + row::Renderer + text::Renderer,
     Message: 'a + Clone,
 {
     fn from(radio: Radio<Message, Renderer>) -> Element<'a, Message, Renderer> {

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -174,8 +174,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct RadioWidget;
-        std::any::TypeId::of::<RadioWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.label.hash(state);
     }

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -125,7 +125,7 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Row<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -191,7 +191,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Row<'_, (), Renderer>>().hash(state);
+        struct RowWidget;
+        std::any::TypeId::of::<RowWidget>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);
@@ -236,7 +237,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<Row<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(row: Row<'a, Message, Renderer>) -> Element<'a, Message, Renderer> {

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -191,8 +191,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct RowWidget;
-        std::any::TypeId::of::<RowWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.height.hash(state);

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -115,7 +115,7 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Scrollable<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + column::Renderer,
+    Renderer: self::Renderer + column::Renderer,
 {
     fn width(&self) -> Length {
         Widget::<Message, Renderer>::width(&self.content)
@@ -311,7 +311,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Scrollable<'_, (), Renderer>>().hash(state);
+        struct ScrollableWidget;
+        std::any::TypeId::of::<ScrollableWidget>().hash(state);
 
         self.height.hash(state);
         self.max_height.hash(state);
@@ -505,7 +506,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<Scrollable<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer + column::Renderer,
+    Renderer: 'a + self::Renderer + column::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -311,8 +311,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct ScrollableWidget;
-        std::any::TypeId::of::<ScrollableWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.height.hash(state);
         self.max_height.hash(state);

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -205,8 +205,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        struct SliderWidget;
-        std::any::TypeId::of::<SliderWidget>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
     }

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -114,7 +114,7 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Slider<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -205,7 +205,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Slider<'_, (), Renderer>>().hash(state);
+        struct SliderWidget;
+        std::any::TypeId::of::<SliderWidget>().hash(state);
 
         self.width.hash(state);
     }
@@ -253,7 +254,7 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<Slider<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a,
 {
     fn from(

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -526,8 +526,8 @@ where
 
     fn hash_layout(&self, state: &mut Hasher) {
         use std::{any::TypeId, hash::Hash};
-        struct TextInputWidget;
-        TypeId::of::<TextInputWidget>().hash(state);
+        struct Marker;
+        TypeId::of::<Marker>().hash(state);
 
         self.width.hash(state);
         self.max_width.hash(state);

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -171,7 +171,7 @@ impl<'a, Message, Renderer: self::Renderer> TextInput<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for TextInput<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: self::Renderer,
     Message: Clone,
 {
     fn width(&self) -> Length {
@@ -526,8 +526,8 @@ where
 
     fn hash_layout(&self, state: &mut Hasher) {
         use std::{any::TypeId, hash::Hash};
-
-        TypeId::of::<TextInput<'_, (), Renderer>>().hash(state);
+        struct TextInputWidget;
+        TypeId::of::<TextInputWidget>().hash(state);
 
         self.width.hash(state);
         self.max_width.hash(state);
@@ -632,7 +632,7 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<TextInput<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'static + self::Renderer,
+    Renderer: 'a + self::Renderer,
     Message: 'a + Clone,
 {
     fn from(


### PR DESCRIPTION
Fixes #288 .

Removes 'static lifetime bound on Renderer implementors by defining marker types where applicable.

Thanks a lot for your reactivity on this issue :)