### PR TITLE
Spike/313/less frameworky integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "examples/game_of_life",
     "examples/geometry",
     "examples/integration",
+    "examples/library_usage",
     "examples/pane_grid",
     "examples/pokedex",
     "examples/progress_bar",

--- a/examples/library_usage/Cargo.toml
+++ b/examples/library_usage/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "library_usage"
+version = "0.1.0"
+authors = ["Azriel Hoh <azriel91@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["tokio"] }
+iced_native = { path = "../../native" }
+winit = "0.22"

--- a/examples/library_usage/README.md
+++ b/examples/library_usage/README.md
@@ -1,0 +1,18 @@
+## Integration
+
+A demonstration of how to integrate Iced in an existing graphical application.
+
+The __[`main`]__ file contains all the code of the example.
+
+<div align="center">
+  <a href="https://gfycat.com/nicemediocrekodiakbear">
+    <img src="https://thumbs.gfycat.com/NiceMediocreKodiakbear-small.gif">
+  </a>
+</div>
+
+You can run it with `cargo run`:
+```
+cargo run --package library_usage
+```
+
+[`main`]: src/main.rs

--- a/examples/library_usage/src/main.rs
+++ b/examples/library_usage/src/main.rs
@@ -1,0 +1,64 @@
+use iced::{
+    executor, Align, Application, Column, Command, Container, Element, Length,
+    Settings, Subscription, Text,
+};
+use winit::event_loop::EventLoop;
+
+pub fn main() {
+    let mut event_loop = EventLoop::with_user_event();
+    let mut context = Events::initialize(&mut event_loop, Settings::default());
+
+    event_loop.run(move |event, _, control_flow| {
+        context.handle_winit_event(event, control_flow);
+    })
+}
+
+#[derive(Debug, Default)]
+struct Events {
+    last: Option<iced_native::Event>,
+}
+
+#[derive(Debug, Clone)]
+struct Message(iced_native::Event);
+
+impl Application for Events {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Events, Command<Message>) {
+        (Events::default(), Command::none())
+    }
+
+    fn title(&self) -> String {
+        String::from("Library Usage - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        self.last = Some(message.0);
+
+        Command::none()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        iced_native::subscription::events().map(Message)
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        let event = self.last.iter().fold(
+            Column::new().spacing(10),
+            |column, event| {
+                column.push(Text::new(format!("{:#?}", event)).size(20))
+            },
+        );
+
+        let content = Column::new().align_items(Align::Center).push(event);
+
+        Container::new(content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
+    }
+}

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -1,10 +1,8 @@
 //! Create interactive, native cross-platform applications.
-use crate::{mouse, Executor, Runtime, Size};
+use crate::{Context, Executor};
+use glutin::event_loop::EventLoopWindowTarget;
 use iced_graphics::window;
-use iced_graphics::Viewport;
-use iced_winit::application;
-use iced_winit::conversion;
-use iced_winit::{Clipboard, Debug, Proxy, Settings};
+use iced_winit::Settings;
 
 pub use iced_winit::Application;
 pub use iced_winit::{program, Program};
@@ -21,189 +19,20 @@ pub fn run<A, E, C>(
     E: Executor + 'static,
     C: window::GLCompositor<Renderer = A::Renderer> + 'static,
 {
-    use glutin::{
-        event,
-        event_loop::{ControlFlow, EventLoop},
-        ContextBuilder,
-    };
+    use glutin::event_loop::{ControlFlow, EventLoop};
 
-    let mut debug = Debug::new();
-    debug.startup_started();
-
-    let event_loop = EventLoop::with_user_event();
-    let mut runtime = {
-        let executor = E::new().expect("Create executor");
-        let proxy = Proxy::new(event_loop.create_proxy());
-
-        Runtime::new(executor, proxy)
-    };
-
-    let flags = settings.flags;
-    let (application, init_command) = runtime.enter(|| A::new(flags));
-    runtime.spawn(init_command);
-
-    let subscription = application.subscription();
-    runtime.track(subscription);
-
-    let mut title = application.title();
-    let mut mode = application.mode();
-
-    let context = {
-        let builder = settings.window.into_builder(
-            &title,
-            mode,
-            event_loop.primary_monitor(),
-        );
-
-        let context = ContextBuilder::new()
-            .with_vsync(true)
-            .with_multisampling(C::sample_count(&compositor_settings) as u16)
-            .build_windowed(builder, &event_loop)
-            .expect("Open window");
-
-        #[allow(unsafe_code)]
-        unsafe {
-            context.make_current().expect("Make OpenGL context current")
-        }
-    };
-
-    let clipboard = Clipboard::new(&context.window());
-    let mut mouse_interaction = mouse::Interaction::default();
-    let mut modifiers = glutin::event::ModifiersState::default();
-
-    let physical_size = context.window().inner_size();
-    let mut viewport = Viewport::with_physical_size(
-        Size::new(physical_size.width, physical_size.height),
-        context.window().scale_factor(),
+    let mut event_loop = EventLoop::with_user_event();
+    let mut context = Context::<A, E, C, A::Message>::new(
+        &mut event_loop,
+        settings,
+        compositor_settings,
     );
-    let mut resized = false;
 
-    #[allow(unsafe_code)]
-    let (mut compositor, mut renderer) = unsafe {
-        C::new(compositor_settings, |address| {
-            context.get_proc_address(address)
-        })
-    };
-
-    let mut state = program::State::new(
-        application,
-        viewport.logical_size(),
-        &mut renderer,
-        &mut debug,
-    );
-    debug.startup_finished();
-
-    event_loop.run(move |event, _, control_flow| match event {
-        event::Event::MainEventsCleared => {
-            let command = runtime.enter(|| {
-                state.update(
-                    clipboard.as_ref().map(|c| c as _),
-                    viewport.logical_size(),
-                    &mut renderer,
-                    &mut debug,
-                )
-            });
-
-            // If the application was updated
-            if let Some(command) = command {
-                runtime.spawn(command);
-
-                let program = state.program();
-
-                // Update subscriptions
-                let subscription = program.subscription();
-                runtime.track(subscription);
-
-                // Update window title
-                let new_title = program.title();
-
-                if title != new_title {
-                    context.window().set_title(&new_title);
-
-                    title = new_title;
-                }
-
-                // Update window mode
-                let new_mode = program.mode();
-
-                if mode != new_mode {
-                    context.window().set_fullscreen(conversion::fullscreen(
-                        context.window().current_monitor(),
-                        new_mode,
-                    ));
-
-                    mode = new_mode;
-                }
-            }
-
-            context.window().request_redraw();
-        }
-        event::Event::UserEvent(message) => {
-            state.queue_message(message);
-        }
-        event::Event::RedrawRequested(_) => {
-            debug.render_started();
-
-            if resized {
-                let physical_size = viewport.physical_size();
-
-                context.resize(glutin::dpi::PhysicalSize::new(
-                    physical_size.width,
-                    physical_size.height,
-                ));
-
-                compositor.resize_viewport(physical_size);
-
-                resized = false;
-            }
-
-            let new_mouse_interaction = compositor.draw(
-                &mut renderer,
-                &viewport,
-                state.primitive(),
-                &debug.overlay(),
-            );
-
-            context.swap_buffers().expect("Swap buffers");
-
-            debug.render_finished();
-
-            if new_mouse_interaction != mouse_interaction {
-                context.window().set_cursor_icon(
-                    conversion::mouse_interaction(new_mouse_interaction),
-                );
-
-                mouse_interaction = new_mouse_interaction;
-            }
-
-            // TODO: Handle animations!
-            // Maybe we can use `ControlFlow::WaitUntil` for this.
-        }
-        event::Event::WindowEvent {
-            event: window_event,
-            ..
-        } => {
-            application::handle_window_event(
-                &window_event,
-                context.window(),
-                control_flow,
-                &mut modifiers,
-                &mut viewport,
-                &mut resized,
-                &mut debug,
-            );
-
-            if let Some(event) = conversion::window_event(
-                &window_event,
-                viewport.scale_factor(),
-                modifiers,
-            ) {
-                state.queue_event(event.clone());
-                runtime.broadcast(event);
-            }
-        }
-        _ => {
-            *control_flow = ControlFlow::Wait;
-        }
-    })
+    event_loop.run(
+        move |event: glutin::event::Event<'_, A::Message>,
+              _: &EventLoopWindowTarget<A::Message>,
+              control_flow: &mut ControlFlow| {
+            context.handle_winit_event(event, control_flow)
+        },
+    )
 }

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -1,0 +1,278 @@
+use crate::{
+    mouse,
+    program::{Program, State},
+    Application, Executor, Mode, Runtime, Size,
+};
+use glutin::{
+    event::Event,
+    event_loop::{ControlFlow, EventLoop},
+    ContextBuilder, PossiblyCurrent, WindowedContext,
+};
+use iced_graphics::window::GLCompositor;
+use iced_graphics::Viewport;
+use iced_winit::conversion;
+use iced_winit::{Clipboard, Debug, Proxy, Settings};
+
+/// Information needed for `iced_glutin` to run.
+#[allow(missing_debug_implementations)]
+pub struct Context<A, E, C, Message>
+where
+    A: Application + 'static,
+    E: Executor + 'static,
+    C: GLCompositor<Renderer = A::Renderer> + 'static,
+    Message: std::fmt::Debug + Send + 'static,
+{
+    runtime: Runtime<E, Proxy<Message>, Message>,
+    title: String,
+    mode: Mode,
+    debug: Debug,
+    compositor: C,
+    renderer: A::Renderer,
+    gl_context: WindowedContext<PossiblyCurrent>,
+    clipboard: Option<Clipboard>,
+    mouse_interaction: mouse::Interaction,
+    modifiers: glutin::event::ModifiersState,
+    viewport: Viewport,
+    resized: bool,
+    state: State<A>,
+}
+
+impl<A, E, C, Message> Context<A, E, C, Message>
+where
+    A: Application + Program<Message = Message> + 'static,
+    E: Executor + 'static,
+    C: GLCompositor<Renderer = A::Renderer> + 'static,
+    Message: std::fmt::Debug + Send + 'static,
+{
+    /// Initializes and returns an `iced::glutin` application context.
+    pub fn new(
+        event_loop: &mut EventLoop<A::Message>,
+        settings: Settings<A::Flags>,
+        compositor_settings: C::Settings,
+    ) -> Self {
+        let mut debug = Debug::new();
+        debug.startup_started();
+
+        let mut runtime = {
+            let executor = E::new().expect("Create executor");
+            let proxy = Proxy::new(event_loop.create_proxy());
+
+            Runtime::new(executor, proxy)
+        };
+
+        let flags = settings.flags;
+        let (application, init_command) = runtime.enter(|| A::new(flags));
+        runtime.spawn(init_command);
+
+        let subscription = application.subscription();
+        runtime.track(subscription);
+
+        let title = application.title();
+        let mode = application.mode();
+
+        let gl_context = {
+            let builder = settings.window.into_builder(
+                &title,
+                mode,
+                event_loop.primary_monitor(),
+            );
+
+            let gl_context =
+                ContextBuilder::new()
+                    .with_vsync(true)
+                    .with_multisampling(
+                        C::sample_count(&compositor_settings) as u16
+                    )
+                    .build_windowed(builder, &event_loop)
+                    .expect("Open window");
+
+            #[allow(unsafe_code)]
+            unsafe {
+                gl_context
+                    .make_current()
+                    .expect("Make OpenGL context current")
+            }
+        };
+
+        let clipboard = Clipboard::new(&gl_context.window());
+        let mouse_interaction = mouse::Interaction::default();
+        let modifiers = glutin::event::ModifiersState::default();
+
+        let physical_size = gl_context.window().inner_size();
+        let viewport = Viewport::with_physical_size(
+            Size::new(physical_size.width, physical_size.height),
+            gl_context.window().scale_factor(),
+        );
+        let resized = false;
+
+        #[allow(unsafe_code)]
+        let (compositor, mut renderer) = unsafe {
+            C::new(compositor_settings, |address| {
+                gl_context.get_proc_address(address)
+            })
+        };
+
+        let state = State::new(
+            application,
+            viewport.logical_size(),
+            &mut renderer,
+            &mut debug,
+        );
+        debug.startup_finished();
+
+        Self {
+            runtime,
+            title,
+            mode,
+            debug,
+            compositor,
+            renderer,
+            gl_context,
+            clipboard,
+            mouse_interaction,
+            modifiers,
+            viewport,
+            resized,
+            state,
+        }
+    }
+
+    /// Manages the `iced_glutin` application based on the `winit` event.
+    pub fn handle_winit_event<'e>(
+        &mut self,
+        event: Event<'e, A::Message>,
+        control_flow: &mut ControlFlow,
+    ) {
+        let Context {
+            runtime,
+            title,
+            mode,
+            debug,
+            compositor,
+            renderer,
+            gl_context,
+            clipboard,
+            mouse_interaction,
+            modifiers,
+            viewport,
+            resized,
+            state,
+        } = self;
+
+        match event {
+            Event::MainEventsCleared => {
+                let command = runtime.enter(|| {
+                    state.update(
+                        clipboard.as_ref().map(|c| c as _),
+                        viewport.logical_size(),
+                        renderer,
+                        debug,
+                    )
+                });
+
+                // If the application was updated
+                if let Some(command) = command {
+                    runtime.spawn(command);
+
+                    let program = state.program();
+
+                    // Update subscriptions
+                    let subscription = program.subscription();
+                    runtime.track(subscription);
+
+                    // Update window title
+                    let new_title = program.title();
+
+                    if title != &new_title {
+                        gl_context.window().set_title(&new_title);
+
+                        *title = new_title;
+                    }
+
+                    // Update window mode
+                    let new_mode = program.mode();
+
+                    if *mode != new_mode {
+                        gl_context.window().set_fullscreen(
+                            conversion::fullscreen(
+                                gl_context.window().current_monitor(),
+                                new_mode,
+                            ),
+                        );
+
+                        *mode = new_mode;
+                    }
+                }
+
+                gl_context.window().request_redraw();
+            }
+            Event::UserEvent(message) => {
+                state.queue_message(message);
+            }
+            Event::RedrawRequested(_) => {
+                debug.render_started();
+
+                if *resized {
+                    let physical_size = viewport.physical_size();
+
+                    gl_context.resize(glutin::dpi::PhysicalSize::new(
+                        physical_size.width,
+                        physical_size.height,
+                    ));
+
+                    compositor.resize_viewport(physical_size);
+
+                    *resized = false;
+                }
+
+                let new_mouse_interaction = compositor.draw(
+                    renderer,
+                    viewport,
+                    state.primitive(),
+                    &debug.overlay(),
+                );
+
+                gl_context.swap_buffers().expect("Swap buffers");
+
+                debug.render_finished();
+
+                if new_mouse_interaction != *mouse_interaction {
+                    gl_context.window().set_cursor_icon(
+                        conversion::mouse_interaction(new_mouse_interaction),
+                    );
+
+                    *mouse_interaction = new_mouse_interaction;
+                }
+
+                // TODO: Handle animations!
+                // Maybe we can use `ControlFlow::WaitUntil` for this.
+            }
+            Event::WindowEvent {
+                event: window_event,
+                ..
+            } => {
+                iced_winit::application::handle_window_event(
+                    &window_event,
+                    gl_context.window(),
+                    control_flow,
+                    modifiers,
+                    viewport,
+                    resized,
+                    debug,
+                );
+
+                if let Some(event) = conversion::window_event(
+                    &window_event,
+                    viewport.scale_factor(),
+                    *modifiers,
+                ) {
+                    state.queue_event(event.clone());
+                    runtime.broadcast(event);
+                }
+            }
+            _ => {
+                *control_flow = ControlFlow::Wait;
+            }
+        }
+    }
+}

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -14,10 +14,14 @@ pub use iced_native::*;
 
 pub mod application;
 
+mod context;
+
 pub use iced_winit::settings;
 pub use iced_winit::Mode;
 
 #[doc(no_inline)]
 pub use application::Application;
+#[doc(no_inline)]
+pub use context::Context;
 #[doc(no_inline)]
 pub use settings::Settings;

--- a/src/application.rs
+++ b/src/application.rs
@@ -210,7 +210,9 @@ pub trait Application: Sized {
     }
 }
 
-struct Instance<A: Application>(A);
+/// Backend specific instance newtype.
+#[allow(missing_debug_implementations)]
+pub struct Instance<A: Application>(pub A);
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<A> iced_winit::Program for Instance<A>

--- a/src/application.rs
+++ b/src/application.rs
@@ -174,6 +174,93 @@ pub trait Application: Sized {
         window::Mode::Windowed
     }
 
+    /// Initializes the application [`Context`].
+    ///
+    /// Use this method if you are managing the event loop. If you want `iced` to
+    /// manage the event loop, use the [`run`] method.
+    ///
+    /// # Parameters
+    ///
+    /// * `event_loop`: The event loop that will run the application.
+    ///
+    /// [`Application`]: trait.Application.html
+    /// [`Context`]: runtime/struct.Context.html
+    /// [`run`]: #method.run
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        not(feature = "glow"),
+        feature = "wgpu"
+    ))]
+    fn initialize(
+        event_loop: &mut crate::runtime::winit::event_loop::EventLoop<
+            Self::Message,
+        >,
+        settings: Settings<Self::Flags>,
+    ) -> crate::runtime::Context<
+        Instance<Self>,
+        Self::Executor,
+        crate::renderer::window::Compositor,
+        Self::Message,
+        crate::renderer::wgpu::SwapChain,
+    > {
+        let renderer_settings = crate::renderer::Settings {
+            default_font: settings.default_font,
+            antialiasing: if settings.antialiasing {
+                Some(crate::renderer::settings::Antialiasing::MSAAx4)
+            } else {
+                None
+            },
+            ..crate::renderer::Settings::default()
+        };
+
+        crate::runtime::Context::new(
+            event_loop,
+            settings.into(),
+            renderer_settings,
+        )
+    }
+
+    /// Initializes the application [`Context`].
+    ///
+    /// Use this method if you are managing the event loop. If you want `iced` to
+    /// manage the event loop, use the [`run`] method.
+    ///
+    /// # Parameters
+    ///
+    /// * `event_loop`: The event loop that will run the application.
+    ///
+    /// [`Application`]: trait.Application.html
+    /// [`Context`]: runtime/struct.Context.html
+    /// [`run`]: #method.run
+    #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
+    fn initialize(
+        event_loop: &mut crate::runtime::glutin::event_loop::EventLoop<
+            Self::Message,
+        >,
+        settings: Settings<Self::Flags>,
+    ) -> crate::runtime::Context<
+        Instance<Self>,
+        Self::Executor,
+        crate::renderer::window::Compositor,
+        Self::Message,
+    > {
+        let renderer_settings = crate::renderer::Settings {
+            default_font: settings.default_font,
+            antialiasing: if settings.antialiasing {
+                Some(crate::renderer::settings::Antialiasing::MSAAx4)
+            } else {
+                None
+            },
+            ..crate::renderer::Settings::default()
+        };
+
+        crate::runtime::Context::new(
+            event_loop,
+            settings.into(),
+            renderer_settings,
+        )
+    }
+
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ use iced_web as runtime;
 #[doc(no_inline)]
 pub use widget::*;
 
