### PR TITLE
[WIP] Add damage tracking, fixes #367

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1,5 +1,5 @@
 /// A font.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Font {
     /// The default font.
     ///

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -126,6 +126,27 @@ impl Rectangle<f32> {
         }
     }
 
+    /// Computes the union with the given [`Rectangle`].
+    ///
+    /// [`Rectangle`]: struct.Rectangle.html
+    pub fn union(&self, other: &Rectangle<f32>) -> Rectangle<f32> {
+        let x = self.x.min(other.x);
+        let y = self.y.min(other.y);
+
+        let lower_right_x = (self.x + self.width).max(other.x + other.width);
+        let lower_right_y = (self.y + self.height).max(other.y + other.height);
+
+        let width = lower_right_x - x;
+        let height = lower_right_y - y;
+
+        Rectangle {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
     /// Snaps the [`Rectangle`] to __unsigned__ integer coordinates.
     ///
     /// [`Rectangle`]: struct.Rectangle.html

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -36,6 +36,6 @@ pub use transformation::Transformation;
 pub use viewport::Viewport;
 
 pub use iced_native::{
-    Background, Color, Font, HorizontalAlignment, Point, Rectangle, Size,
+    Background, Damage, Color, Font, HorizontalAlignment, Point, Rectangle, Size,
     Vector, VerticalAlignment,
 };

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -7,7 +7,7 @@ use crate::triangle;
 use std::sync::Arc;
 
 /// A rendering primitive.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Primitive {
     /// An empty primitive
     None,

--- a/graphics/src/triangle.rs
+++ b/graphics/src/triangle.rs
@@ -3,7 +3,7 @@
 /// A set of [`Vertex2D`] and indices representing a list of triangles.
 ///
 /// [`Vertex2D`]: struct.Vertex2D.html
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Mesh2D {
     /// The vertices of the mesh
     pub vertices: Vec<Vertex2D>,
@@ -16,7 +16,7 @@ pub struct Mesh2D {
 }
 
 /// A two-dimensional vertex with some color in __linear__ RGBA.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct Vertex2D {
     /// The vertex position

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -78,7 +78,7 @@ pub use hasher::Hasher;
 pub use layout::Layout;
 pub use overlay::Overlay;
 pub use program::Program;
-pub use renderer::Renderer;
+pub use renderer::{Damage, Renderer};
 pub use runtime::Runtime;
 pub use subscription::Subscription;
 pub use user_interface::{Cache, UserInterface};

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Cache, Clipboard, Command, Debug, Event, Point, Program, Renderer, Size,
-    UserInterface,
+    Cache, Clipboard, Command, Damage, Debug, Event, Point, Program, Rectangle,
+    Renderer, Size, UserInterface,
 };
 
 /// The execution state of a [`Program`]. It leverages caching, event
@@ -100,7 +100,8 @@ where
     /// the widgets of the linked [`Program`] if necessary.
     ///
     /// Returns the [`Command`] obtained from [`Program`] after updating it,
-    /// only if an update was necessary.
+    /// only if an update was necessary; and a damage rectangle if any pixels
+    /// changed from the previous frame.
     ///
     /// [`Program`]: trait.Program.html
     pub fn update(
@@ -110,7 +111,7 @@ where
         clipboard: Option<&dyn Clipboard>,
         renderer: &mut P::Renderer,
         debug: &mut Debug,
-    ) -> Option<Command<P::Message>> {
+    ) -> (Option<Command<P::Message>>, Option<Vec<Rectangle>>) {
         let mut user_interface = build_user_interface(
             &mut self.program,
             self.cache.take().unwrap(),
@@ -133,12 +134,15 @@ where
 
         if messages.is_empty() {
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position);
+            let primitive = user_interface.draw(renderer, cursor_position);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());
 
-            None
+            let damage = self.primitive.damage(&primitive);
+            self.primitive = primitive;
+
+            (None, damage)
         } else {
             // When there are messages, we are forced to rebuild twice
             // for now :^)
@@ -164,12 +168,15 @@ where
             );
 
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position);
+            let primitive = user_interface.draw(renderer, cursor_position);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());
 
