### PR TITLE
Add `background_color` to `Application` and `Sandbox`

### DIFF
--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Backend, Renderer, Settings, Viewport};
+use crate::{Backend, Color, Renderer, Settings, Viewport};
 
 use core::ffi::c_void;
 use glow::HasContext;
@@ -20,8 +20,6 @@ impl iced_graphics::window::GLCompositor for Compositor {
         loader_function: impl FnMut(&str) -> *const c_void,
     ) -> (Self, Self::Renderer) {
         let gl = glow::Context::from_loader_function(loader_function);
-
-        gl.clear_color(1.0, 1.0, 1.0, 1.0);
 
         // Enable auto-conversion from/to sRGB
         gl.enable(glow::FRAMEBUFFER_SRGB);
@@ -60,12 +58,16 @@ impl iced_graphics::window::GLCompositor for Compositor {
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,
+        color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction {
         let gl = &self.gl;
 
+        let [r, g, b, a] = color.into_linear();
+
         unsafe {
+            gl.clear_color(r, g, b, a);
             gl.clear(glow::COLOR_BUFFER_BIT);
         }
 

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -47,6 +47,7 @@ pub fn run<A, E, C>(
 
     let mut title = application.title();
     let mut mode = application.mode();
+    let mut background_color = application.background_color();
 
     let context = {
         let builder = settings.window.into_builder(
@@ -138,6 +139,9 @@ pub fn run<A, E, C>(
 
                     mode = new_mode;
                 }
+
+                // Update background color
+                background_color = program.background_color();
             }
 
             context.window().request_redraw();
@@ -164,6 +168,7 @@ pub fn run<A, E, C>(
             let new_mouse_interaction = compositor.draw(
                 &mut renderer,
                 &viewport,
+                background_color,
                 state.primitive(),
                 &debug.overlay(),
             );

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -35,6 +35,6 @@ pub use transformation::Transformation;
 pub use viewport::Viewport;
 
 pub use iced_native::{
-    Background, Font, HorizontalAlignment, Point, Rectangle, Size, Vector,
-    VerticalAlignment,
+    Background, Color, Font, HorizontalAlignment, Point, Rectangle, Size,
+    Vector, VerticalAlignment,
 };

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::Viewport;
+use crate::{Color, Viewport};
 use iced_native::mouse;
 use raw_window_handle::HasRawWindowHandle;
 
@@ -49,6 +49,7 @@ pub trait Compositor: Sized {
         renderer: &mut Self::Renderer,
         swap_chain: &mut Self::SwapChain,
         viewport: &Viewport,
+        background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction;

--- a/graphics/src/window/gl_compositor.rs
+++ b/graphics/src/window/gl_compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Size, Viewport};
+use crate::{Color, Size, Viewport};
 use iced_native::mouse;
 
 use core::ffi::c_void;
@@ -61,6 +61,7 @@ pub trait GLCompositor: Sized {
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,
+        background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction;

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,4 +1,6 @@
-use crate::{window, Command, Element, Executor, Settings, Subscription};
+use crate::{
+    window, Color, Command, Element, Executor, Settings, Subscription,
+};
 
 /// An interactive cross-platform application.
 ///
@@ -174,6 +176,16 @@ pub trait Application: Sized {
         window::Mode::Windowed
     }
 
+    /// Returns the background color of the [`Application`].
+    ///
+    /// By default, it returns [`Color::WHITE`].
+    ///
+    /// [`Application`]: trait.Application.html
+    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
+    fn background_color(&self) -> Color {
+        Color::WHITE
+    }
+
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread
@@ -255,6 +267,10 @@ where
 
     fn subscription(&self) -> Subscription<Self::Message> {
         self.0.subscription()
+    }
+
+    fn background_color(&self) -> Color {
+        self.0.background_color()
     }
 }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,4 +1,6 @@
-use crate::{executor, Application, Command, Element, Settings, Subscription};
+use crate::{
+    executor, Application, Color, Command, Element, Settings, Subscription,
+};
 
 /// A sandboxed [`Application`].
 ///
@@ -124,6 +126,16 @@ pub trait Sandbox {
     /// [`Sandbox`]: trait.Sandbox.html
     fn view(&mut self) -> Element<'_, Self::Message>;
 
+    /// Returns the background color of the [`Sandbox`].
+    ///
+    /// By default, it returns [`Color::WHITE`].
+    ///
+    /// [`Application`]: trait.Application.html
+    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
+    fn background_color(&self) -> Color {
+        Color::WHITE
+    }
+
     /// Runs the [`Sandbox`].
     ///
     /// On native platforms, this method will take control of the current thread
@@ -168,5 +180,9 @@ where
 
     fn view(&mut self) -> Element<'_, T::Message> {
         T::view(self)
+    }
+
+    fn background_color(&self) -> Color {
+        T::background_color(self)
     }
 }

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! It contains a set of styles and stylesheets for most of the built-in
 //! widgets.
+pub use iced_core::{Background, Color};
+
 pub mod button;
 pub mod checkbox;
 pub mod container;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -36,7 +36,7 @@ mod backend;
 mod quad;
 mod text;
 
-pub use iced_graphics::{Antialiasing, Defaults, Primitive, Viewport};
+pub use iced_graphics::{Antialiasing, Color, Defaults, Primitive, Viewport};
 pub use wgpu;
 
 pub use backend::Backend;

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Backend, Renderer, Settings};
+use crate::{Backend, Color, Renderer, Settings};
 
 use iced_graphics::Viewport;
 use iced_native::{futures, mouse};
@@ -103,6 +103,7 @@ impl iced_graphics::window::Compositor for Compositor {
         renderer: &mut Self::Renderer,
         swap_chain: &mut Self::SwapChain,
         viewport: &Viewport,
+        background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction {
@@ -118,11 +119,15 @@ impl iced_graphics::window::Compositor for Compositor {
                 resolve_target: None,
                 load_op: wgpu::LoadOp::Clear,
                 store_op: wgpu::StoreOp::Store,
-                clear_color: wgpu::Color {
-                    r: 1.0,
-                    g: 1.0,
-                    b: 1.0,
-                    a: 1.0,
+                clear_color: {
+                    let [r, g, b, a] = background_color.into_linear();
+
+                    wgpu::Color {
+                        r: f64::from(r),
+                        g: f64::from(g),
+                        b: f64::from(b),
+                        a: f64::from(a),
+                    }
                 },
             }],
             depth_stencil_attachment: None,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -1,6 +1,6 @@
 //! Create interactive, native cross-platform applications.
 use crate::{
-    conversion, mouse, Clipboard, Command, Debug, Executor, Mode, Proxy,
+    conversion, mouse, Clipboard, Color, Command, Debug, Executor, Mode, Proxy,
     Runtime, Settings, Size, Subscription,
 };
 use iced_graphics::window;
@@ -73,6 +73,17 @@ pub trait Application: Program {
     fn mode(&self) -> Mode {
         Mode::Windowed
     }
+
+    /// Returns the background [`Color`] of the [`Application`].
+    ///
+    /// By default, it returns [`Color::WHITE`].
+    ///
+    /// [`Color`]: struct.Color.html
+    /// [`Application`]: trait.Application.html
+    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
+    fn background_color(&self) -> Color {
+        Color::WHITE
+    }
 }
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
@@ -112,6 +123,7 @@ pub fn run<A, E, C>(
 
     let mut title = application.title();
     let mut mode = application.mode();
+    let mut background_color = application.background_color();
 
     let window = settings
         .window
@@ -193,6 +205,9 @@ pub fn run<A, E, C>(
 
                     mode = new_mode;
                 }
+
+                // Update background color
+                background_color = program.background_color();
             }
 
             window.request_redraw();
@@ -219,6 +234,7 @@ pub fn run<A, E, C>(
                 &mut renderer,
                 &mut swap_chain,
                 &viewport,
+                background_color,
                 state.primitive(),
                 &debug.overlay(),
             );


### PR DESCRIPTION
Supersedes #371.

This PR adds a `background_color` method to the `Application` and `Sandbox` traits to control the default clear color of the underlying renderer. Like `title` and `mode`, the returned value can change at runtime.

/cc @myfreeweb 