-pub use application::Application;
+pub use application::{Application, Instance};
 pub use element::Element;
 pub use executor::Executor;
 pub use sandbox::Sandbox;

--- a/winit/src/context.rs
+++ b/winit/src/context.rs
@@ -1,0 +1,260 @@
+use crate::{
+    conversion, mouse,
+    program::{Program, State},
+    winit::{self, event::Event, event_loop::ControlFlow, window::Window},
+    Application, Clipboard, Debug, Executor, Mode, Proxy, Runtime, Settings,
+    Size, Viewport,
+};
+use iced_graphics::window::Compositor;
+
+/// Information needed for `iced_winit` to run.
+#[allow(missing_debug_implementations)]
+pub struct Context<A, E, C, Message, SC>
+where
+    A: Application + 'static,
+    E: Executor + 'static,
+    C: Compositor<Renderer = A::Renderer, SwapChain = SC> + 'static,
+    Message: std::fmt::Debug + Send + 'static,
+{
+    runtime: Runtime<E, Proxy<Message>, Message>,
+    title: String,
+    mode: Mode,
+    debug: Debug,
+    compositor: C,
+    renderer: A::Renderer,
+    surface: C::Surface,
+    clipboard: Option<Clipboard>,
+    mouse_interaction: mouse::Interaction,
+    modifiers: winit::event::ModifiersState,
+    viewport: Viewport,
+    resized: bool,
+    swap_chain: SC,
+    state: State<A>,
+    window: Window,
+}
+
+impl<A, E, C, Message, SC> Context<A, E, C, Message, SC>
+where
+    A: Application + Program<Message = Message> + 'static,
+    E: Executor + 'static,
+    C: Compositor<Renderer = A::Renderer, SwapChain = SC> + 'static,
+    Message: std::fmt::Debug + Send + 'static,
+    SC: 'static,
+{
+    /// Initializes and returns an `iced_winit` application context.
+    pub fn new(
+        event_loop: &mut winit::event_loop::EventLoop<A::Message>,
+        settings: Settings<A::Flags>,
+        compositor_settings: C::Settings,
+    ) -> Self {
+        let mut debug = Debug::new();
+        debug.startup_started();
+
+        let mut runtime = {
+            let executor = E::new().expect("Create executor");
+            let proxy = Proxy::new(event_loop.create_proxy());
+
+            Runtime::new(executor, proxy)
+        };
+
+        let flags = settings.flags;
+        let (application, init_command) = runtime.enter(|| A::new(flags));
+        runtime.spawn(init_command);
+
+        let subscription = application.subscription();
+        runtime.track(subscription);
+
+        let title = application.title();
+        let mode = application.mode();
+
+        let window = settings
+            .window
+            .into_builder(&title, mode, event_loop.primary_monitor())
+            .build(&event_loop)
+            .expect("Open window");
+
+        let clipboard = Clipboard::new(&window);
+        let mouse_interaction = mouse::Interaction::default();
+        let modifiers = winit::event::ModifiersState::default();
+
+        let physical_size = window.inner_size();
+        let viewport = Viewport::with_physical_size(
+            Size::new(physical_size.width, physical_size.height),
+            window.scale_factor(),
+        );
+        let resized = false;
+
+        let (mut compositor, mut renderer) = C::new(compositor_settings);
+
+        let surface = compositor.create_surface(&window);
+
+        let swap_chain = compositor.create_swap_chain(
+            &surface,
+            physical_size.width,
+            physical_size.height,
+        );
+
+        let state = State::new(
+            application,
+            viewport.logical_size(),
+            &mut renderer,
+            &mut debug,
+        );
+        debug.startup_finished();
+
+        Self {
+            runtime,
+            title,
+            mode,
+            debug,
+            compositor,
+            renderer,
+            surface,
+            clipboard,
+            mouse_interaction,
+            modifiers,
+            viewport,
+            resized,
+            swap_chain,
+            state,
+            window,
+        }
+    }
+
+    /// Manages the `iced_winit` application based on the `winit` event.
+    pub fn handle_winit_event<'e>(
+        &mut self,
+        event: winit::event::Event<'e, A::Message>,
+        control_flow: &mut ControlFlow,
+    ) {
+        let Context {
+            runtime,
+            title,
+            mode,
+            debug,
+            compositor,
+            renderer,
+            surface,
+            clipboard,
+            mouse_interaction,
+            modifiers,
+            viewport,
+            resized,
+            swap_chain,
+            state,
+            window,
+        } = self;
+
+        match event {
+            Event::MainEventsCleared => {
+                let command = runtime.enter(|| {
+                    state.update(
+                        clipboard.as_ref().map(|c| c as _),
+                        viewport.logical_size(),
+                        renderer,
+                        debug,
+                    )
+                });
+
+                // If the application was updated
+                if let Some(command) = command {
+                    runtime.spawn(command);
+
+                    let program = state.program();
+
+                    // Update subscriptions
+                    let subscription = program.subscription();
+                    runtime.track(subscription);
+
+                    // Update window title
+                    let new_title = program.title();
+
+                    if *title != new_title {
+                        window.set_title(&new_title);
+
+                        *title = new_title;
+                    }
+
+                    // Update window mode
+                    let new_mode = program.mode();
+
+                    if *mode != new_mode {
+                        window.set_fullscreen(conversion::fullscreen(
+                            window.current_monitor(),
+                            new_mode,
+                        ));
+
+                        *mode = new_mode;
+                    }
+                }
+
+                window.request_redraw();
+            }
+            Event::UserEvent(message) => {
+                state.queue_message(message);
+            }
+            Event::RedrawRequested(_) => {
+                debug.render_started();
+
+                if *resized {
+                    let physical_size = viewport.physical_size();
+
+                    *swap_chain = compositor.create_swap_chain(
+                        &surface,
+                        physical_size.width,
+                        physical_size.height,
+                    );
+
+                    *resized = false;
+                }
+
+                let new_mouse_interaction = compositor.draw(
+                    renderer,
+                    swap_chain,
+                    &viewport,
+                    state.primitive(),
+                    &debug.overlay(),
+                );
+
+                debug.render_finished();
+
+                if *mouse_interaction != new_mouse_interaction {
+                    window.set_cursor_icon(conversion::mouse_interaction(
+                        new_mouse_interaction,
+                    ));
+
+                    *mouse_interaction = new_mouse_interaction;
+                }
+
+                // TODO: Handle animations!
+                // Maybe we can use `ControlFlow::WaitUntil` for this.
+            }
+            Event::WindowEvent {
+                event: window_event,
+                ..
+            } => {
+                crate::application::handle_window_event(
+                    &window_event,
+                    &window,
+                    control_flow,
+                    modifiers,
+                    viewport,
+                    resized,
+                    debug,
+                );
+
+                if let Some(event) = conversion::window_event(
+                    &window_event,
+                    viewport.scale_factor(),
+                    *modifiers,
+                ) {
+                    state.queue_event(event.clone());
+                    runtime.broadcast(event);
+                }
+            }
+            _ => {
+                *control_flow = ControlFlow::Wait;
+            }
+        }
+    }
+}

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -30,11 +30,13 @@ pub mod conversion;
 pub mod settings;
 
 mod clipboard;
+mod context;
 mod mode;
 mod proxy;
 
 pub use application::Application;
 pub use clipboard::Clipboard;
+pub use context::Context;
 pub use mode::Mode;
 pub use proxy::Proxy;
 pub use settings::Settings;


### PR DESCRIPTION
Initial approach for #313. This allows users to control the `event_loop`:

```rust
pub fn main() {
    let mut event_loop = EventLoop::with_user_event();
    let mut context =
        Events::initialize(&mut event_loop, Settings::default());

    event_loop.run(move |event, _, control_flow| {
        // users have control over `control_flow`
        // and can run other code as well

        context.handle_winit_event(event, control_flow);
    })
}
```

Todo:

* [ ] Re-export `EventLoop` from `iced_winit` / `iced_glutin`?
* [ ] Figure out what `Context` looks like for `wasm32`.
* [x] Cut down example?
* [ ] Update example screenshot
