### PR TITLE
fix(wgpu): Set adapter backend to PRIMARY

### DIFF
--- a/wgpu/src/window/backend.rs
+++ b/wgpu/src/window/backend.rs
@@ -28,7 +28,7 @@ impl iced_native::window::Backend for Backend {
                     },
                     compatible_surface: None,
                 },
-                wgpu::BackendBit::all(),
+                wgpu::BackendBit::PRIMARY,
             )
             .await
             .expect("Request adapter");


### PR DESCRIPTION
This PR changes the set adapter's backend to `wgpu::BackendBit::PRIMARY` due to wgpu not having full support for OpenGL and DirectX11. This fixes #341.