### PR TITLE
fix progress bar docs to no longer mention buttons

### DIFF
--- a/wgpu/src/widget/progress_bar.rs
+++ b/wgpu/src/widget/progress_bar.rs
@@ -1,9 +1,9 @@
-//! Allow your users to perform actions by pressing a button.
+//! Allow your users to visually track the progress of a computation.
 //!
-//! A [`Button`] has some local [`State`].
+//! A [`ProgressBar`] has a range of possible values and a current value,
+//! as well as a length, height and style.
 //!
-//! [`Button`]: type.Button.html
-//! [`State`]: struct.State.html
+//! [`ProgressBar`]: type.ProgressBar.html
 use crate::Renderer;
 
 pub use iced_style::progress_bar::{Style, StyleSheet};


### PR DESCRIPTION
When reading the rustdocs for the progress bar widget I noticed that they seemed to be copy-pasted from the button widget, so I took a crack at fixing them. Let me know if you want any phrasing tweaks.