### PR TITLE
Add `ImagePane` widget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
       run: cargo check --package iced --target wasm32-unknown-unknown
     - name: Check compilation of `tour` example
       run: cargo build --package tour --target wasm32-unknown-unknown
-    - name: Check compilation of `pokedex` example
-      run: cargo build --package pokedex --target wasm32-unknown-unknown
+    - name: Check compilation of `todos` example
+      run: cargo build --package todos --target wasm32-unknown-unknown

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -1,6 +1,6 @@
 use iced::{
     button, futures, image, Align, Application, Button, Column, Command,
-    Container, Element, Image, Length, Row, Settings, Text,
+    Container, Element, Length, Row, Settings, Text,
 };
 
 pub fn main() -> iced::Result {
@@ -112,16 +112,20 @@ struct Pokemon {
     name: String,
     description: String,
     image: image::Handle,
+    image_viewer: image::viewer::State,
 }
 
 impl Pokemon {
     const TOTAL: u16 = 807;
 
-    fn view(&self) -> Element<Message> {
+    fn view(&mut self) -> Element<Message> {
         Row::new()
             .spacing(20)
             .align_items(Align::Center)
-            .push(Image::new(self.image.clone()))
+            .push(image::Viewer::new(
+                &mut self.image_viewer,
+                self.image.clone(),
+            ))
             .push(
                 Column::new()
                     .spacing(20)
@@ -200,6 +204,7 @@ impl Pokemon {
                 .map(|c| if c.is_control() { ' ' } else { c })
                 .collect(),
             image,
+            image_viewer: image::viewer::State::new(),
         })
     }
 

--- a/graphics/src/widget/image.rs
+++ b/graphics/src/widget/image.rs
@@ -1,11 +1,14 @@
 //! Display images in your user interface.
+pub mod viewer;
+
 use crate::backend::{self, Backend};
+
 use crate::{Primitive, Renderer};
 use iced_native::image;
 use iced_native::mouse;
 use iced_native::Layout;
 
-pub use iced_native::image::{Handle, Image};
+pub use iced_native::image::{Handle, Image, Viewer};
 
 impl<B> image::Renderer for Renderer<B>
 where

--- a/graphics/src/widget/image/viewer.rs
+++ b/graphics/src/widget/image/viewer.rs
@@ -1,0 +1,51 @@
+//! Zoom and pan on an image.
+use crate::backend::{self, Backend};
+use crate::{Primitive, Renderer};
+
+use iced_native::{
+    image::{self, viewer},
+    mouse, Rectangle, Vector,
+};
+
+impl<B> viewer::Renderer for Renderer<B>
+where
+    B: Backend + backend::Image,
+{
+    fn draw(
+        &mut self,
+        state: &viewer::State,
+        bounds: Rectangle,
+        image_bounds: Rectangle,
+        translation: Vector,
+        handle: image::Handle,
+        is_mouse_over: bool,
+    ) -> Self::Output {
+        (
+            {
+                Primitive::Clip {
+                    bounds,
+                    content: Box::new(Primitive::Translate {
+                        translation,
+                        content: Box::new(Primitive::Image {
+                            handle,
+                            bounds: image_bounds,
+                        }),
+                    }),
+                    offset: Vector::new(0, 0),
+                }
+            },
+            {
+                if state.is_cursor_clicked() {
+                    mouse::Interaction::Grabbing
+                } else if is_mouse_over
+                    && (image_bounds.width > bounds.width
+                        || image_bounds.height > bounds.height)
+                {
+                    mouse::Interaction::Grab
+                } else {
+                    mouse::Interaction::Idle
+                }
+            },
+        )
+    }
+}

--- a/graphics/src/widget/image/viewer.rs
+++ b/graphics/src/widget/image/viewer.rs
@@ -5,7 +5,7 @@ use crate::{Primitive, Renderer};
 use iced_native::image;
 use iced_native::image::viewer;
 use iced_native::mouse;
-use iced_native::{Rectangle, Vector};
+use iced_native::{Rectangle, Size, Vector};
 
 impl<B> viewer::Renderer for Renderer<B>
 where
@@ -15,7 +15,7 @@ where
         &mut self,
         state: &viewer::State,
         bounds: Rectangle,
-        image_bounds: Rectangle,
+        image_size: Size,
         translation: Vector,
         handle: image::Handle,
         is_mouse_over: bool,
@@ -28,7 +28,11 @@ where
                         translation,
                         content: Box::new(Primitive::Image {
                             handle,
-                            bounds: image_bounds,
+                            bounds: Rectangle {
+                                x: bounds.x,
+                                y: bounds.y,
+                                ..Rectangle::with_size(image_size)
+                            },
                         }),
                     }),
                     offset: Vector::new(0, 0),
@@ -38,8 +42,8 @@ where
                 if state.is_cursor_clicked() {
                     mouse::Interaction::Grabbing
                 } else if is_mouse_over
-                    && (image_bounds.width > bounds.width
-                        || image_bounds.height > bounds.height)
+                    && (image_size.width > bounds.width
+                        || image_size.height > bounds.height)
                 {
                     mouse::Interaction::Grab
                 } else {

--- a/graphics/src/widget/image/viewer.rs
+++ b/graphics/src/widget/image/viewer.rs
@@ -39,7 +39,7 @@ where
                 }
             },
             {
-                if state.is_cursor_clicked() {
+                if state.is_cursor_grabbed() {
                     mouse::Interaction::Grabbing
                 } else if is_mouse_over
                     && (image_size.width > bounds.width

--- a/graphics/src/widget/image/viewer.rs
+++ b/graphics/src/widget/image/viewer.rs
@@ -2,10 +2,10 @@
 use crate::backend::{self, Backend};
 use crate::{Primitive, Renderer};
 
-use iced_native::{
-    image::{self, viewer},
-    mouse, Rectangle, Vector,
-};
+use iced_native::image;
+use iced_native::image::viewer;
+use iced_native::mouse;
+use iced_native::{Rectangle, Vector};
 
 impl<B> viewer::Renderer for Renderer<B>
 where

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -1,4 +1,7 @@
 //! Display images in your user interface.
+pub mod viewer;
+pub use viewer::Viewer;
+
 use crate::layout;
 use crate::{Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget};
 

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -268,14 +268,14 @@ where
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                 if is_mouse_over =>
             {
-                self.state.starting_cursor_pos = Some(cursor_position);
+                self.state.cursor_grabbed_at = Some(cursor_position);
                 self.state.starting_offset = self.state.current_offset;
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
-                self.state.starting_cursor_pos = None
+                self.state.cursor_grabbed_at = None
             }
             Event::Mouse(mouse::Event::CursorMoved { position })
-                if self.state.is_cursor_clicked() =>
+                if self.state.is_cursor_grabbed() =>
             {
                 let image_size = self.image_size(renderer, bounds.size());
 
@@ -343,7 +343,7 @@ pub struct State {
     scale: f32,
     starting_offset: Vector,
     current_offset: Vector,
-    starting_cursor_pos: Option<Point>,
+    cursor_grabbed_at: Option<Point>,
 }
 
 impl Default for State {
@@ -352,7 +352,7 @@ impl Default for State {
             scale: 1.0,
             starting_offset: Vector::default(),
             current_offset: Vector::default(),
-            starting_cursor_pos: None,
+            cursor_grabbed_at: None,
         }
     }
 }
@@ -377,8 +377,8 @@ impl State {
         let hidden_height =
             (image_size.height - bounds.height / 2.0).max(0.0).round();
 
-        let delta_x = x - self.starting_cursor_pos.unwrap().x;
-        let delta_y = y - self.starting_cursor_pos.unwrap().y;
+        let delta_x = x - self.cursor_grabbed_at.unwrap().x;
+        let delta_y = y - self.cursor_grabbed_at.unwrap().y;
 
         if bounds.width < image_size.width {
             self.current_offset.x = (self.starting_offset.x - delta_x)
@@ -411,13 +411,12 @@ impl State {
         )
     }
 
-    /// Returns if the left mouse button is still held down since clicking inside
-    /// the [`Viewer`].
+    /// Returns if the cursor is currently grabbed by the [`Viewer`].
     ///
     /// [`Viewer`]: struct.Viewer.html
     /// [`State`]: struct.State.html
-    pub fn is_cursor_clicked(&self) -> bool {
-        self.starting_cursor_pos.is_some()
+    pub fn is_cursor_grabbed(&self) -> bool {
+        self.cursor_grabbed_at.is_some()
     }
 }
 

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -371,12 +371,11 @@ impl State {
     /// [`Viewer`]: struct.Viewer.html
     /// [`State`]: struct.State.html
     fn pan(&mut self, x: f32, y: f32, bounds: Rectangle, image_size: Size) {
-        let hidden_width = ((image_size.width - bounds.width) as f32 / 2.0)
-            .max(0.0)
-            .round();
-        let hidden_height = ((image_size.height - bounds.height) as f32 / 2.0)
-            .max(0.0)
-            .round();
+        let hidden_width =
+            (image_size.width - bounds.width / 2.0).max(0.0).round();
+
+        let hidden_height =
+            (image_size.height - bounds.height / 2.0).max(0.0).round();
 
         let delta_x = x - self.starting_cursor_pos.unwrap().x;
         let delta_y = y - self.starting_cursor_pos.unwrap().y;
@@ -400,12 +399,11 @@ impl State {
     /// [`Viewer`]: struct.Viewer.html
     /// [`State`]: struct.State.html
     fn offset(&self, bounds: Rectangle, image_size: Size) -> Vector {
-        let hidden_width = ((image_size.width - bounds.width) as f32 / 2.0)
-            .max(0.0)
-            .round();
-        let hidden_height = ((image_size.height - bounds.height) as f32 / 2.0)
-            .max(0.0)
-            .round();
+        let hidden_width =
+            (image_size.width - bounds.width / 2.0).max(0.0).round();
+
+        let hidden_height =
+            (image_size.height - bounds.height / 2.0).max(0.0).round();
 
         Vector::new(
             self.current_offset

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -8,7 +8,7 @@ use crate::{
     Widget,
 };
 
-use std::{f32, hash::Hash, u32};
+use std::hash::Hash;
 
 /// A frame that displays an image with the ability to zoom in/out and pan.
 #[allow(missing_debug_implementations)]
@@ -17,8 +17,6 @@ pub struct Viewer<'a> {
     padding: u16,
     width: Length,
     height: Length,
-    max_width: u32,
-    max_height: u32,
     min_scale: f32,
     max_scale: f32,
     scale_step: f32,
@@ -35,8 +33,6 @@ impl<'a> Viewer<'a> {
             padding: 0,
             width: Length::Shrink,
             height: Length::Shrink,
-            max_width: u32::MAX,
-            max_height: u32::MAX,
             min_scale: 0.25,
             max_scale: 10.0,
             scale_step: 0.10,
@@ -59,18 +55,6 @@ impl<'a> Viewer<'a> {
     /// Sets the height of the [`Viewer`].
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
-        self
-    }
-
-    /// Sets the max width of the [`Viewer`].
-    pub fn max_width(mut self, max_width: u32) -> Self {
-        self.max_width = max_width;
-        self
-    }
-
-    /// Sets the max height of the [`Viewer`].
-    pub fn max_height(mut self, max_height: u32) -> Self {
-        self.max_height = max_height;
         self
     }
 
@@ -315,8 +299,6 @@ where
 
         self.width.hash(state);
         self.height.hash(state);
-        self.max_width.hash(state);
-        self.max_height.hash(state);
         self.padding.hash(state);
 
         self.handle.hash(state);

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -1,0 +1,500 @@
+//! Zoom and pan on an image.
+use crate::event::{self, Event};
+use crate::image;
+use crate::layout;
+use crate::mouse;
+use crate::{
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
+    Widget,
+};
+
+use std::{f32, hash::Hash, u32};
+
+/// A frame that displays an image with the ability to zoom in/out and pan.
+#[allow(missing_debug_implementations)]
+pub struct Viewer<'a> {
+    state: &'a mut State,
+    padding: u16,
+    width: Length,
+    height: Length,
+    max_width: u32,
+    max_height: u32,
+    min_scale: f32,
+    max_scale: f32,
+    scale_pct: f32,
+    handle: image::Handle,
+}
+
+impl<'a> Viewer<'a> {
+    /// Creates a new [`Viewer`] with the given [`State`] and [`Handle`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    /// [`State`]: struct.State.html
+    /// [`Handle`]: ../../image/struct.Handle.html
+    pub fn new(state: &'a mut State, handle: image::Handle) -> Self {
+        Viewer {
+            state,
+            padding: 0,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            max_width: u32::MAX,
+            max_height: u32::MAX,
+            min_scale: 0.25,
+            max_scale: 10.0,
+            scale_pct: 0.10,
+            handle,
+        }
+    }
+
+    /// Sets the padding of the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn padding(mut self, units: u16) -> Self {
+        self.padding = units;
+        self
+    }
+
+    /// Sets the width of the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Sets the height of the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = height;
+        self
+    }
+
+    /// Sets the max width of the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn max_width(mut self, max_width: u32) -> Self {
+        self.max_width = max_width;
+        self
+    }
+
+    /// Sets the max height of the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn max_height(mut self, max_height: u32) -> Self {
+        self.max_height = max_height;
+        self
+    }
+
+    /// Sets the max scale applied to the image of the [`Viewer`].
+    ///
+    /// Default is `10.0`
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn max_scale(mut self, max_scale: f32) -> Self {
+        self.max_scale = max_scale;
+        self
+    }
+
+    /// Sets the min scale applied to the image of the [`Viewer`].
+    ///
+    /// Default is `0.25`
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn min_scale(mut self, min_scale: f32) -> Self {
+        self.min_scale = min_scale;
+        self
+    }
+
+    /// Sets the percentage the image of the [`Viewer`] will be scaled by
+    /// when zoomed in / out.
+    ///
+    /// Default is `0.10`
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    pub fn scale_pct(mut self, scale_pct: f32) -> Self {
+        self.scale_pct = scale_pct;
+        self
+    }
+
+    /// Returns the bounds of the underlying image, given the bounds of
+    /// the [`Viewer`]. Scaling will be applied and original aspect ratio
+    /// will be respected.
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    fn image_bounds<Renderer>(
+        &self,
+        renderer: &Renderer,
+        bounds: Rectangle,
+    ) -> Rectangle
+    where
+        Renderer: self::Renderer + image::Renderer,
+    {
+        let (width, height) = renderer.dimensions(&self.handle);
+
+        let dimensions = {
+            let dimensions = (width as f32, height as f32);
+
+            let width_ratio = bounds.width / dimensions.0;
+            let height_ratio = bounds.height / dimensions.1;
+
+            let ratio = width_ratio.min(height_ratio);
+
+            let scale = self.state.scale.unwrap_or(1.0);
+
+            if ratio < 1.0 {
+                (dimensions.0 * ratio * scale, dimensions.1 * ratio * scale)
+            } else {
+                (dimensions.0 * scale, dimensions.1 * scale)
+            }
+        };
+
+        Rectangle {
+            x: bounds.x,
+            y: bounds.y,
+            width: dimensions.0,
+            height: dimensions.1,
+        }
+    }
+
+    /// Cursor position relative to the [`Viewer`] bounds.
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    fn relative_cursor_position(
+        &self,
+        mut absolute_position: Point,
+        bounds: Rectangle,
+    ) -> Point {
+        absolute_position.x -= bounds.x;
+        absolute_position.y -= bounds.y;
+        absolute_position
+    }
+
+    /// Center point relative to the [`Viewer`] bounds.
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    fn relative_center(&self, bounds: Rectangle) -> Point {
+        let mut center = bounds.center();
+        center.x -= bounds.x;
+        center.y -= bounds.y;
+        center
+    }
+}
+
+impl<'a, Message, Renderer> Widget<Message, Renderer> for Viewer<'a>
+where
+    Renderer: self::Renderer + image::Renderer,
+{
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
+    fn layout(
+        &self,
+        _renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let padding = f32::from(self.padding);
+
+        let limits = limits
+            .max_width(self.max_width)
+            .max_height(self.max_height)
+            .width(self.width)
+            .height(self.height)
+            .pad(padding);
+
+        let size = limits.resolve(Size::INFINITY);
+
+        layout::Node::new(size)
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        _messages: &mut Vec<Message>,
+        renderer: &Renderer,
+        _clipboard: Option<&dyn Clipboard>,
+    ) -> event::Status {
+        let bounds = layout.bounds();
+        let is_mouse_over = bounds.contains(cursor_position);
+
+        if is_mouse_over {
+            match event {
+                Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                    match delta {
+                        mouse::ScrollDelta::Lines { y, .. }
+                        | mouse::ScrollDelta::Pixels { y, .. } => {
+                            let previous_scale =
+                                self.state.scale.unwrap_or(1.0);
+
+                            if y < 0.0 && previous_scale > self.min_scale
+                                || y > 0.0 && previous_scale < self.max_scale
+                            {
+                                self.state.scale = Some(
+                                    (if y > 0.0 {
+                                        self.state.scale.unwrap_or(1.0)
+                                            * (1.0 + self.scale_pct)
+                                    } else {
+                                        self.state.scale.unwrap_or(1.0)
+                                            / (1.0 + self.scale_pct)
+                                    })
+                                    .max(self.min_scale)
+                                    .min(self.max_scale),
+                                );
+
+                                let image_bounds =
+                                    self.image_bounds(renderer, bounds);
+
+                                let factor = self.state.scale.unwrap()
+                                    / previous_scale
+                                    - 1.0;
+
+                                let cursor_to_center =
+                                    self.relative_cursor_position(
+                                        cursor_position,
+                                        bounds,
+                                    ) - self.relative_center(bounds);
+
+                                let adjustment = cursor_to_center * factor
+                                    + self.state.current_offset * factor;
+
+                                self.state.current_offset = Vector::new(
+                                    if image_bounds.width > bounds.width {
+                                        self.state.current_offset.x
+                                            + adjustment.x
+                                    } else {
+                                        0.0
+                                    },
+                                    if image_bounds.height > bounds.height {
+                                        self.state.current_offset.y
+                                            + adjustment.y
+                                    } else {
+                                        0.0
+                                    },
+                                );
+                            }
+                        }
+                    }
+                }
+                Event::Mouse(mouse::Event::ButtonPressed(button)) => {
+                    if button == mouse::Button::Left {
+                        self.state.starting_cursor_pos = Some(cursor_position);
+
+                        self.state.starting_offset = self.state.current_offset;
+                    }
+                }
+                Event::Mouse(mouse::Event::ButtonReleased(button)) => {
+                    if button == mouse::Button::Left {
+                        self.state.starting_cursor_pos = None
+                    }
+                }
+                Event::Mouse(mouse::Event::CursorMoved { position }) => {
+                    if self.state.is_cursor_clicked() {
+                        let image_bounds = self.image_bounds(renderer, bounds);
+
+                        self.state.pan(
+                            position.x,
+                            position.y,
+                            bounds,
+                            image_bounds,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        } else if let Event::Mouse(mouse::Event::ButtonReleased(button)) = event
+        {
+            if button == mouse::Button::Left {
+                self.state.starting_cursor_pos = None;
+            }
+        }
+
+        event::Status::Ignored
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        _defaults: &Renderer::Defaults,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        _viewport: &Rectangle,
+    ) -> Renderer::Output {
+        let bounds = layout.bounds();
+
+        let image_bounds = self.image_bounds(renderer, bounds);
+
+        let translation = {
+            let image_top_left = Vector::new(
+                bounds.width / 2.0 - image_bounds.width / 2.0,
+                bounds.height / 2.0 - image_bounds.height / 2.0,
+            );
+
+            image_top_left - self.state.offset(bounds, image_bounds)
+        };
+
+        let is_mouse_over = bounds.contains(cursor_position);
+
+        self::Renderer::draw(
+            renderer,
+            &self.state,
+            bounds,
+            image_bounds,
+            translation,
+            self.handle.clone(),
+            is_mouse_over,
+        )
+    }
+
+    fn hash_layout(&self, state: &mut Hasher) {
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
+
+        self.width.hash(state);
+        self.height.hash(state);
+        self.max_width.hash(state);
+        self.max_height.hash(state);
+        self.padding.hash(state);
+
+        self.handle.hash(state);
+    }
+}
+
+/// The local state of a [`Viewer`].
+///
+/// [`Viewer`]: struct.Viewer.html
+#[derive(Debug, Clone, Copy, Default)]
+pub struct State {
+    scale: Option<f32>,
+    starting_offset: Vector,
+    current_offset: Vector,
+    starting_cursor_pos: Option<Point>,
+}
+
+impl State {
+    /// Creates a new [`State`].
+    ///
+    /// [`State`]: struct.State.html
+    pub fn new() -> Self {
+        State::default()
+    }
+
+    /// Apply a panning offset to the current [`State`], given the bounds of
+    /// the [`Viewer`] and its image.
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    /// [`State`]: struct.State.html
+    fn pan(
+        &mut self,
+        x: f32,
+        y: f32,
+        bounds: Rectangle,
+        image_bounds: Rectangle,
+    ) {
+        let hidden_width = ((image_bounds.width - bounds.width) as f32 / 2.0)
+            .max(0.0)
+            .round();
+        let hidden_height = ((image_bounds.height - bounds.height) as f32
+            / 2.0)
+            .max(0.0)
+            .round();
+
+        let delta_x = x - self.starting_cursor_pos.unwrap().x;
+        let delta_y = y - self.starting_cursor_pos.unwrap().y;
+
+        if bounds.width < image_bounds.width {
+            self.current_offset.x = (self.starting_offset.x - delta_x)
+                .min(hidden_width)
+                .max(-1.0 * hidden_width);
+        }
+
+        if bounds.height < image_bounds.height {
+            self.current_offset.y = (self.starting_offset.y - delta_y)
+                .min(hidden_height)
+                .max(-1.0 * hidden_height);
+        }
+    }
+
+    /// Returns the current offset of the [`State`], given the bounds
+    /// of the [`Viewer`] and its image.
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    /// [`State`]: struct.State.html
+    fn offset(&self, bounds: Rectangle, image_bounds: Rectangle) -> Vector {
+        let hidden_width = ((image_bounds.width - bounds.width) as f32 / 2.0)
+            .max(0.0)
+            .round();
+        let hidden_height = ((image_bounds.height - bounds.height) as f32
+            / 2.0)
+            .max(0.0)
+            .round();
+
+        Vector::new(
+            self.current_offset
+                .x
+                .min(hidden_width)
+                .max(-1.0 * hidden_width),
+            self.current_offset
+                .y
+                .min(hidden_height)
+                .max(-1.0 * hidden_height),
+        )
+    }
+
+    /// Returns if the left mouse button is still held down since clicking inside
+    /// the [`Viewer`].
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    /// [`State`]: struct.State.html
+    pub fn is_cursor_clicked(&self) -> bool {
+        self.starting_cursor_pos.is_some()
+    }
+}
+
+/// The renderer of an [`Viewer`].
+///
+/// Your [renderer] will need to implement this trait before being
+/// able to use a [`Viewer`] in your user interface.
+///
+/// [`Viewer`]: struct.Viewer.html
+/// [renderer]: ../../../renderer/index.html
+pub trait Renderer: crate::Renderer + Sized {
+    /// Draws the [`Viewer`].
+    ///
+    /// It receives:
+    /// - the [`State`] of the [`Viewer`]
+    /// - the bounds of the [`Viewer`] widget
+    /// - the bounds of the scaled [`Viewer`] image
+    /// - the translation of the clipped image
+    /// - the [`Handle`] to the underlying image
+    /// - whether the mouse is over the [`Viewer`] or not
+    ///
+    /// [`Viewer`]: struct.Viewer.html
+    /// [`State`]: struct.State.html
+    /// [`Handle`]: ../../image/struct.Handle.html
+    fn draw(
+        &mut self,
+        state: &State,
+        bounds: Rectangle,
+        image_bounds: Rectangle,
+        translation: Vector,
+        handle: image::Handle,
+        is_mouse_over: bool,
+    ) -> Self::Output;
+}
+
+impl<'a, Message, Renderer> From<Viewer<'a>> for Element<'a, Message, Renderer>
+where
+    Renderer: 'a + self::Renderer + image::Renderer,
+    Message: 'a,
+{
+    fn from(viewer: Viewer<'a>) -> Element<'a, Message, Renderer> {
+        Element::new(viewer)
+    }
+}

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -383,13 +383,13 @@ impl State {
         if bounds.width < image_size.width {
             self.current_offset.x = (self.starting_offset.x - delta_x)
                 .min(hidden_width)
-                .max(-1.0 * hidden_width);
+                .max(-hidden_width);
         }
 
         if bounds.height < image_size.height {
             self.current_offset.y = (self.starting_offset.y - delta_y)
                 .min(hidden_height)
-                .max(-1.0 * hidden_height);
+                .max(-hidden_height);
         }
     }
 
@@ -406,14 +406,8 @@ impl State {
             (image_size.height - bounds.height / 2.0).max(0.0).round();
 
         Vector::new(
-            self.current_offset
-                .x
-                .min(hidden_width)
-                .max(-1.0 * hidden_width),
-            self.current_offset
-                .y
-                .min(hidden_height)
-                .max(-1.0 * hidden_height),
+            self.current_offset.x.min(hidden_width).max(-hidden_width),
+            self.current_offset.y.min(hidden_height).max(-hidden_height),
         )
     }
 

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -136,7 +136,7 @@ impl<'a> Viewer<'a> {
 
             let ratio = width_ratio.min(height_ratio);
 
-            let scale = self.state.scale.unwrap_or(1.0);
+            let scale = self.state.scale;
 
             if ratio < 1.0 {
                 (dimensions.0 * ratio * scale, dimensions.1 * ratio * scale)
@@ -222,29 +222,24 @@ where
                 match delta {
                     mouse::ScrollDelta::Lines { y, .. }
                     | mouse::ScrollDelta::Pixels { y, .. } => {
-                        let previous_scale = self.state.scale.unwrap_or(1.0);
+                        let previous_scale = self.state.scale;
 
                         if y < 0.0 && previous_scale > self.min_scale
                             || y > 0.0 && previous_scale < self.max_scale
                         {
-                            self.state.scale = Some(
-                                (if y > 0.0 {
-                                    self.state.scale.unwrap_or(1.0)
-                                        * (1.0 + self.scale_step)
-                                } else {
-                                    self.state.scale.unwrap_or(1.0)
-                                        / (1.0 + self.scale_step)
-                                })
-                                .max(self.min_scale)
-                                .min(self.max_scale),
-                            );
+                            self.state.scale = (if y > 0.0 {
+                                self.state.scale * (1.0 + self.scale_step)
+                            } else {
+                                self.state.scale / (1.0 + self.scale_step)
+                            })
+                            .max(self.min_scale)
+                            .min(self.max_scale);
 
                             let image_size =
                                 self.image_size(renderer, bounds.size());
 
-                            let factor = self.state.scale.unwrap()
-                                / previous_scale
-                                - 1.0;
+                            let factor =
+                                self.state.scale / previous_scale - 1.0;
 
                             let cursor_to_center = relative_cursor_position(
                                 cursor_position,
@@ -343,12 +338,23 @@ where
 /// The local state of a [`Viewer`].
 ///
 /// [`Viewer`]: struct.Viewer.html
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct State {
-    scale: Option<f32>,
+    scale: f32,
     starting_offset: Vector,
     current_offset: Vector,
     starting_cursor_pos: Option<Point>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            scale: 1.0,
+            starting_offset: Vector::default(),
+            current_offset: Vector::default(),
+            starting_cursor_pos: None,
+        }
+    }
 }
 
 impl State {

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -132,7 +132,7 @@ impl<'a> Viewer<'a> {
     {
         let (width, height) = renderer.dimensions(&self.handle);
 
-        let dimensions = {
+        let (width, height) = {
             let dimensions = (width as f32, height as f32);
 
             let width_ratio = bounds.width / dimensions.0;
@@ -152,33 +152,27 @@ impl<'a> Viewer<'a> {
         Rectangle {
             x: bounds.x,
             y: bounds.y,
-            width: dimensions.0,
-            height: dimensions.1,
+            width,
+            height,
         }
     }
+}
 
-    /// Cursor position relative to the [`Viewer`] bounds.
-    ///
-    /// [`Viewer`]: struct.Viewer.html
-    fn relative_cursor_position(
-        &self,
-        mut absolute_position: Point,
-        bounds: Rectangle,
-    ) -> Point {
-        absolute_position.x -= bounds.x;
-        absolute_position.y -= bounds.y;
-        absolute_position
-    }
+/// Cursor position relative to the [`Viewer`] bounds.
+///
+/// [`Viewer`]: struct.Viewer.html
+fn relative_cursor_position(
+    absolute_position: Point,
+    bounds: Rectangle,
+) -> Point {
+    absolute_position - Vector::new(bounds.x, bounds.y)
+}
 
-    /// Center point relative to the [`Viewer`] bounds.
-    ///
-    /// [`Viewer`]: struct.Viewer.html
-    fn relative_center(&self, bounds: Rectangle) -> Point {
-        let mut center = bounds.center();
-        center.x -= bounds.x;
-        center.y -= bounds.y;
-        center
-    }
+/// Center point relative to the [`Viewer`] bounds.
+///
+/// [`Viewer`]: struct.Viewer.html
+fn relative_center(bounds: Rectangle) -> Point {
+    bounds.center() - Vector::new(bounds.x, bounds.y)
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer> for Viewer<'a>
@@ -256,10 +250,10 @@ where
                                     - 1.0;
 
                                 let cursor_to_center =
-                                    self.relative_cursor_position(
+                                    relative_cursor_position(
                                         cursor_position,
                                         bounds,
-                                    ) - self.relative_center(bounds);
+                                    ) - relative_center(bounds);
 
                                 let adjustment = cursor_to_center * factor
                                     + self.state.current_offset * factor;

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -149,23 +149,6 @@ impl<'a> Viewer<'a> {
     }
 }
 
-/// Cursor position relative to the [`Viewer`] bounds.
-///
-/// [`Viewer`]: struct.Viewer.html
-fn relative_cursor_position(
-    absolute_position: Point,
-    bounds: Rectangle,
-) -> Point {
-    absolute_position - Vector::new(bounds.x, bounds.y)
-}
-
-/// Center point relative to the [`Viewer`] bounds.
-///
-/// [`Viewer`]: struct.Viewer.html
-fn relative_center(bounds: Rectangle) -> Point {
-    bounds.center() - Vector::new(bounds.x, bounds.y)
-}
-
 impl<'a, Message, Renderer> Widget<Message, Renderer> for Viewer<'a>
 where
     Renderer: self::Renderer + image::Renderer,
@@ -241,10 +224,8 @@ where
                             let factor =
                                 self.state.scale / previous_scale - 1.0;
 
-                            let cursor_to_center = relative_cursor_position(
-                                cursor_position,
-                                bounds,
-                            ) - relative_center(bounds);
+                            let cursor_to_center =
+                                cursor_position - bounds.center();
 
                             let adjustment = cursor_to_center * factor
                                 + self.state.current_offset * factor;

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -21,7 +21,7 @@ pub struct Viewer<'a> {
     max_height: u32,
     min_scale: f32,
     max_scale: f32,
-    scale_pct: f32,
+    scale_step: f32,
     handle: image::Handle,
 }
 
@@ -41,7 +41,7 @@ impl<'a> Viewer<'a> {
             max_height: u32::MAX,
             min_scale: 0.25,
             max_scale: 10.0,
-            scale_pct: 0.10,
+            scale_step: 0.10,
             handle,
         }
     }
@@ -112,8 +112,8 @@ impl<'a> Viewer<'a> {
     /// Default is `0.10`
     ///
     /// [`Viewer`]: struct.Viewer.html
-    pub fn scale_pct(mut self, scale_pct: f32) -> Self {
-        self.scale_pct = scale_pct;
+    pub fn scale_step(mut self, scale_step: f32) -> Self {
+        self.scale_step = scale_step;
         self
     }
 
@@ -230,10 +230,10 @@ where
                             self.state.scale = Some(
                                 (if y > 0.0 {
                                     self.state.scale.unwrap_or(1.0)
-                                        * (1.0 + self.scale_pct)
+                                        * (1.0 + self.scale_step)
                                 } else {
                                     self.state.scale.unwrap_or(1.0)
-                                        / (1.0 + self.scale_pct)
+                                        / (1.0 + self.scale_step)
                                 })
                                 .max(self.min_scale)
                                 .min(self.max_scale),

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -270,26 +270,21 @@ where
                     }
                 }
             }
-            Event::Mouse(mouse::Event::ButtonPressed(button))
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                 if is_mouse_over =>
             {
-                if button == mouse::Button::Left {
-                    self.state.starting_cursor_pos = Some(cursor_position);
-
-                    self.state.starting_offset = self.state.current_offset;
-                }
+                self.state.starting_cursor_pos = Some(cursor_position);
+                self.state.starting_offset = self.state.current_offset;
             }
-            Event::Mouse(mouse::Event::ButtonReleased(button)) => {
-                if button == mouse::Button::Left {
-                    self.state.starting_cursor_pos = None
-                }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                self.state.starting_cursor_pos = None
             }
-            Event::Mouse(mouse::Event::CursorMoved { position }) => {
-                if self.state.is_cursor_clicked() {
-                    let image_size = self.image_size(renderer, bounds.size());
+            Event::Mouse(mouse::Event::CursorMoved { position })
+                if self.state.is_cursor_clicked() =>
+            {
+                let image_size = self.image_size(renderer, bounds.size());
 
-                    self.state.pan(position.x, position.y, bounds, image_size);
-                }
+                self.state.pan(position.x, position.y, bounds, image_size);
             }
             _ => {}
         }

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -28,9 +28,7 @@ pub struct Viewer<'a> {
 impl<'a> Viewer<'a> {
     /// Creates a new [`Viewer`] with the given [`State`] and [`Handle`].
     ///
-    /// [`Viewer`]: struct.Viewer.html
-    /// [`State`]: struct.State.html
-    /// [`Handle`]: ../../image/struct.Handle.html
+    /// [`Handle`]: image::Handle
     pub fn new(state: &'a mut State, handle: image::Handle) -> Self {
         Viewer {
             state,
@@ -47,40 +45,30 @@ impl<'a> Viewer<'a> {
     }
 
     /// Sets the padding of the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the max width of the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the max height of the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
@@ -89,8 +77,6 @@ impl<'a> Viewer<'a> {
     /// Sets the max scale applied to the image of the [`Viewer`].
     ///
     /// Default is `10.0`
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn max_scale(mut self, max_scale: f32) -> Self {
         self.max_scale = max_scale;
         self
@@ -99,8 +85,6 @@ impl<'a> Viewer<'a> {
     /// Sets the min scale applied to the image of the [`Viewer`].
     ///
     /// Default is `0.25`
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn min_scale(mut self, min_scale: f32) -> Self {
         self.min_scale = min_scale;
         self
@@ -110,8 +94,6 @@ impl<'a> Viewer<'a> {
     /// when zoomed in / out.
     ///
     /// Default is `0.10`
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     pub fn scale_step(mut self, scale_step: f32) -> Self {
         self.scale_step = scale_step;
         self
@@ -120,8 +102,6 @@ impl<'a> Viewer<'a> {
     /// Returns the bounds of the underlying image, given the bounds of
     /// the [`Viewer`]. Scaling will be applied and original aspect ratio
     /// will be respected.
-    ///
-    /// [`Viewer`]: struct.Viewer.html
     fn image_size<Renderer>(&self, renderer: &Renderer, bounds: Size) -> Size
     where
         Renderer: self::Renderer + image::Renderer,
@@ -344,8 +324,6 @@ where
 }
 
 /// The local state of a [`Viewer`].
-///
-/// [`Viewer`]: struct.Viewer.html
 #[derive(Debug, Clone, Copy)]
 pub struct State {
     scale: f32,
@@ -367,17 +345,12 @@ impl Default for State {
 
 impl State {
     /// Creates a new [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         State::default()
     }
 
     /// Returns the current offset of the [`State`], given the bounds
     /// of the [`Viewer`] and its image.
-    ///
-    /// [`Viewer`]: struct.Viewer.html
-    /// [`State`]: struct.State.html
     fn offset(&self, bounds: Rectangle, image_size: Size) -> Vector {
         let hidden_width =
             (image_size.width - bounds.width / 2.0).max(0.0).round();
@@ -392,9 +365,6 @@ impl State {
     }
 
     /// Returns if the cursor is currently grabbed by the [`Viewer`].
-    ///
-    /// [`Viewer`]: struct.Viewer.html
-    /// [`State`]: struct.State.html
     pub fn is_cursor_grabbed(&self) -> bool {
         self.cursor_grabbed_at.is_some()
     }
@@ -405,22 +375,19 @@ impl State {
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Viewer`] in your user interface.
 ///
-/// [`Viewer`]: struct.Viewer.html
-/// [renderer]: ../../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer + Sized {
     /// Draws the [`Viewer`].
     ///
     /// It receives:
     /// - the [`State`] of the [`Viewer`]
     /// - the bounds of the [`Viewer`] widget
-    /// - the bounds of the scaled [`Viewer`] image
+    /// - the [`Size`] of the scaled [`Viewer`] image
     /// - the translation of the clipped image
     /// - the [`Handle`] to the underlying image
     /// - whether the mouse is over the [`Viewer`] or not
     ///
-    /// [`Viewer`]: struct.Viewer.html
-    /// [`State`]: struct.State.html
-    /// [`Handle`]: ../../image/struct.Handle.html
+    /// [`Handle`]: image::Handle
     fn draw(
         &mut self,
         state: &State,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -37,7 +37,8 @@ mod platform {
     #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
     pub mod image {
         //! Display images in your user interface.
-        pub use crate::runtime::image::{Handle, Image};
+        pub use crate::runtime::image::viewer;
+        pub use crate::runtime::image::{Handle, Image, Viewer};
     }
 
     #[cfg_attr(docsrs, doc(cfg(feature = "svg")))]


### PR DESCRIPTION
This isn't complete, but the zooming and panning features "work". If an image handle's dimensions are larger than the dimensions of the `ImagePane`, it is scaled down to fit inside the pane. Images smaller than the pane won't get rescaled until the mouse wheel is scrolled.

Some improvements needed before merging:

- Image should be centered inside the `ImagePane`. Can't implement this until negative offsets are allowed inside `Clip` primitive
- Clipping offset should get updated when scaling the image to "zoom" around wherever the cursor is placed. Right now offset doesn't change on scaling, so image just zooms out from top left corner.
- Add builder methods for `State` to allow specifying the min / max scale factor and step size

Let me know what you think and if there are any other features / defaults that should be added!

resolves #306 