### PR TITLE
Add `ModifiersChanged` to `keyboard::Event`

### DIFF
--- a/core/src/keyboard/event.rs
+++ b/core/src/keyboard/event.rs
@@ -28,4 +28,7 @@ pub enum Event {
 
     /// A unicode character was received.
     CharacterReceived(char),
+
+    /// The keyboard modifiers have changed.
+    ModifiersChanged(ModifiersState),
 }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -539,10 +539,8 @@ where
                                 }
                             }
                         }
-
-                        *self.pressed_modifiers = modifiers;
                     }
-                    keyboard::Event::KeyReleased { modifiers, .. } => {
+                    keyboard::Event::ModifiersChanged(modifiers) => {
                         *self.pressed_modifiers = modifiers;
                     }
                     _ => {}

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -92,6 +92,9 @@ pub fn window_event(
                 }
             }
         })),
+        WindowEvent::ModifiersChanged(new_modifiers) => Some(Event::Keyboard(
+            keyboard::Event::ModifiersChanged(modifiers_state(*new_modifiers)),
+        )),
         WindowEvent::HoveredFile(path) => {
             Some(Event::Window(window::Event::FileHovered(path.clone())))
         }


### PR DESCRIPTION
This PR introduces a `ModifiersChanged` variant to `keyboard::Event`.

This new event is produced when there is a change in the state of the modifier keys on a keyboard. Listening to this event is the correct way to combine keyboard modifiers with non-keyboard interactions.