### PR TITLE
Make default text size configurable in `Settings`

### DIFF
--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -18,6 +18,7 @@ pub struct Backend {
     quad_pipeline: quad::Pipeline,
     text_pipeline: text::Pipeline,
     triangle_pipeline: triangle::Pipeline,
+    default_text_size: u16,
 }
 
 impl Backend {
@@ -33,6 +34,7 @@ impl Backend {
             quad_pipeline,
             text_pipeline,
             triangle_pipeline,
+            default_text_size: settings.default_text_size,
         }
     }
 
@@ -191,6 +193,10 @@ impl iced_graphics::Backend for Backend {
 impl backend::Text for Backend {
     const ICON_FONT: Font = font::ICONS;
     const CHECKMARK_ICON: char = font::CHECKMARK_ICON;
+
+    fn default_size(&self) -> u16 {
+        self.default_text_size
+    }
 
     fn measure(
         &self,

--- a/glow/src/settings.rs
+++ b/glow/src/settings.rs
@@ -11,6 +11,11 @@ pub struct Settings {
     /// If `None` is provided, a default system font will be chosen.
     pub default_font: Option<&'static [u8]>,
 
+    /// The default size of text.
+    ///
+    /// By default, it will be set to 20.
+    pub default_text_size: u16,
+
     /// The antialiasing strategy that will be used for triangle primitives.
     pub antialiasing: Option<Antialiasing>,
 }
@@ -19,6 +24,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             default_font: None,
+            default_text_size: 20,
             antialiasing: None,
         }
     }

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -25,6 +25,9 @@ pub trait Text {
     /// [`ICON_FONT`]: #associatedconst.ICON_FONt
     const CHECKMARK_ICON: char;
 
+    /// Returns the default size of text.
+    fn default_size(&self) -> u16;
+
     /// Measures the text contents with the given size and font,
     /// returning the size of a laid out paragraph that fits in the provided
     /// bounds.

--- a/graphics/src/widget/text.rs
+++ b/graphics/src/widget/text.rs
@@ -20,7 +20,9 @@ where
 {
     type Font = Font;
 
-    const DEFAULT_SIZE: u16 = 20;
+    fn default_size(&self) -> u16 {
+        self.backend().default_size()
+    }
 
     fn measure(
         &self,

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -49,7 +49,9 @@ impl row::Renderer for Null {
 impl text::Renderer for Null {
     type Font = Font;
 
-    const DEFAULT_SIZE: u16 = 20;
+    fn default_size(&self) -> u16 {
+        20
+    }
 
     fn measure(
         &self,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -32,7 +32,7 @@ pub struct Checkbox<Message, Renderer: self::Renderer + text::Renderer> {
     width: Length,
     size: u16,
     spacing: u16,
-    text_size: u16,
+    text_size: Option<u16>,
     style: Renderer::Style,
 }
 
@@ -60,7 +60,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
             width: Length::Shrink,
             size: <Renderer as self::Renderer>::DEFAULT_SIZE,
             spacing: Renderer::DEFAULT_SPACING,
-            text_size: <Renderer as text::Renderer>::DEFAULT_SIZE,
+            text_size: None,
             style: Renderer::Style::default(),
         }
     }
@@ -93,7 +93,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     ///
     /// [`Checkbox`]: struct.Checkbox.html
     pub fn text_size(mut self, text_size: u16) -> Self {
-        self.text_size = text_size;
+        self.text_size = Some(text_size);
         self
     }
 
@@ -136,7 +136,7 @@ where
             .push(
                 Text::new(&self.label)
                     .width(self.width)
-                    .size(self.text_size),
+                    .size(self.text_size.unwrap_or(renderer.default_size())),
             )
             .layout(renderer, limits)
     }
@@ -181,7 +181,7 @@ where
             defaults,
             label_layout.bounds(),
             &self.label,
-            self.text_size,
+            self.text_size.unwrap_or(renderer.default_size()),
             Default::default(),
             None,
             HorizontalAlignment::Left,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -41,7 +41,7 @@ pub struct Radio<Message, Renderer: self::Renderer + text::Renderer> {
     width: Length,
     size: u16,
     spacing: u16,
-    text_size: u16,
+    text_size: Option<u16>,
     style: Renderer::Style,
 }
 
@@ -75,7 +75,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
             width: Length::Shrink,
             size: <Renderer as self::Renderer>::DEFAULT_SIZE,
             spacing: Renderer::DEFAULT_SPACING, //15
-            text_size: <Renderer as text::Renderer>::DEFAULT_SIZE,
+            text_size: None,
             style: Renderer::Style::default(),
         }
     }
@@ -108,7 +108,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     ///
     /// [`Radio`]: struct.Radio.html
     pub fn text_size(mut self, text_size: u16) -> Self {
-        self.text_size = text_size;
+        self.text_size = Some(text_size);
         self
     }
 
@@ -151,7 +151,7 @@ where
             .push(
                 Text::new(&self.label)
                     .width(self.width)
-                    .size(self.text_size),
+                    .size(self.text_size.unwrap_or(renderer.default_size())),
             )
             .layout(renderer, limits)
     }
@@ -194,7 +194,7 @@ where
             defaults,
             label_layout.bounds(),
             &self.label,
-            self.text_size,
+            self.text_size.unwrap_or(renderer.default_size()),
             Default::default(),
             None,
             HorizontalAlignment::Left,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -131,7 +131,7 @@ where
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
 
-        let size = self.size.unwrap_or(Renderer::DEFAULT_SIZE);
+        let size = self.size.unwrap_or(renderer.default_size());
 
         let bounds = limits.max();
 
@@ -154,7 +154,7 @@ where
             defaults,
             layout.bounds(),
             &self.content,
-            self.size.unwrap_or(Renderer::DEFAULT_SIZE),
+            self.size.unwrap_or(renderer.default_size()),
             self.font,
             self.color,
             self.horizontal_alignment,
@@ -187,10 +187,10 @@ pub trait Renderer: crate::Renderer {
     /// [`Text`]: struct.Text.html
     type Font: Default + Copy;
 
-    /// The default size of [`Text`].
+    /// Returns the default size of [`Text`].
     ///
     /// [`Text`]: struct.Text.html
-    const DEFAULT_SIZE: u16;
+    fn default_size(&self) -> u16;
 
     /// Measures the [`Text`] in the given bounds and returns the minimum
     /// boundaries that can fit the contents.

--- a/src/application.rs
+++ b/src/application.rs
@@ -202,6 +202,7 @@ pub trait Application: Sized {
         {
             let renderer_settings = crate::renderer::Settings {
                 default_font: settings.default_font,
+                default_text_size: settings.default_text_size,
                 antialiasing: if settings.antialiasing {
                     Some(crate::renderer::settings::Antialiasing::MSAAx4)
                 } else {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,7 @@
 use crate::window;
 
 /// The settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings<Flags> {
     /// The window settings.
     ///
@@ -22,6 +22,11 @@ pub struct Settings<Flags> {
     // TODO: Add `name` for web compatibility
     pub default_font: Option<&'static [u8]>,
 
+    /// The text size that will be used by default.
+    ///
+    /// The default value is 20.
+    pub default_text_size: u16,
+
     /// If set to true, the renderer will try to perform antialiasing for some
     /// primitives.
     ///
@@ -39,12 +44,28 @@ impl<Flags> Settings<Flags> {
     ///
     /// [`Application`]: ../trait.Application.html
     pub fn with_flags(flags: Flags) -> Self {
+        let default_settings = Settings::<()>::default();
+
         Self {
             flags,
-            // not using ..Default::default() struct update syntax since it is more permissive to
-            // allow initializing with flags without trait bound on Default
+            antialiasing: default_settings.antialiasing,
+            default_font: default_settings.default_font,
+            default_text_size: default_settings.default_text_size,
+            window: default_settings.window,
+        }
+    }
+}
+
+impl<Flags> Default for Settings<Flags>
+where
+    Flags: Default,
+{
+    fn default() -> Self {
+        Self {
+            flags: Default::default(),
             antialiasing: Default::default(),
             default_font: Default::default(),
+            default_text_size: 20,
             window: Default::default(),
         }
     }

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -24,6 +24,8 @@ pub struct Backend {
 
     #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
+
+    default_text_size: u16,
 }
 
 impl Backend {
@@ -50,6 +52,8 @@ impl Backend {
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
+
+            default_text_size: settings.default_text_size,
         }
     }
 
@@ -244,6 +248,10 @@ impl iced_graphics::Backend for Backend {
 impl backend::Text for Backend {
     const ICON_FONT: Font = font::ICONS;
     const CHECKMARK_ICON: char = font::CHECKMARK_ICON;
+
+    fn default_size(&self) -> u16 {
+        self.default_text_size
+    }
 
     fn measure(
         &self,

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -16,6 +16,11 @@ pub struct Settings {
     /// If `None` is provided, a default system font will be chosen.
     pub default_font: Option<&'static [u8]>,
 
+    /// The default size of text.
+    ///
+    /// By default, it will be set to 20.
+    pub default_text_size: u16,
+
     /// The antialiasing strategy that will be used for triangle primitives.
     pub antialiasing: Option<Antialiasing>,
 }
@@ -25,6 +30,7 @@ impl Default for Settings {
         Settings {
             format: wgpu::TextureFormat::Bgra8UnormSrgb,
             default_font: None,
+            default_text_size: 20,
             antialiasing: None,
         }
     }


### PR DESCRIPTION
This PR adds a `default_text_size` field to `Settings`, which can be used to change the default size of any text.

For backwards compatibility, the default value for this setting is `20`. However, we will eventually reduce it to `16` to achieve consistency with web browsers.