### PR TITLE
Relax the Clone bound on Message types

### DIFF
--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -61,7 +61,7 @@ impl Sandbox for Example {
             .push(
                 Button::new(&mut self.button_state, Text::new("Clear"))
                     .padding(8)
-                    .on_press(Message::Clear),
+                    .on_press(|| Message::Clear),
             )
             .into()
     }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -45,12 +45,12 @@ impl Sandbox for Counter {
             .align_items(Align::Center)
             .push(
                 Button::new(&mut self.increment_button, Text::new("Increment"))
-                    .on_press(Message::IncrementPressed),
+                    .on_press(|| Message::IncrementPressed),
             )
             .push(Text::new(self.value.to_string()).size(50))
             .push(
                 Button::new(&mut self.decrement_button, Text::new("Decrement"))
-                    .on_press(Message::DecrementPressed),
+                    .on_press(|| Message::DecrementPressed),
             )
             .into()
     }

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -100,7 +100,7 @@ impl Application for Example {
         let control: Element<_> = match self {
             Example::Idle { button } => {
                 Button::new(button, Text::new("Start the download!"))
-                    .on_press(Message::Download)
+                    .on_press(|| Message::Download)
                     .into()
             }
             Example::Finished { button } => Column::new()
@@ -109,7 +109,7 @@ impl Application for Example {
                 .push(Text::new("Download finished!"))
                 .push(
                     Button::new(button, Text::new("Start again"))
-                        .on_press(Message::Download),
+                        .on_press(|| Message::Download),
                 )
                 .into(),
             Example::Downloading { .. } => {
@@ -122,7 +122,7 @@ impl Application for Example {
                 .push(Text::new("Something went wrong :("))
                 .push(
                     Button::new(button, Text::new("Try again"))
-                        .on_press(Message::Download),
+                        .on_press(|| Message::Download),
                 )
                 .into(),
         };

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -757,12 +757,12 @@ impl Controls {
                     &mut self.toggle_button,
                     Text::new(if is_playing { "Pause" } else { "Play" }),
                 )
-                .on_press(Message::TogglePlayback)
+                .on_press(|| Message::TogglePlayback)
                 .style(style::Button),
             )
             .push(
                 Button::new(&mut self.next_button, Text::new("Next"))
-                    .on_press(Message::Next)
+                    .on_press(|| Message::Next)
                     .style(style::Button),
             );
 
@@ -795,7 +795,7 @@ impl Controls {
             )
             .push(
                 Button::new(&mut self.clear_button, Text::new("Clear"))
-                    .on_press(Message::Clear)
+                    .on_press(|| Message::Clear)
                     .style(style::Clear),
             )
             .into()

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -176,7 +176,7 @@ impl Content {
             )
             .width(Length::Fill)
             .padding(8)
-            .on_press(message)
+            .on_press(move || message)
             .style(style)
         };
 

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -88,13 +88,16 @@ impl Application for Pokedex {
                 .align_items(Align::End)
                 .push(pokemon.view())
                 .push(
-                    button(search, "Keep searching!").on_press(Message::Search),
+                    button(search, "Keep searching!")
+                        .on_press(|| Message::Search),
                 ),
             Pokedex::Errored { try_again, .. } => Column::new()
                 .spacing(20)
                 .align_items(Align::End)
                 .push(Text::new("Whoops! Something went wrong...").size(40))
-                .push(button(try_again, "Try again").on_press(Message::Search)),
+                .push(
+                    button(try_again, "Try again").on_press(|| Message::Search),
+                ),
         };
 
         Container::new(content)

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -117,12 +117,12 @@ impl Application for Stopwatch {
                 State::Ticking { .. } => ("Stop", style::Button::Destructive),
             };
 
-            button(&mut self.toggle, label, color).on_press(Message::Toggle)
+            button(&mut self.toggle, label, color).on_press(|| Message::Toggle)
         };
 
         let reset_button =
             button(&mut self.reset, "Reset", style::Button::Secondary)
-                .on_press(Message::Reset);
+                .on_press(|| Message::Reset);
 
         let controls = Row::new()
             .spacing(20)

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -78,7 +78,7 @@ impl Sandbox for Styling {
 
         let button = Button::new(&mut self.button, Text::new("Submit"))
             .padding(10)
-            .on_press(Message::ButtonPressed)
+            .on_press(|| Message::ButtonPressed)
             .style(self.theme);
 
         let slider = Slider::new(

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -161,7 +161,7 @@ impl Application for Todos {
                 )
                 .padding(15)
                 .size(30)
-                .on_submit(Message::CreateTask);
+                .on_submit(|| Message::CreateTask);
 
                 let controls = controls.view(&tasks, *filter);
                 let filtered_tasks =
@@ -296,7 +296,7 @@ impl Task {
                     .push(checkbox)
                     .push(
                         Button::new(edit_button, edit_icon())
-                            .on_press(TaskMessage::Edit)
+                            .on_press(|| TaskMessage::Edit)
                             .padding(10)
                             .style(style::Button::Icon),
                     )
@@ -312,7 +312,7 @@ impl Task {
                     &self.description,
                     TaskMessage::DescriptionEdited,
                 )
-                .on_submit(TaskMessage::FinishEdition)
+                .on_submit(|| TaskMessage::FinishEdition)
                 .padding(10);
 
                 Row::new()
@@ -327,7 +327,7 @@ impl Task {
                                 .push(delete_icon())
                                 .push(Text::new("Delete")),
                         )
-                        .on_press(TaskMessage::Delete)
+                        .on_press(|| TaskMessage::Delete)
                         .padding(10)
                         .style(style::Button::Destructive),
                     )
@@ -361,7 +361,9 @@ impl Controls {
                     selected: filter == current_filter,
                 });
 
-            button.on_press(Message::FilterChanged(filter)).padding(8)
+            button
+                .on_press(move || Message::FilterChanged(filter))
+                .padding(8)
         };
 
         Row::new()

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -63,7 +63,7 @@ impl Sandbox for Tour {
         if steps.has_previous() {
             controls = controls.push(
                 button(back_button, "Back")
-                    .on_press(Message::BackPressed)
+                    .on_press(|| Message::BackPressed)
                     .style(style::Button::Secondary),
             );
         }
@@ -73,7 +73,7 @@ impl Sandbox for Tour {
         if steps.can_continue() {
             controls = controls.push(
                 button(next_button, "Next")
-                    .on_press(Message::NextPressed)
+                    .on_press(|| Message::NextPressed)
                     .style(style::Button::Primary),
             );
         }


### PR DESCRIPTION
I've found that the `Clone` bound on `Message` types can be a hit to ergonomics, particularly when working with `Command`s.

Example: a typical fallible async function returns some form of `Result<_, Error>`. The standard approach to call such a function in iced seems to be:
```rust
Command::perform(async_method(), Message::VariantThatWrapsOutput)
```
and then handle the message in the view's `update()`.

However, most error types are not `Clone` (e.g., `std::io::Error`), so that future's output can't be wrapped in a Message directly and some mapping of the error to a clonable type is needed.

I've been going through the code in `iced_native` and from what I can see the `Clone` bound is only required by `TextInput` and `Button`, for code such as:
```rust
Event::Keyboard(keyboard::Event::Input {/* (...) */}) 
if self.state.is_focused => match key_code {
    keyboard::KeyCode::Enter => {
        if let Some(on_submit) = self.on_submit.clone() {
            messages.push(on_submit);
        }
    }
```

From what I understand the aim of this is to produce a new message on each key press. This PR proposes changing these fields from:
```rust
    on_submit: Option<Message>,
```
to
```rust
    on_submit: Option<Box<dyn Fn() -> Message>>,
```
i.e., lazily producing the Message variant. This allows us to get rid of the `Clone` bound.

I've opened this as a draft to hear your thoughts first. I haven't adjusted documentation nor the web versions of `TextInput`/`Button`. What do you think?