### PR TITLE
Update `dodrio` in `iced_web`

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["web-programming"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dodrio = "0.1.0"
-wasm-bindgen = "0.2.51"
+dodrio = "0.2"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 url = "2.0"
 num-traits = "0.2"

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -238,28 +238,25 @@ struct Instance<A: Application> {
     bus: Bus<A::Message>,
 }
 
-impl<A> dodrio::Render for Instance<A>
+impl<'a, A> dodrio::Render<'a> for Instance<A>
 where
     A: Application,
 {
-    fn render<'a, 'bump>(
-        &'a self,
-        bump: &'bump bumpalo::Bump,
-    ) -> dodrio::Node<'bump>
-    where
-        'a: 'bump,
-    {
+    fn render(
+        &self,
+        context: &mut dodrio::RenderContext<'a>,
+    ) -> dodrio::Node<'a> {
         use dodrio::builder::*;
 
         let mut ui = self.application.borrow_mut();
         let element = ui.view();
         let mut css = Css::new();
 
-        let node = element.widget.node(bump, &self.bus, &mut css);
+        let node = element.widget.node(context.bump, &self.bus, &mut css);
 
-        div(bump)
+        div(context.bump)
             .attr("style", "width: 100%; height: 100%")
-            .children(vec![css.node(bump), node])
+            .children(vec![css.node(context.bump), node])
             .finish()
     }
 }

--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -154,16 +154,20 @@ where
             },
         };
 
+        let class = {
+            use dodrio::bumpalo::collections::String;
+
+            String::from_str_in(&padding_class, bump).into_bump_str()
+        };
+
         let mut node = button(bump)
