### PR TITLE
Improvement/58/feature gate font kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `"system_font"` feature gates reading system fonts. [#370]
+
+[#370]: https://github.com/hecrj/iced/pull/370
 
 ## [0.1.1] - 2020-04-15
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
-default = ["wgpu"]
+default = ["wgpu", "default_system_font"]
 # Enables the `iced_wgpu` renderer
 wgpu = ["iced_wgpu"]
 # Enables the `Image` widget
@@ -21,10 +21,14 @@ image = ["iced_wgpu/image"]
 svg = ["iced_wgpu/svg"]
 # Enables the `Canvas` widget
 canvas = ["iced_wgpu/canvas"]
+# Enables using system fonts.
+default_system_font = ["iced_wgpu/default_system_font"]
 # Enables the `iced_glow` renderer. Overrides `iced_wgpu`
 glow = ["iced_glow", "iced_glutin"]
 # Enables the `Canvas` widget for `iced_glow`
 glow_canvas = ["iced_glow/canvas"]
+# Enables using system fonts for `iced_glow`.
+glow_default_system_font = ["iced_glow/default_system_font"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug"]
 # Enables `tokio` as the `executor::Default` on native platforms

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/hecrj/iced"
 
 [features]
 canvas = ["iced_graphics/canvas"]
+default_system_font = ["iced_graphics/font-source"]
 # Not supported yet!
 image = []
 svg = []
@@ -29,7 +30,7 @@ path = "../native"
 [dependencies.iced_graphics]
 version = "0.1"
 path = "../graphics"
-features = ["font-source", "font-fallback", "font-icons", "opengl"]
+features = ["font-fallback", "font-icons", "opengl"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/glow/src/text.rs
+++ b/glow/src/text.rs
@@ -12,15 +12,20 @@ pub struct Pipeline {
 
 impl Pipeline {
     pub fn new(gl: &glow::Context, default_font: Option<&[u8]>) -> Self {
+        let default_font = default_font.map(|slice| slice.to_vec());
+
         // TODO: Font customization
-        let font_source = font::Source::new();
+        #[cfg(feature = "default_system_font")]
+        let default_font = {
+            default_font.or_else(|| {
+                font::Source::new()
+                    .load(&[font::Family::SansSerif, font::Family::Serif])
+                    .ok()
+            })
+        };
 
         let default_font =
-            default_font.map(|slice| slice.to_vec()).unwrap_or_else(|| {
-                font_source
-                    .load(&[font::Family::SansSerif, font::Family::Serif])
-                    .unwrap_or_else(|_| font::FALLBACK.to_vec())
-            });
+            default_font.unwrap_or_else(|| font::FALLBACK.to_vec());
 
         let font = ab_glyph::FontArc::try_from_vec(default_font)
             .unwrap_or_else(|_| {

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/hecrj/iced"
 [features]
 svg = ["resvg"]
 canvas = ["iced_graphics/canvas"]
+default_system_font = ["iced_graphics/font-source"]
 
 [dependencies]
 wgpu = "0.5"
@@ -32,7 +33,7 @@ path = "../native"
 [dependencies.iced_graphics]
 version = "0.1"
 path = "../graphics"
-features = ["font-source", "font-fallback", "font-icons"]
+features = ["font-fallback", "font-icons"]
 
 [dependencies.image]
 version = "0.23"

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -16,15 +16,20 @@ impl Pipeline {
         format: wgpu::TextureFormat,
         default_font: Option<&[u8]>,
     ) -> Self {
+        let default_font = default_font.map(|slice| slice.to_vec());
+
         // TODO: Font customization
-        let font_source = font::Source::new();
+        #[cfg(feature = "default_system_font")]
+        let default_font = {
+            default_font.or_else(|| {
+                font::Source::new()
+                    .load(&[font::Family::SansSerif, font::Family::Serif])
+                    .ok()
+            })
+        };
 
         let default_font =
-            default_font.map(|slice| slice.to_vec()).unwrap_or_else(|| {
-                font_source
-                    .load(&[font::Family::SansSerif, font::Family::Serif])
-                    .unwrap_or_else(|_| font::FALLBACK.to_vec())
-            });
+            default_font.unwrap_or_else(|| font::FALLBACK.to_vec());
 
         let font = ab_glyph::FontArc::try_from_vec(default_font)
             .unwrap_or_else(|_| {


### PR DESCRIPTION
Closes #58.

I thought `iced` wasn't working when nothing was showing up in the examples, and it happened to be #199 / #270 / #351. Should've searched issues earlier.

Successor to #364 -- couldn't reopen it after deleting the branch unfortunately.

I'm not sure whether to choose `-` or `_` between feature words, since there's a `"glow_canvas"` feature in the top level `Cargo.toml`.

I've tested this using the `custom_widget` example for both `iced_wgpu` and `iced_glow`. For `iced_glow` I disabled default features from `iced` in `examples/custom_widget/Cargo.toml`, and then running:

```bash
cargo run --package custom_widget --no-default-features --features "glow"
cargo run --package custom_widget --no-default-features --features "glow glow_default_system_font"
```