### PR TITLE
Add `scale_factor` to `Application` and `Sandbox`

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -48,6 +48,7 @@ pub fn run<A, E, C>(
     let mut title = application.title();
     let mut mode = application.mode();
     let mut background_color = application.background_color();
+    let mut scale_factor = application.scale_factor();
 
     let context = {
         let builder = settings.window.into_builder(
@@ -75,7 +76,7 @@ pub fn run<A, E, C>(
     let physical_size = context.window().inner_size();
     let mut viewport = Viewport::with_physical_size(
         Size::new(physical_size.width, physical_size.height),
-        context.window().scale_factor(),
+        context.window().scale_factor() * scale_factor,
     );
     let mut resized = false;
 
@@ -142,6 +143,20 @@ pub fn run<A, E, C>(
 
                 // Update background color
                 background_color = program.background_color();
+
+                // Update scale factor
+                let new_scale_factor = program.scale_factor();
+
+                if scale_factor != new_scale_factor {
+                    let size = context.window().inner_size();
+
+                    viewport = Viewport::with_physical_size(
+                        Size::new(size.width, size.height),
+                        context.window().scale_factor() * new_scale_factor,
+                    );
+
+                    scale_factor = new_scale_factor;
+                }
             }
 
             context.window().request_redraw();
@@ -195,6 +210,7 @@ pub fn run<A, E, C>(
             application::handle_window_event(
                 &window_event,
                 context.window(),
+                scale_factor,
                 control_flow,
                 &mut modifiers,
                 &mut viewport,

--- a/src/application.rs
+++ b/src/application.rs
@@ -186,6 +186,21 @@ pub trait Application: Sized {
         Color::WHITE
     }
 
+    /// Returns the scale factor of the [`Application`].
+    ///
+    /// It can be used to dynamically control the size of the UI at runtime
+    /// (i.e. zooming).
+    ///
+    /// For instance, a scale factor of `2.0` will make widgets twice as big,
+    /// while a scale factor of `0.5` will shrink them to half their size.
+    ///
+    /// By default, it returns `1.0`.
+    ///
+    /// [`Application`]: trait.Application.html
+    fn scale_factor(&self) -> f64 {
+        1.0
+    }
+
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread
@@ -271,6 +286,10 @@ where
 
     fn background_color(&self) -> Color {
         self.0.background_color()
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.0.scale_factor()
     }
 }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -130,10 +130,25 @@ pub trait Sandbox {
     ///
     /// By default, it returns [`Color::WHITE`].
     ///
-    /// [`Application`]: trait.Application.html
+    /// [`Sandbox`]: trait.Sandbox.html
     /// [`Color::WHITE`]: struct.Color.html#const.WHITE
     fn background_color(&self) -> Color {
         Color::WHITE
+    }
+
+    /// Returns the scale factor of the [`Sandbox`].
+    ///
+    /// It can be used to dynamically control the size of the UI at runtime
+    /// (i.e. zooming).
+    ///
+    /// For instance, a scale factor of `2.0` will make widgets twice as big,
+    /// while a scale factor of `0.5` will shrink them to half their size.
+    ///
+    /// By default, it returns `1.0`.
+    ///
+    /// [`Sandbox`]: trait.Sandbox.html
+    fn scale_factor(&self) -> f64 {
+        1.0
     }
 
     /// Runs the [`Sandbox`].
@@ -184,5 +199,9 @@ where
 
     fn background_color(&self) -> Color {
         T::background_color(self)
+    }
+
+    fn scale_factor(&self) -> f64 {
+        T::scale_factor(self)
     }
 }


### PR DESCRIPTION
This PR introduces a provided `scale_factor` method in the `Application` and `Sandbox` traits.

This new method can be used to dynamically control the size of the UI at runtime.