### PR TITLE
Splits iterator for `PaneGrid` and minor improvements

### DIFF
--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -288,7 +288,7 @@ impl<'a, Message, Renderer> PaneGrid<'a, Message, Renderer> {
             if let Some((split, _)) = self.state.picked_split() {
                 let bounds = layout.bounds();
 
-                let splits = self.state.splits(
+                let splits = self.state.split_regions(
                     f32::from(self.spacing),
                     Size::new(bounds.width, bounds.height),
                 );
@@ -410,7 +410,7 @@ where
         let limits = limits.width(self.width).height(self.height);
         let size = limits.resolve(Size::ZERO);
 
-        let regions = self.state.regions(f32::from(self.spacing), size);
+        let regions = self.state.pane_regions(f32::from(self.spacing), size);
 
         let children = self
             .elements
@@ -453,7 +453,7 @@ where
                                     cursor_position.y - bounds.y,
                                 );
 
-                                let splits = self.state.splits(
+                                let splits = self.state.split_regions(
                                     f32::from(self.spacing),
                                     Size::new(bounds.width, bounds.height),
                                 );
@@ -590,7 +590,7 @@ where
 
                     let splits = self
                         .state
-                        .splits(f32::from(self.spacing), bounds.size());
+                        .split_regions(f32::from(self.spacing), bounds.size());
 
                     hovered_split(
                         splits.iter(),

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -273,8 +273,6 @@ impl<'a, Message, Renderer> PaneGrid<'a, Message, Renderer> {
                     self.state.focus(pane);
                 }
             }
-        } else {
-            self.state.unfocus();
         }
     }
 
@@ -482,6 +480,8 @@ where
                                 );
                             }
                         }
+                    } else {
+                        self.state.unfocus();
                     }
                 }
                 mouse::Event::ButtonReleased(mouse::Button::Left) => {

--- a/native/src/widget/pane_grid/node.rs
+++ b/native/src/widget/pane_grid/node.rs
@@ -43,6 +43,30 @@ pub enum Node {
 }
 
 impl Node {
+    /// Returns an iterator over each [`Split`] in this [`Node`].
+    ///
+    /// [`Split`]: struct.Split.html
+    /// [`Node`]: enum.Node.html
+    pub fn splits(&self) -> impl Iterator<Item = &Split> {
+        let mut unvisited_nodes = vec![self];
+
+        std::iter::from_fn(move || {
+            while let Some(node) = unvisited_nodes.pop() {
+                match node {
+                    Node::Split { id, a, b, .. } => {
+                        unvisited_nodes.push(a);
+                        unvisited_nodes.push(b);
+
+                        return Some(id);
+                    }
+                    _ => {}
+                }
+            }
+
+            None
+        })
+    }
+
     /// Returns the rectangular region for each [`Pane`] in the [`Node`] given
     /// the spacing between panes and the total available space.
     ///

--- a/native/src/widget/pane_grid/node.rs
+++ b/native/src/widget/pane_grid/node.rs
@@ -48,7 +48,7 @@ impl Node {
     ///
     /// [`Pane`]: struct.Pane.html
     /// [`Node`]: enum.Node.html
-    pub fn regions(
+    pub fn pane_regions(
         &self,
         spacing: f32,
         size: Size,
@@ -75,7 +75,7 @@ impl Node {
     ///
     /// [`Split`]: struct.Split.html
     /// [`Node`]: enum.Node.html
-    pub fn splits(
+    pub fn split_regions(
         &self,
         spacing: f32,
         size: Size,

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -193,6 +193,13 @@ impl<T> State<T> {
         self.internal.focus(pane);
     }
 
+    /// Unfocuses the current focused [`Pane`].
+    ///
+    /// [`Pane`]: struct.Pane.html
+    pub fn unfocus(&mut self) {
+        self.internal.unfocus();
+    }
+
     /// Splits the given [`Pane`] into two in the given [`Axis`] and
     /// initializing the new [`Pane`] with the provided internal state.
     ///

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -154,8 +154,10 @@ impl<T> State<T> {
     /// [`Pane`]: struct.Pane.html
     /// [`State::active`]: struct.State.html#method.active
     pub fn adjacent(&self, pane: &Pane, direction: Direction) -> Option<Pane> {
-        let regions =
-            self.internal.layout.regions(0.0, Size::new(4096.0, 4096.0));
+        let regions = self
+            .internal
+            .layout
+            .pane_regions(0.0, Size::new(4096.0, 4096.0));
 
         let current_region = regions.get(pane)?;
 
@@ -362,20 +364,20 @@ impl Internal {
         }
     }
 
-    pub fn regions(
+    pub fn pane_regions(
         &self,
         spacing: f32,
         size: Size,
     ) -> HashMap<Pane, Rectangle> {
-        self.layout.regions(spacing, size)
+        self.layout.pane_regions(spacing, size)
     }
 
-    pub fn splits(
+    pub fn split_regions(
         &self,
         spacing: f32,
         size: Size,
     ) -> HashMap<Split, (Axis, Rectangle, f32)> {
-        self.layout.splits(spacing, size)
+        self.layout.split_regions(spacing, size)
     }
 
     pub fn focus(&mut self, pane: &Pane) {


### PR DESCRIPTION
This PR:

- Renames `regions` and `splits` in `pane_grid::Node` to `pane_regions` and `split_regions`, respectively.
- Introduces a `splits` method in `pane_grid::Node` which returns an iterator over the splits in the `Node`.
- Fixes a bug introduced in #397, which caused unfocusing a `Pane` when clicking outside of the `PaneGrid` bounds to stop working.
- Adds an `unfocus` method to `pane_grid::State`.