### PR TITLE
document that img handle constructors guess fmt

### DIFF
--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -123,6 +123,8 @@ pub struct Handle {
 impl Handle {
     /// Creates an image [`Handle`] pointing to the image of the given path.
     ///
+    /// Makes an educated guess about the image format by examining the data in the file.
+    ///
     /// [`Handle`]: struct.Handle.html
     pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
         Self::from_data(Data::Path(path.into()))
@@ -144,6 +146,8 @@ impl Handle {
     }
 
     /// Creates an image [`Handle`] containing the image data directly.
+    ///
+    /// Makes an educated guess about the image format by examining the given data.
     ///
     /// This is useful if you already have your image loaded in-memory, maybe
     /// because you downloaded or generated it procedurally.


### PR DESCRIPTION
This patch documents the fact that a couple of the image
handle constructors know how to guess the image format based
on the data that they are provided.

I had to dig through `iced` sources until I discovered that those
routines ultimately boil down to stuff like [image::load_from_memory][1]
from the `image` crate, so I thought I would save others the trouble
of doing the same reverse-engineering

[1]: https://docs.rs/image/0.23.4/image/fn.load_from_memory.html