### PR TITLE
Update `Radio` to have the same layout members and fns as `Checkbox`

### DIFF
--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -161,9 +161,8 @@ impl button::Renderer for Null {
 impl radio::Renderer for Null {
     type Style = ();
 
-    fn default_size(&self) -> u32 {
-        20
-    }
+    const DEFAULT_SIZE: u16 = 20;
+    const DEFAULT_SPACING: u16 = 15;
 
     fn draw(
         &mut self,

--- a/wgpu/src/renderer/widget/radio.rs
+++ b/wgpu/src/renderer/widget/radio.rs
@@ -7,9 +7,8 @@ const DOT_SIZE: f32 = SIZE / 2.0;
 impl radio::Renderer for Renderer {
     type Style = Box<dyn StyleSheet>;
 
-    fn default_size(&self) -> u32 {
-        SIZE as u32
-    }
+    const DEFAULT_SIZE: u16 = SIZE as u16;
+    const DEFAULT_SPACING: u16 = 15;
 
     fn draw(
         &mut self,


### PR DESCRIPTION
This fixes a layout problem I was having with `Radio` buttons, and potentially a handful of others. I tried to find all the `Radio` implementations and update them as well.

The `web`  version doesn't look like it relates to the other versions at all, and I don't understand the web stuff as well, so I left it alone for now.

Let me know if you need changes!