### PR TITLE
#321 Fix async examples by feature-gating Command implementations + A…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,5 @@ jobs:
       run: cargo check --package iced --target wasm32-unknown-unknown
     - name: Check compilation of `tour` example
       run: cargo build --package tour --target wasm32-unknown-unknown
+    - name: Check compilation of `pokedex` example
+      run: cargo build --package pokedex --target wasm32-unknown-unknown

--- a/futures/src/command.rs
+++ b/futures/src/command.rs
@@ -85,7 +85,7 @@ impl<T> Command<T> {
     where
         T: 'static,
     {
-        let f = std::sync::Arc::new(f);
+        let f = std::rc::Rc::new(f);
 
         Command {
             futures: self

--- a/futures/src/command.rs
+++ b/futures/src/command.rs
@@ -81,10 +81,7 @@ impl<T> Command<T> {
     ///
     /// [`Command`]: struct.Command.html
     #[cfg(target_arch = "wasm32")]
-    pub fn map<A>(
-        mut self,
-        f: impl Fn(T) -> A + 'static,
-    ) -> Command<A>
+    pub fn map<A>(mut self, f: impl Fn(T) -> A + 'static) -> Command<A>
     where
         T: 'static,
     {
@@ -150,7 +147,6 @@ where
         }
     }
 }
-
 
 impl<T> std::fmt::Debug for Command<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/futures/src/command.rs
+++ b/futures/src/command.rs
@@ -27,8 +27,22 @@ impl<T> Command<T> {
     /// Creates a [`Command`] that performs the action of the given future.
     ///
     /// [`Command`]: struct.Command.html
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn perform<A>(
         future: impl Future<Output = T> + 'static + Send,
+        f: impl Fn(T) -> A + 'static + Send,
+    ) -> Command<A> {
+        Command {
+            futures: vec![Box::pin(future.map(f))],
+        }
+    }
+
+    /// Creates a [`Command`] that performs the action of the given future.
+    ///
+    /// [`Command`]: struct.Command.html
+    #[cfg(target_arch = "wasm32")]
+    pub fn perform<A>(
+        future: impl Future<Output = T> + 'static,
         f: impl Fn(T) -> A + 'static + Send,
     ) -> Command<A> {
         Command {
@@ -39,9 +53,37 @@ impl<T> Command<T> {
     /// Applies a transformation to the result of a [`Command`].
     ///
     /// [`Command`]: struct.Command.html
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn map<A>(
         mut self,
         f: impl Fn(T) -> A + 'static + Send + Sync,
+    ) -> Command<A>
+    where
+        T: 'static,
+    {
+        let f = std::sync::Arc::new(f);
+
+        Command {
+            futures: self
+                .futures
+                .drain(..)
+                .map(|future| {
+                    let f = f.clone();
+
+                    Box::pin(future.map(move |result| f(result)))
+                        as BoxFuture<A>
+                })
+                .collect(),
+        }
+    }
+
+    /// Applies a transformation to the result of a [`Command`].
+    ///
+    /// [`Command`]: struct.Command.html
+    #[cfg(target_arch = "wasm32")]
+    pub fn map<A>(
+        mut self,
+        f: impl Fn(T) -> A + 'static,
     ) -> Command<A>
     where
         T: 'static,
@@ -85,6 +127,7 @@ impl<T> Command<T> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T, A> From<A> for Command<T>
 where
     A: Future<Output = T> + 'static + Send,
@@ -95,6 +138,19 @@ where
         }
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+impl<T, A> From<A> for Command<T>
+where
+    A: Future<Output = T> + 'static,
+{
+    fn from(future: A) -> Self {
+        Self {
+            futures: vec![future.boxed_local()],
+        }
+    }
+}
+
 
 impl<T> std::fmt::Debug for Command<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Fixes #321 .

* Fixes broken async examples by feature-gating Command methods that required Send on wasm32, causing conflicts.  
* Adds `pokedex` example in CI so that at least one async example is runned on CI.