-            Some(commands)
+            let damage = self.primitive.damage(&primitive);
+            self.primitive = primitive;
+
+            (Some(commands), damage)
         }
     }
 }

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -31,11 +31,11 @@ use crate::{layout, Element, Rectangle};
 /// updated between two frames.
 pub trait Damage {
     /// Calculates damage between two frames
-    fn damage(&self, other: &Self) -> Option<Rectangle>;
+    fn damage(&self, other: &Self) -> Option<Vec<Rectangle>>;
 }
 
 impl Damage for () {
-    fn damage(&self, _other: &Self) -> Option<Rectangle> {
+    fn damage(&self, _other: &Self) -> Option<Vec<Rectangle>> {
         None
     }
 }
@@ -44,7 +44,7 @@ impl<T, U> Damage for (T, U)
 where
     T: Damage,
 {
-    fn damage(&self, other: &Self) -> Option<Rectangle> {
+    fn damage(&self, other: &Self) -> Option<Vec<Rectangle>> {
         self.0.damage(&other.0)
     }
 }

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -27,6 +27,28 @@ pub use null::Null;
 
 use crate::{layout, Element, Rectangle};
 
+/// An output of rendering that can determine the pixel region that would be
+/// updated between two frames.
+pub trait Damage {
+    /// Calculates damage between two frames
+    fn damage(&self, other: &Self) -> Option<Rectangle>;
+}
+
+impl Damage for () {
+    fn damage(&self, _other: &Self) -> Option<Rectangle> {
+        None
+    }
+}
+
+impl<T, U> Damage for (T, U)
+where
+    T: Damage,
+{
+    fn damage(&self, other: &Self) -> Option<Rectangle> {
+        self.0.damage(&other.0)
+    }
+}
+
 /// A component that can take the state of a user interface and produce an
 /// output for its users.
 pub trait Renderer: Sized {
@@ -36,7 +58,7 @@ pub trait Renderer: Sized {
     /// likely be a tree of visual primitives.
     ///
     /// [`Renderer`]: trait.Renderer.html
-    type Output;
+    type Output: Damage + Default;
 
     /// The default styling attributes of the [`Renderer`].
     ///

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -114,7 +114,7 @@ where
 /// An [`Image`] handle.
 ///
 /// [`Image`]: struct.Image.html
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Handle {
     id: u64,
     data: Arc<Data>,
@@ -200,7 +200,7 @@ impl Hash for Handle {
 /// The data of an [`Image`].
 ///
 /// [`Image`]: struct.Image.html
-#[derive(Clone, Hash)]
+#[derive(Clone, Hash, PartialEq)]
 pub enum Data {
     /// File data
     Path(PathBuf),

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -119,7 +119,7 @@ where
 /// An [`Svg`] handle.
 ///
 /// [`Svg`]: struct.Svg.html
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Handle {
     id: u64,
     data: Arc<Data>,
@@ -179,7 +179,7 @@ impl Hash for Handle {
 /// The data of an [`Svg`].
 ///
 /// [`Svg`]: struct.Svg.html
-#[derive(Clone, Hash)]
+#[derive(Clone, Hash, PartialEq)]
 pub enum Data {
     /// File data
     Path(PathBuf),

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -184,7 +184,7 @@ pub fn run<A, E, C>(
                 return;
             }
 
-            let command = runtime.enter(|| {
+            let (command, _damage) = runtime.enter(|| {
                 state.update(
                     viewport.logical_size(),
                     conversion::cursor_position(


### PR DESCRIPTION
fixes #367

Experimenting with implementing damage by "diffing" `Primitive`s.


- [x] primitives' `bounds` is not what I expected, e.g. the `x` of a centered text box under the slider in the tour example has its `x` in the *middle* of the screen o_0
- [x] be more precise by not joining everything into one rect
  - but for debugging one rect is easier..
- [x] don't use unstable `fold_first` (`iterator_fold_self`)
- [ ] wgpu for now should at least skip rendering when there's no damage
- [ ] why do mouse clicks always cause whole screen damage?
- [x] with the compositor hints (`swap_buffers_with_damage`) we lose the winit border hover effects (we don't damage for them).. fix this somehow?
- [ ] mouse interaction when skipping rendering due to zero damage ?? why is mouse cursor determined by actual pixel rendering?

Demo: [Wayfire `-d` damage debug view, couple examples, joined rect](https://gfycat.com/immaculateorganicblackmamba); [now with many rects!](https://gfycat.com/joyfulfragranthog)