-            .attr(
-                "class",
-                bumpalo::format!(in bump, "{}", padding_class).into_bump_str(),
-            )
+            .attr("class", class)
             .attr(
                 "style",
                 bumpalo::format!(
                     in bump,
-                    "background: {}; border-radius: {}px; width:{}; min-width: {}; color: {}",
+                    "background: {}; border-radius: {}px; width:{}; \
+                    min-width: {}; color: {}",
                     background,
                     style.border_radius,
                     css::length(self.width),

--- a/web/src/widget/checkbox.rs
+++ b/web/src/widget/checkbox.rs
@@ -94,9 +94,10 @@ where
         style_sheet: &mut Css<'b>,
     ) -> dodrio::Node<'b> {
         use dodrio::builder::*;
+        use dodrio::bumpalo::collections::String;
 
         let checkbox_label =
-            bumpalo::format!(in bump, "{}", self.label).into_bump_str();
+            String::from_str_in(&self.label, bump).into_bump_str();
 
         let event_bus = bus.clone();
         let on_toggle = self.on_toggle.clone();
@@ -107,7 +108,7 @@ where
         let spacing_class = style_sheet.insert(bump, css::Rule::Spacing(5));
 
         let (label, input) = if let Some(id) = &self.id {
-            let id = bumpalo::format!(in bump, "{}", id).into_bump_str();
+            let id = String::from_str_in(id, bump).into_bump_str();
 
             (label(bump).attr("for", id), input(bump).attr("id", id))
         } else {

--- a/web/src/widget/image.rs
+++ b/web/src/widget/image.rs
@@ -78,14 +78,19 @@ impl<Message> Widget<Message> for Image {
         _style_sheet: &mut Css<'b>,
     ) -> dodrio::Node<'b> {
         use dodrio::builder::*;
+        use dodrio::bumpalo::collections::String;
 
-        let src = bumpalo::format!(in bump, "{}", match self.handle.data.as_ref() {
-            Data::Path(path) => path.to_str().unwrap_or("")
-        });
-        let alt = bumpalo::format!(in bump, "{}", self.alt).into_bump_str();
+        let src = String::from_str_in(
+            match self.handle.data.as_ref() {
+                Data::Path(path) => path.to_str().unwrap_or(""),
+            },
+            bump,
+        )
+        .into_bump_str();
 
-        let mut image =
-            img(bump).attr("src", src.into_bump_str()).attr("alt", alt);
+        let alt = String::from_str_in(&self.alt, bump).into_bump_str();
+
+        let mut image = img(bump).attr("src", src).attr("alt", alt);
 
         match self.width {
             Length::Shrink => {}

--- a/web/src/widget/radio.rs
+++ b/web/src/widget/radio.rs
@@ -107,15 +107,16 @@ where
         _style_sheet: &mut Css<'b>,
     ) -> dodrio::Node<'b> {
         use dodrio::builder::*;
+        use dodrio::bumpalo::collections::String;
 
         let radio_label =
-            bumpalo::format!(in bump, "{}", self.label).into_bump_str();
+            String::from_str_in(&self.label, bump).into_bump_str();
 
         let event_bus = bus.clone();
         let on_click = self.on_click.clone();
 
         let (label, input) = if let Some(id) = &self.id {
-            let id = bumpalo::format!(in bump, "{}", id).into_bump_str();
+            let id = String::from_str_in(id, bump).into_bump_str();
 
             (label(bump).attr("for", id), input(bump).attr("id", id))
         } else {
@@ -123,7 +124,7 @@ where
         };
 
         let input = if let Some(name) = &self.name {
-            let name = bumpalo::format!(in bump, "{}", name).into_bump_str();
+            let name = String::from_str_in(name, bump).into_bump_str();
 
             dodrio::builder::input(bump).attr("name", name)
         } else {

--- a/web/src/widget/text.rs
+++ b/web/src/widget/text.rs
@@ -116,7 +116,12 @@ impl<'a, Message> Widget<Message> for Text {
     ) -> dodrio::Node<'b> {
         use dodrio::builder::*;
 
-        let content = bumpalo::format!(in bump, "{}", self.content);
+        let content = {
+            use dodrio::bumpalo::collections::String;
+
+            String::from_str_in(&self.content, bump)
+        };
+
         let color = self
             .color
             .map(css::color)
@@ -133,7 +138,8 @@ impl<'a, Message> Widget<Message> for Text {
 
         let style = bumpalo::format!(
             in bump,
-            "width: {}; height: {}; font-size: {}px; color: {}; text-align: {}; font-family: {}",
+            "width: {}; height: {}; font-size: {}px; color: {}; \
+            text-align: {}; font-family: {}",
             width,
             height,
             self.size.unwrap_or(20),

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -151,8 +151,26 @@ where
         use dodrio::builder::*;
         use wasm_bindgen::JsCast;
 
-        let padding_class =
-            style_sheet.insert(bump, css::Rule::Padding(self.padding));
+        let class = {
+            use dodrio::bumpalo::collections::String;
+
+            let padding_class =
+                style_sheet.insert(bump, css::Rule::Padding(self.padding));
+
+            String::from_str_in(&padding_class, bump).into_bump_str()
+        };
+
+        let placeholder = {
+            use dodrio::bumpalo::collections::String;
+
+            String::from_str_in(&self.placeholder, bump).into_bump_str()
+        };
+
+        let value = {
+            use dodrio::bumpalo::collections::String;
+
+            String::from_str_in(&self.value, bump).into_bump_str()
+        };
 
         let on_change = self.on_change.clone();
         let on_submit = self.on_submit.clone();
@@ -161,15 +179,14 @@ where
         let style = self.style_sheet.active();
 
         input(bump)
-            .attr(
-                "class",
-                bumpalo::format!(in bump, "{}", padding_class).into_bump_str(),
-            )
+            .attr("class", class)
             .attr(
                 "style",
                 bumpalo::format!(
                     in bump,
-                    "width: {}; max-width: {}; font-size: {}px; background: {}; border-width: {}px; border-color: {}; border-radius: {}px; color: {}",
+                    "width: {}; max-width: {}; font-size: {}px; \
+                    background: {}; border-width: {}px; border-color: {}; \
+                    border-radius: {}px; color: {}",
                     css::length(self.width),
                     css::max_length(self.max_width),
                     self.size.unwrap_or(20),
@@ -181,19 +198,9 @@ where
                 )
                 .into_bump_str(),
             )
-            .attr(
-                "placeholder",
-                bumpalo::format!(in bump, "{}", self.placeholder)
-                    .into_bump_str(),
-            )
-            .attr(
-                "value",
-                bumpalo::format!(in bump, "{}", self.value).into_bump_str(),
-            )
-            .attr(
-                "type",
-                bumpalo::format!(in bump, "{}", if self.is_secure { "password" } else { "text" }).into_bump_str(),
-            )
+            .attr("placeholder", placeholder)
+            .attr("value", value)
+            .attr("type", if self.is_secure { "password" } else { "text" })
             .on("input", move |_root, _vdom, event| {
                 let text_input = match event.target().and_then(|t| {
                     t.dyn_into::<web_sys::HtmlInputElement>().ok()
@@ -206,10 +213,13 @@ where
             })
             .on("keypress", move |_root, _vdom, event| {
                 if let Some(on_submit) = on_submit.clone() {
-                    let event = event.unchecked_into::<web_sys::KeyboardEvent>();
+                    let event =
+                        event.unchecked_into::<web_sys::KeyboardEvent>();
 
                     match event.key_code() {
-                        13 => { submit_event_bus.publish(on_submit); }
+                        13 => {
+                            submit_event_bus.publish(on_submit);
+                        }
                         _ => {}
                     }
                 }


### PR DESCRIPTION
This PR updates the `dodrio` dependency in `iced_web` to `0.2` and replaces `bumpalo::format!` with `String::from_str_in` where possible.