### PR TITLE
Calculated sweep_angle in call to lyon::geom::Arc was actually end_angle

### DIFF
--- a/graphics/src/widget/canvas/path/builder.rs
+++ b/graphics/src/widget/canvas/path/builder.rs
@@ -84,7 +84,7 @@ impl Builder {
             radii: math::Vector::new(arc.radii.x, arc.radii.y),
             x_rotation: math::Angle::radians(arc.rotation),
             start_angle: math::Angle::radians(arc.start_angle),
-            sweep_angle: math::Angle::radians(arc.end_angle),
+            sweep_angle: math::Angle::radians(arc.end_angle - arc.start_angle),
         };
 
         let _ = self.raw.move_to(arc.sample(0.0));


### PR DESCRIPTION
Fixes #400.

All tests pass, all other (2) uses of `end_angle` are correct.