### PR TITLE
Removed empty bind group from integration example

### DIFF
--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -3,17 +3,13 @@ use iced_winit::Color;
 
 pub struct Scene {
     pipeline: wgpu::RenderPipeline,
-    bind_group: wgpu::BindGroup,
 }
 
 impl Scene {
     pub fn new(device: &wgpu::Device) -> Scene {
-        let (pipeline, bind_group) = build_pipeline(device);
+        let pipeline = build_pipeline(device);
 
-        Scene {
-            pipeline,
-            bind_group,
-        }
+        Scene { pipeline }
     }
 
     pub fn clear<'a>(
@@ -45,14 +41,11 @@ impl Scene {
 
     pub fn draw<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
         render_pass.set_pipeline(&self.pipeline);
-        render_pass.set_bind_group(0, &self.bind_group, &[]);
         render_pass.draw(0..3, 0..1);
     }
 }
 
-fn build_pipeline(
-    device: &wgpu::Device,
-) -> (wgpu::RenderPipeline, wgpu::BindGroup) {
+fn build_pipeline(device: &wgpu::Device) -> wgpu::RenderPipeline {
     let vs = include_bytes!("shader/vert.spv");
     let fs = include_bytes!("shader/frag.spv");
 
@@ -64,21 +57,9 @@ fn build_pipeline(
         &wgpu::read_spirv(std::io::Cursor::new(&fs[..])).unwrap(),
     );
 
-    let bind_group_layout =
-        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: None,
-            bindings: &[],
-        });
-
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: None,
-        layout: &bind_group_layout,
-        bindings: &[],
-    });
-
     let pipeline_layout =
         device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            bind_group_layouts: &[&bind_group_layout],
+            bind_group_layouts: &[],
         });
 
     let pipeline =
@@ -116,5 +97,5 @@ fn build_pipeline(
             alpha_to_coverage_enabled: false,
         });
 
-    (pipeline, bind_group)
+    pipeline
 }


### PR DESCRIPTION
This makes the current integration example avoid validation errors (or possible crashes) from empty bind groups that come from https://github.com/gfx-rs/wgpu/issues/240.