### PR TITLE
Add `children_size()` method for `Row`, `Column` and `Scrollable`

### DIFF
--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -119,6 +119,13 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         self.children.push(child.into());
         self
     }
+
+    /// Gets the children size of the [`Column`].
+    ///
+    /// [`Column`]: struct.Column.html
+    pub fn children_size(&self) -> usize {
+        self.children.len()
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -120,6 +120,13 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         self.children.push(child.into());
         self
     }
+
+    /// Gets the children size of the [`Row`].
+    ///
+    /// [`Row`]: struct.Row.html
+    pub fn children_size(&self) -> usize {
+        self.children.len()
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -110,6 +110,13 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
         self.content = self.content.push(child);
         self
     }
+
+    /// Gets the children size of the [`Scrollable`].
+    ///
+    /// [`Scrollable`]: struct.Scrollable.html
+    pub fn children_size(&self) -> usize {
+        self.content.children_size()
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>


### PR DESCRIPTION
The end-user cannot access the children's size of `Row`, `Column`, and `Scrollable` widget as the `children` field is private. So I think adding this method should idea to fix this.