### PR TITLE
Cursor Manipulation

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -696,8 +696,8 @@ impl State {
     /// 
     /// [`Cursor`]: struct.Cursor.html
     /// [`TextInput`]: struct.TextInput.html
-    pub fn move_cursor_to_end(&mut self) {
-        self.cursor.move_to(5000);
+    pub fn move_cursor_to_end(&mut self, value: &String) {
+        self.cursor.move_to(value.len());
     }
 }
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -696,8 +696,8 @@ impl State {
     ///
     /// [`Cursor`]: struct.Cursor.html
     /// [`TextInput`]: struct.TextInput.html
-    pub fn move_cursor_to_end(&mut self, value: &String) {
-        self.cursor.move_to(value.len());
+    pub fn move_cursor_to_end(&mut self) {
+        self.cursor.move_to(usize::MAX);
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to an arbitrary location.

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -683,6 +683,22 @@ impl State {
     pub fn cursor(&self) -> Cursor {
         self.cursor
     }
+
+    /// Moves the [`Cursor`] of the [`TextInput`] to the front of the input text.
+    /// 
+    /// [`Cursor`]: struct.Cursor.html
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn move_cursor_to_front(&mut self) {
+        self.cursor.move_to(0);
+    }
+
+    /// Moves the [`Cursor`] of the [`TextInput`] to the end of the input text.
+    /// 
+    /// [`Cursor`]: struct.Cursor.html
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn move_cursor_to_end(&mut self) {
+        self.cursor.move_to(5000);
+    }
 }
 
 // TODO: Reduce allocations

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -699,6 +699,14 @@ impl State {
     pub fn move_cursor_to_end(&mut self, value: &String) {
         self.cursor.move_to(value.len());
     }
+
+    /// Moves the [`Cursor`] of the [`TextInput`] to an arbitrary location.
+    /// 
+    /// [`Cursor`]: struct.Cursor.html
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn move_cursor_to(&mut self, position: usize) {
+        self.cursor.move_to(position);
+    }
 }
 
 // TODO: Reduce allocations

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -685,7 +685,7 @@ impl State {
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to the front of the input text.
-    /// 
+    ///
     /// [`Cursor`]: struct.Cursor.html
     /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to_front(&mut self) {
@@ -693,7 +693,7 @@ impl State {
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to the end of the input text.
-    /// 
+    ///
     /// [`Cursor`]: struct.Cursor.html
     /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to_end(&mut self, value: &String) {
@@ -701,7 +701,7 @@ impl State {
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to an arbitrary location.
-    /// 
+    ///
     /// [`Cursor`]: struct.Cursor.html
     /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to(&mut self, position: usize) {


### PR DESCRIPTION
This adds some cursor commands to text_input::State, allowing the text_input's cursor's location to be manipulated (as discussed in #388). It should be noted that this only manipulates the cursor's index, and not it's selection.

3 new commands are added:
move_cursor_to_front
move_cursor_to_end
move_cursor_to

The first two should be pretty self explanatory. The last one allows you to supply an arbitrary index, allowing the cursor to be moved into the middle of a word if needed.

One of the things I think could use some improvement is move_cursor_to_end. Right now, you have to supply a string in order to use it (it gets the length of that string, and then sets the cursor's index to the length). I would like it so no argument is required. I can't see a way around this unless we refactor text_input::State to include the text its currently editing, and I'm not sure if this change is wanted or even needed. Would like some feedback on that. If the way I've implemented is good enough, then that's ok too.