### PR TITLE
Add on_release message to Slider

### DIFF
--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -9,7 +9,7 @@ pub struct Controls {
     sliders: [slider::State; 3],
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Message {
     BackgroundColorChanged(Color),
 }

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -187,10 +187,12 @@ where
                     }
                 }
                 mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    if let Some(on_release) = self.on_release.clone() {
-                        messages.push(on_release);
+                    if self.state.is_dragging {
+                        if let Some(on_release) = self.on_release.clone() {
+                            messages.push(on_release);
+                        }
+                        self.state.is_dragging = false;
                     }
-                    self.state.is_dragging = false;
                 }
                 mouse::Event::CursorMoved { .. } => {
                     if self.state.is_dragging {

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -161,16 +161,17 @@ where
         _clipboard: Option<&dyn Clipboard>,
     ) {
         let bounds = layout.bounds();
-    
+
         let value = if cursor_position.x <= bounds.x {
             *self.range.start()
         } else if cursor_position.x >= bounds.x + bounds.width {
             *self.range.end()
         } else {
             let percent = (cursor_position.x - bounds.x) / bounds.width;
-            (self.range.end() - self.range.start()) * percent + self.range.start()
+            (self.range.end() - self.range.start()) * percent
+                + self.range.start()
         };
-    
+
         match event {
             Event::Mouse(mouse_event) => match mouse_event {
                 mouse::Event::ButtonPressed(mouse::Button::Left) => {


### PR DESCRIPTION
Sometimes, it's useful to have a message fire only when the user has finished changing a parameter. Other widgets like text inputs may also benefit from this functionality, and I'd be happy to implement those as well!