### PR TITLE
Make `Font` an associated type of `text::Renderer`

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -16,3 +16,9 @@ pub enum Font {
         bytes: &'static [u8],
     },
 }
+
+impl Default for Font {
+    fn default() -> Font {
+        Font::Default
+    }
+}

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -81,7 +81,7 @@ where
     ///
     /// ```
     /// # mod counter {
-    /// #     use iced_native::{text, Text};
+    /// #     type Text = iced_native::Text<iced_native::renderer::Null>;
     /// #
     /// #     #[derive(Debug, Clone, Copy)]
     /// #     pub enum Message {}

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -47,6 +47,8 @@ impl row::Renderer for Null {
 }
 
 impl text::Renderer for Null {
+    type Font = Font;
+
     const DEFAULT_SIZE: u16 = 20;
 
     fn measure(

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 
 use crate::{
     input::{mouse, ButtonState},
-    layout, row, text, Align, Clipboard, Element, Event, Font, Hasher,
+    layout, row, text, Align, Clipboard, Element, Event, Hasher,
     HorizontalAlignment, Layout, Length, Point, Rectangle, Row, Text,
     VerticalAlignment, Widget,
 };
@@ -186,7 +186,7 @@ where
             label_layout.bounds(),
             &self.label,
             self.text_size,
-            Font::Default,
+            Default::default(),
             None,
             HorizontalAlignment::Left,
             VerticalAlignment::Center,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -1,7 +1,7 @@
 //! Create choices using radio buttons.
 use crate::{
     input::{mouse, ButtonState},
-    layout, row, text, Align, Clipboard, Element, Event, Font, Hasher,
+    layout, row, text, Align, Clipboard, Element, Event, Hasher,
     HorizontalAlignment, Layout, Length, Point, Rectangle, Row, Text,
     VerticalAlignment, Widget,
 };
@@ -155,7 +155,7 @@ where
             label_layout.bounds(),
             &self.label,
             <Renderer as text::Renderer>::DEFAULT_SIZE,
-            Font::Default,
+            Default::default(),
             None,
             HorizontalAlignment::Left,
             VerticalAlignment::Center,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -1,7 +1,7 @@
 //! Write some text for your users to read.
 use crate::{
-    layout, Color, Element, Font, Hasher, HorizontalAlignment, Layout, Length,
-    Point, Rectangle, Size, VerticalAlignment, Widget,
+    layout, Color, Element, Hasher, HorizontalAlignment, Layout, Length, Point,
+    Rectangle, Size, VerticalAlignment, Widget,
 };
 
 use std::hash::Hash;
@@ -11,7 +11,7 @@ use std::hash::Hash;
 /// # Example
 ///
 /// ```
-/// # use iced_native::Text;
+/// # type Text = iced_native::Text<iced_native::renderer::Null>;
 /// #
 /// Text::new("I <3 iced!")
 ///     .color([0.0, 0.0, 1.0])
@@ -20,18 +20,18 @@ use std::hash::Hash;
 ///
 /// ![Text drawn by `iced_wgpu`](https://github.com/hecrj/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/text.png?raw=true)
 #[derive(Debug, Clone)]
-pub struct Text {
+pub struct Text<Renderer: self::Renderer> {
     content: String,
     size: Option<u16>,
     color: Option<Color>,
-    font: Font,
+    font: Renderer::Font,
     width: Length,
     height: Length,
     horizontal_alignment: HorizontalAlignment,
     vertical_alignment: VerticalAlignment,
 }
 
-impl Text {
+impl<Renderer: self::Renderer> Text<Renderer> {
     /// Create a new fragment of [`Text`] with the given contents.
     ///
     /// [`Text`]: struct.Text.html
@@ -40,7 +40,7 @@ impl Text {
             content: label.into(),
             size: None,
             color: None,
-            font: Font::Default,
+            font: Default::default(),
             width: Length::Shrink,
             height: Length::Shrink,
             horizontal_alignment: HorizontalAlignment::Left,
@@ -69,8 +69,8 @@ impl Text {
     ///
     /// [`Text`]: struct.Text.html
     /// [`Font`]: ../../struct.Font.html
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = font;
+    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+        self.font = font.into();
         self
     }
 
@@ -112,7 +112,7 @@ impl Text {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Text
+impl<Message, Renderer> Widget<Message, Renderer> for Text<Renderer>
 where
     Renderer: self::Renderer,
 {
@@ -163,7 +163,8 @@ where
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
-        std::any::TypeId::of::<Text>().hash(state);
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
 
         self.content.hash(state);
         self.size.hash(state);
@@ -181,6 +182,11 @@ where
 /// [renderer]: ../../renderer/index.html
 /// [`UserInterface`]: ../../struct.UserInterface.html
 pub trait Renderer: crate::Renderer {
+    /// The font type used for [`Text`].
+    ///
+    /// [`Text`]: struct.Text.html
+    type Font: Default + Copy;
+
     /// The default size of [`Text`].
     ///
     /// [`Text`]: struct.Text.html
@@ -194,7 +200,7 @@ pub trait Renderer: crate::Renderer {
         &self,
         content: &str,
         size: u16,
-        font: Font,
+        font: Self::Font,
         bounds: Size,
     ) -> (f32, f32);
 
@@ -217,18 +223,19 @@ pub trait Renderer: crate::Renderer {
         bounds: Rectangle,
         content: &str,
         size: u16,
-        font: Font,
+        font: Self::Font,
         color: Option<Color>,
         horizontal_alignment: HorizontalAlignment,
         vertical_alignment: VerticalAlignment,
     ) -> Self::Output;
 }
 
-impl<'a, Message, Renderer> From<Text> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<Text<Renderer>>
+    for Element<'a, Message, Renderer>
 where
-    Renderer: self::Renderer,
+    Renderer: self::Renderer + 'a,
 {
-    fn from(text: Text) -> Element<'a, Message, Renderer> {
+    fn from(text: Text<Renderer>) -> Element<'a, Message, Renderer> {
         Element::new(text)
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -20,7 +20,7 @@
 mod platform {
     pub use iced_wgpu::widget::{
         button, checkbox, container, pane_grid, progress_bar, radio,
-        scrollable, slider, text_input,
+        scrollable, slider, text_input, Text,
     };
 
     #[cfg(feature = "canvas")]
@@ -39,7 +39,7 @@ mod platform {
         pub use iced_winit::svg::{Handle, Svg};
     }
 
-    pub use iced_winit::{Space, Text};
+    pub use iced_winit::Space;
 
     #[doc(no_inline)]
     pub use {

--- a/wgpu/src/renderer/widget/text.rs
+++ b/wgpu/src/renderer/widget/text.rs
@@ -7,6 +7,8 @@ use iced_native::{
 use std::f32;
 
 impl text::Renderer for Renderer {
+    type Font = Font;
+
     const DEFAULT_SIZE: u16 = 20;
 
     fn measure(

--- a/wgpu/src/widget.rs
+++ b/wgpu/src/widget.rs
@@ -17,6 +17,8 @@ pub mod scrollable;
 pub mod slider;
 pub mod text_input;
 
+mod text;
+
 #[doc(no_inline)]
 pub use button::Button;
 #[doc(no_inline)]
@@ -35,6 +37,8 @@ pub use scrollable::Scrollable;
 pub use slider::Slider;
 #[doc(no_inline)]
 pub use text_input::TextInput;
+
+pub use text::Text;
 
 #[cfg(feature = "canvas")]
 #[cfg_attr(docsrs, doc(cfg(feature = "canvas")))]

--- a/wgpu/src/widget/text.rs
+++ b/wgpu/src/widget/text.rs
@@ -1,0 +1,7 @@
+//! Write some text for your users to read.
+use crate::Renderer;
+
+/// A paragraph of text.
+///
+/// This is an alias of an `iced_native` text with an `iced_wgpu::Renderer`.
+pub type Text = iced_native::Text<Renderer>;


### PR DESCRIPTION
This PR makes the `Font` type used in `Text` generic. Therefore, the `text::Renderer` can choose to implement a new font type if necessary.

This can be useful if you are building a custom renderer. This change was discussed in [a thread on the Zulip server](https://iced.zulipchat.com/#narrow/stream/213316-general/topic/Font.20type).