### PR TITLE
Removes `0.5` addition when using `round()`.

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -133,8 +133,8 @@ impl Rectangle<f32> {
         Rectangle {
             x: self.x as u32,
             y: self.y as u32,
-            width: (self.width + 0.5).round() as u32,
-            height: (self.height + 0.5).round() as u32,
+            width: self.width.round() as u32,
+            height: self.height.round() as u32,
         }
     }
 }


### PR DESCRIPTION
Yo, saw a `(f32 + 0.5).round()`, and [`f32::round()`](https://doc.rust-lang.org/std/primitive.f32.html#method.round) already rounds to the nearest integer ([playpen](https://play.rust-lang.org/)).

```rust
3.8.round(): 4
3.3.round(): 3
```