### PR TITLE
Update iced_wgpu dependencies

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -18,9 +18,9 @@ zerocopy = "0.3"
 glyph_brush = "0.6"
 raw-window-handle = "0.3"
 glam = "0.8"
-font-kit = "0.4"
+font-kit = "0.6"
 log = "0.4"
-guillotiere = "0.4"
+guillotiere = "0.5"
 
 [dependencies.iced_native]
 version = "0.2"
@@ -31,11 +31,11 @@ version = "0.1"
 path = "../style"
 
 [dependencies.image]
-version = "0.22"
+version = "0.23"
 optional = true
 
 [dependencies.resvg]
-version = "0.8"
+version = "0.9"
 features = ["raqote-backend"]
 optional = true
 


### PR DESCRIPTION
I noticed some duplicate dependencies due to different transitive dependency versions in my cargo lock file so I checked and found a few that can be updated to resolve some of those.

font-kit 0.4 -> 0.6
guillotiere 0.4 -> 0.5
image 0.22 -> 0.23
resvg 0.8 -> 0.9