### PR TITLE
Prevent gratuitous resizing in integration example

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -144,7 +144,7 @@ pub fn main() {
                             present_mode: wgpu::PresentMode::Mailbox,
                         },
                     );
-                    
+
                     resized = false;
                 }
 

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -144,6 +144,8 @@ pub fn main() {
                             present_mode: wgpu::PresentMode::Mailbox,
                         },
                     );
+                    
+                    resized = false;
                 }
 
                 let frame = swap_chain.get_next_texture().expect("Next frame");


### PR DESCRIPTION
If I didn't miss anything, that `resized` variable is never set back to `false`, meaning that swapchain recreation is retriggered every frame after the first resize.