### PR TITLE
Feature gates `font-kit` behind `"system_font"` feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `"system_font"` feature gates reading system fonts. [#364]
+
+https://github.com/hecrj/iced/pull/364
 
 ## [0.1.1] - 2020-04-15
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ categories = ["gui"]
 image = ["iced_wgpu/image"]
 # Enables the `Svg` widget
 svg = ["iced_wgpu/svg"]
+# Enables system fonts on native platforms.
+system_font = ["iced_wgpu/system_font"]
 # Enables the `Canvas` widget
 canvas = ["iced_wgpu/canvas"]
 # Enables a debug view in native platforms (press F12)

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/hecrj/iced"
 [features]
 svg = ["resvg"]
 canvas = ["lyon"]
+system_font = ["font-kit"]
 
 [dependencies]
 wgpu = "0.5"
@@ -18,7 +19,7 @@ zerocopy = "0.3"
 glyph_brush = "0.6"
 raw-window-handle = "0.3"
 glam = "0.8"
-font-kit = "0.6"
+font-kit = { version = "0.6", optional = true }
 log = "0.4"
 guillotiere = "0.5"
 # Pin `gfx-memory` until https://github.com/gfx-rs/wgpu-rs/issues/261 is

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "system_font")]
 mod font;
 
 use crate::Transformation;
@@ -27,15 +28,21 @@ impl Pipeline {
         format: wgpu::TextureFormat,
         default_font: Option<&[u8]>,
     ) -> Self {
-        // TODO: Font customization
-        let font_source = font::Source::new();
+        let default_font = default_font.map(|slice| slice.to_vec());
 
-        let default_font =
-            default_font.map(|slice| slice.to_vec()).unwrap_or_else(|| {
+        // TODO: Font customization
+        #[cfg(feature = "system_font")]
+        let default_font = {
+            let font_source = font::Source::new();
+            default_font.or_else(|| {
                 font_source
                     .load(&[font::Family::SansSerif, font::Family::Serif])
-                    .unwrap_or_else(|_| FALLBACK_FONT.to_vec())
-            });
+                    .ok()
+            })
+        };
+
+        let default_font =
+            default_font.unwrap_or_else(|| FALLBACK_FONT.to_vec());
 
         let load_glyph_brush = |font: Vec<u8>| {
             let builder =


### PR DESCRIPTION
Closes #58.

I thought `iced` wasn't working when nothing was showing up in the examples, and it happened to be #199 / #270 / #351. Should've searched issues earlier =/.