### PR TITLE
Title bar support for `PaneGrid`

### DIFF
--- a/examples/pane_grid/README.md
+++ b/examples/pane_grid/README.md
@@ -15,8 +15,8 @@ This example showcases the `PaneGrid` widget, which features:
 The __[`main`]__ file contains all the code of the example.
 
 <div align="center">
-  <a href="https://gfycat.com/mixedflatjellyfish">
-    <img src="https://thumbs.gfycat.com/MixedFlatJellyfish-small.gif">
+  <a href="https://gfycat.com/frailfreshairedaleterrier">
+    <img src="https://thumbs.gfycat.com/FrailFreshAiredaleterrier-small.gif">
   </a>
 </div>
 

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -97,7 +97,7 @@ impl Sandbox for Example {
 
         let pane_grid =
             PaneGrid::new(&mut self.panes, |pane, content, focus| {
-                content.view(pane, focus, total_panes)
+                pane_grid::Content::new(content.view(pane, focus, total_panes))
             })
             .width(Length::Fill)
             .height(Length::Fill)

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -97,16 +97,15 @@ impl Sandbox for Example {
 
         let pane_grid =
             PaneGrid::new(&mut self.panes, |pane, content, focus| {
+                let is_focused = focus.is_some();
                 let title_bar =
                     pane_grid::TitleBar::new(format!("Pane {}", content.id))
                         .padding(10)
-                        .style(style::TitleBar { focus });
+                        .style(style::TitleBar { is_focused });
 
                 pane_grid::Content::new(content.view(pane, total_panes))
                     .title_bar(title_bar)
-                    .style(style::Pane {
-                        is_focused: focus.is_some(),
-                    })
+                    .style(style::Pane { is_focused })
             })
             .width(Length::Fill)
             .height(Length::Fill)
@@ -229,7 +228,7 @@ impl Content {
 }
 
 mod style {
-    use iced::{button, container, pane_grid, Background, Color, Vector};
+    use iced::{button, container, Background, Color, Vector};
 
     const SURFACE: Color = Color::from_rgb(
         0xF2 as f32 / 255.0,
@@ -250,13 +249,13 @@ mod style {
     );
 
     pub struct TitleBar {
-        pub focus: Option<pane_grid::Focus>,
+        pub is_focused: bool,
     }
 
     impl container::StyleSheet for TitleBar {
         fn style(&self) -> container::Style {
             let pane = Pane {
-                is_focused: self.focus.is_some(),
+                is_focused: self.is_focused,
             }
             .style();
 

--- a/glow/src/widget/pane_grid.rs
+++ b/glow/src/widget/pane_grid.rs
@@ -11,8 +11,8 @@
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
-    Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
-    Node, Pane, ResizeEvent, Split, State,
+    Axis, Configuration, Direction, DragEvent, Focus, KeyPressEvent, Node,
+    Pane, ResizeEvent, Split, State,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -22,3 +22,15 @@ pub use iced_native::pane_grid::{
 ///
 /// This is an alias of an `iced_native` pane grid with an `iced_wgpu::Renderer`.
 pub type PaneGrid<'a, Message> = iced_native::PaneGrid<'a, Message, Renderer>;
+
+/// The content of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type Content<'a, Message> =
+    iced_native::pane_grid::Content<'a, Message, Renderer>;
+
+/// The title bar of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type TitleBar<'a, Message> =
+    iced_native::pane_grid::TitleBar<'a, Message, Renderer>;

--- a/glow/src/widget/pane_grid.rs
+++ b/glow/src/widget/pane_grid.rs
@@ -11,8 +11,8 @@
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
-    Axis, Content, Direction, DragEvent, Focus, KeyPressEvent, Node, Pane,
-    ResizeEvent, Split, State,
+    Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
+    Node, Pane, ResizeEvent, Split, State,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits

--- a/graphics/src/widget/container.rs
+++ b/graphics/src/widget/container.rs
@@ -39,20 +39,10 @@ where
         let (content, mouse_interaction) =
             content.draw(self, &defaults, content_layout, cursor_position);
 
-        if style.background.is_some() || style.border_width > 0 {
-            let quad = Primitive::Quad {
-                bounds,
-                background: style
-                    .background
-                    .unwrap_or(Background::Color(Color::TRANSPARENT)),
-                border_radius: style.border_radius,
-                border_width: style.border_width,
-                border_color: style.border_color,
-            };
-
+        if let Some(background) = background(bounds, &style) {
             (
                 Primitive::Group {
-                    primitives: vec![quad, content],
+                    primitives: vec![background, content],
                 },
                 mouse_interaction,
             )
@@ -60,4 +50,23 @@ where
             (content, mouse_interaction)
         }
     }
+}
+
+pub(crate) fn background(
+    bounds: Rectangle,
+    style: &container::Style,
+) -> Option<Primitive> {
+    if style.background.is_none() && style.border_width > 0 {
+        return None;
+    }
+
+    Some(Primitive::Quad {
+        bounds,
+        background: style
+            .background
+            .unwrap_or(Background::Color(Color::TRANSPARENT)),
+        border_radius: style.border_radius,
+        border_width: style.border_width,
+        border_color: style.border_color,
+    })
 }

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -8,10 +8,15 @@
 //!
 //! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
 //! [`PaneGrid`]: type.PaneGrid.html
-use crate::{Backend, Primitive, Renderer};
+use crate::backend::{self, Backend};
+use crate::{Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::pane_grid;
-use iced_native::{Element, Layout, Point, Rectangle, Vector};
+use iced_native::text;
+use iced_native::{
+    Element, HorizontalAlignment, Layout, Point, Rectangle, Vector,
+    VerticalAlignment,
+};
 
 pub use iced_native::pane_grid::{
     Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
@@ -29,7 +34,7 @@ pub type PaneGrid<'a, Message, Backend> =
 
 impl<B> pane_grid::Renderer for Renderer<B>
 where
-    B: Backend,
+    B: Backend + backend::Text,
 {
     fn draw<Message>(
         &mut self,
@@ -189,17 +194,28 @@ where
         defaults: &Self::Defaults,
         bounds: Rectangle,
         style_sheet: &Self::Style,
-        title: (&Element<'_, Message, Self>, Layout<'_>),
+        title: &str,
+        title_size: u16,
+        title_font: Self::Font,
+        title_bounds: Rectangle,
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
     ) -> Self::Output {
         let style = style_sheet.style();
-        let (title, title_layout) = title;
 
         let background = crate::widget::container::background(bounds, &style);
 
-        let (title_primitive, _) =
-            title.draw(self, defaults, title_layout, cursor_position);
+        let (title_primitive, _) = text::Renderer::draw(
+            self,
+            defaults,
+            title_bounds,
+            title,
+            title_size,
+            title_font,
+            None,
+            HorizontalAlignment::Left,
+            VerticalAlignment::Top,
+        );
 
         if let Some((controls, controls_layout)) = controls {
             let (controls_primitive, controls_interaction) =

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -148,8 +148,8 @@ where
 
         if let Some((title_bar, title_bar_layout)) = title_bar {
             let show_controls = bounds.contains(cursor_position);
-            let is_over_draggable =
-                title_bar.is_over_draggable(title_bar_layout, cursor_position);
+            let is_over_pick_area =
+                title_bar.is_over_pick_area(title_bar_layout, cursor_position);
 
             let (title_bar_primitive, title_bar_interaction) = title_bar.draw(
                 self,
@@ -167,7 +167,7 @@ where
                         body_primitive,
                     ],
                 },
-                if is_over_draggable {
+                if is_over_pick_area {
                     mouse::Interaction::Grab
                 } else if title_bar_interaction > body_interaction {
                     title_bar_interaction

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -14,8 +14,8 @@ use iced_native::pane_grid;
 use iced_native::{Element, Layout, Point, Rectangle, Vector};
 
 pub use iced_native::pane_grid::{
-    Axis, Direction, DragEvent, Focus, KeyPressEvent, Pane, ResizeEvent, Split,
-    State,
+    Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
+    Pane, ResizeEvent, Split, State, TitleBar,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -34,7 +34,7 @@ where
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,
-        content: &[(Pane, Element<'_, Message, Self>)],
+        content: &[(Pane, Content<'_, Message, Self>)],
         dragging: Option<Pane>,
         resizing: Option<Axis>,
         layout: Layout<'_>,
@@ -114,5 +114,16 @@ where
                 mouse_interaction
             },
         )
+    }
+
+    fn draw_pane<Message>(
+        &mut self,
+        defaults: &Self::Defaults,
+        _title_bar: Option<&TitleBar<'_, Message, Self>>,
+        body: &Element<'_, Message, Self>,
+        layout: Layout<'_>,
+        cursor_position: Point,
+    ) -> Self::Output {
+        body.draw(self, defaults, layout, cursor_position)
     }
 }

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -9,6 +9,7 @@
 //! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
 //! [`PaneGrid`]: type.PaneGrid.html
 use crate::backend::{self, Backend};
+use crate::defaults;
 use crate::{Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::pane_grid;
@@ -197,11 +198,17 @@ where
     ) -> Self::Output {
         let style = style_sheet.style();
 
+        let defaults = Self::Defaults {
+            text: defaults::Text {
+                color: style.text_color.unwrap_or(defaults.text.color),
+            },
+        };
+
         let background = crate::widget::container::background(bounds, &style);
 
         let (title_primitive, _) = text::Renderer::draw(
             self,
-            defaults,
+            &defaults,
             title_bounds,
             title,
             title_size,
@@ -212,8 +219,12 @@ where
         );
 
         if let Some((controls, controls_layout)) = controls {
-            let (controls_primitive, controls_interaction) =
-                controls.draw(self, defaults, controls_layout, cursor_position);
+            let (controls_primitive, controls_interaction) = controls.draw(
+                self,
+                &defaults,
+                controls_layout,
+                cursor_position,
+            );
 
             (
                 Primitive::Group {

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -82,12 +82,6 @@ where
             let pane = panes.remove(index);
             let bounds = layout.bounds();
 
-            if let Primitive::Group { primitives } = &pane {
-                panes.push(
-                    primitives.first().cloned().unwrap_or(Primitive::None),
-                );
-            }
-
             // TODO: Fix once proper layering is implemented.
             // This is a pretty hacky way to achieve layering.
             let clip = Primitive::Clip {

--- a/native/src/layout.rs
+++ b/native/src/layout.rs
@@ -34,7 +34,14 @@ impl<'a> Layout<'a> {
         }
     }
 
-    /// Gets the bounds of the [`Layout`].
+    /// Returns the position of the [`Layout`].
+    ///
+    /// [`Layout`]: struct.Layout.html
+    pub fn position(&self) -> Point {
+        self.position
+    }
+
+    /// Returns the bounds of the [`Layout`].
     ///
     /// The returned [`Rectangle`] describes the position and size of a
     /// [`Node`].

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -30,8 +30,8 @@
 //! [`Widget`]: widget/trait.Widget.html
 //! [`UserInterface`]: struct.UserInterface.html
 //! [renderer]: renderer/index.html
-//#![deny(missing_docs)]
-//#![deny(missing_debug_implementations)]
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -30,8 +30,8 @@
 //! [`Widget`]: widget/trait.Widget.html
 //! [`UserInterface`]: struct.UserInterface.html
 //! [renderer]: renderer/index.html
-#![deny(missing_docs)]
-#![deny(missing_debug_implementations)]
+//#![deny(missing_docs)]
+//#![deny(missing_debug_implementations)]
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -1,7 +1,7 @@
 use crate::{
-    button, checkbox, column, progress_bar, radio, row, scrollable, slider,
-    text, text_input, Color, Element, Font, HorizontalAlignment, Layout, Point,
-    Rectangle, Renderer, Size, VerticalAlignment,
+    button, checkbox, column, container, progress_bar, radio, row, scrollable,
+    slider, text, text_input, Color, Element, Font, HorizontalAlignment,
+    Layout, Point, Rectangle, Renderer, Size, VerticalAlignment,
 };
 
 /// A renderer that does nothing.
@@ -223,6 +223,21 @@ impl progress_bar::Renderer for Null {
         _range: std::ops::RangeInclusive<f32>,
         _value: f32,
         _style: &Self::Style,
+    ) {
+    }
+}
+
+impl container::Renderer for Null {
+    type Style = ();
+
+    fn draw<Message>(
+        &mut self,
+        _defaults: &Self::Defaults,
+        _bounds: Rectangle,
+        _cursor_position: Point,
+        _style: &Self::Style,
+        _content: &Element<'_, Message, Self>,
+        _content_layout: Layout<'_>,
     ) {
     }
 }

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -1,7 +1,8 @@
 use crate::{
-    button, checkbox, column, container, progress_bar, radio, row, scrollable,
-    slider, text, text_input, Color, Element, Font, HorizontalAlignment,
-    Layout, Point, Rectangle, Renderer, Size, VerticalAlignment,
+    button, checkbox, column, container, pane_grid, progress_bar, radio, row,
+    scrollable, slider, text, text_input, Color, Element, Font,
+    HorizontalAlignment, Layout, Point, Rectangle, Renderer, Size,
+    VerticalAlignment,
 };
 
 /// A renderer that does nothing.
@@ -238,6 +239,47 @@ impl container::Renderer for Null {
         _style: &Self::Style,
         _content: &Element<'_, Message, Self>,
         _content_layout: Layout<'_>,
+    ) {
+    }
+}
+
+impl pane_grid::Renderer for Null {
+    fn draw<Message>(
+        &mut self,
+        _defaults: &Self::Defaults,
+        _content: &[(pane_grid::Pane, pane_grid::Content<'_, Message, Self>)],
+        _dragging: Option<(pane_grid::Pane, Point)>,
+        _resizing: Option<pane_grid::Axis>,
+        _layout: Layout<'_>,
+        _cursor_position: Point,
+    ) {
+    }
+
+    fn draw_pane<Message>(
+        &mut self,
+        _defaults: &Self::Defaults,
+        _bounds: Rectangle,
+        _style: &Self::Style,
+        _title_bar: Option<(
+            &pane_grid::TitleBar<'_, Message, Self>,
+            Layout<'_>,
+        )>,
+        _body: (&Element<'_, Message, Self>, Layout<'_>),
+        _cursor_position: Point,
+    ) {
+    }
+
+    fn draw_title_bar<Message>(
+        &mut self,
+        _defaults: &Self::Defaults,
+        _bounds: Rectangle,
+        _style: &Self::Style,
+        _title: &str,
+        _title_size: u16,
+        _title_font: Self::Font,
+        _title_bounds: Rectangle,
+        _controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
+        _cursor_position: Point,
     ) {
     }
 }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -36,7 +36,7 @@ use crate::{
 /// A collection of panes distributed using either vertical or horizontal splits
 /// to completely fill the space available.
 ///
-/// [![Pane grid - Iced](https://thumbs.gfycat.com/MixedFlatJellyfish-small.gif)](https://gfycat.com/mixedflatjellyfish)
+/// [![Pane grid - Iced](https://thumbs.gfycat.com/FrailFreshAiredaleterrier-small.gif)](https://gfycat.com/frailfreshairedaleterrier)
 ///
 /// This distribution of space is common in tiling window managers (like
 /// [`awesome`](https://awesomewm.org/), [`i3`](https://i3wm.org/), or even

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -88,7 +88,6 @@ use crate::{
 #[allow(missing_debug_implementations)]
 pub struct PaneGrid<'a, Message, Renderer: self::Renderer> {
     state: &'a mut state::Internal,
-    pressed_modifiers: &'a mut keyboard::ModifiersState,
     elements: Vec<(Pane, Content<'a, Message, Renderer>)>,
     width: Length,
     height: Length,
@@ -143,7 +142,6 @@ where
 
         Self {
             state: &mut state.internal,
-            pressed_modifiers: &mut state.modifiers,
             elements,
             width: Length::Fill,
             height: Length::Fill,
@@ -557,9 +555,6 @@ where
                                 }
                             }
                         }
-                    }
-                    keyboard::Event::ModifiersChanged(modifiers) => {
-                        *self.pressed_modifiers = modifiers;
                     }
                     _ => {}
                 }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -29,8 +29,8 @@ pub use state::{Focus, State};
 pub use title_bar::TitleBar;
 
 use crate::{
-    container, keyboard, layout, mouse, row, Clipboard, Element, Event, Hasher,
-    Layout, Length, Point, Rectangle, Size, Widget,
+    container, keyboard, layout, mouse, row, text, Clipboard, Element, Event,
+    Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -86,7 +86,7 @@ use crate::{
 /// [`PaneGrid`]: struct.PaneGrid.html
 /// [`State`]: struct.State.html
 #[allow(missing_debug_implementations)]
-pub struct PaneGrid<'a, Message, Renderer: container::Renderer> {
+pub struct PaneGrid<'a, Message, Renderer: self::Renderer> {
     state: &'a mut state::Internal,
     pressed_modifiers: &'a mut keyboard::ModifiersState,
     elements: Vec<(Pane, Content<'a, Message, Renderer>)>,
@@ -101,7 +101,7 @@ pub struct PaneGrid<'a, Message, Renderer: container::Renderer> {
 
 impl<'a, Message, Renderer> PaneGrid<'a, Message, Renderer>
 where
-    Renderer: container::Renderer,
+    Renderer: self::Renderer,
 {
     /// Creates a [`PaneGrid`] with the given [`State`] and view function.
     ///
@@ -646,7 +646,9 @@ where
 ///
 /// [`PaneGrid`]: struct.PaneGrid.html
 /// [renderer]: ../../renderer/index.html
-pub trait Renderer: crate::Renderer + container::Renderer + Sized {
+pub trait Renderer:
+    crate::Renderer + container::Renderer + text::Renderer + Sized
+{
     /// Draws a [`PaneGrid`].
     ///
     /// It receives:
@@ -694,7 +696,10 @@ pub trait Renderer: crate::Renderer + container::Renderer + Sized {
         defaults: &Self::Defaults,
         bounds: Rectangle,
         style: &Self::Style,
-        title: (&Element<'_, Message, Self>, Layout<'_>),
+        title: &str,
+        title_size: u16,
+        title_font: Self::Font,
+        title_bounds: Rectangle,
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
     ) -> Self::Output;

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -182,8 +182,7 @@ where
 
     /// Sets the modifier keys of the [`PaneGrid`].
     ///
-    /// The modifier keys will need to be pressed to trigger dragging, and key
-    /// events.
+    /// The modifier keys will need to be pressed to trigger key events.
     ///
     /// The default modifier key is `Ctrl`.
     ///

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -30,7 +30,7 @@ pub use title_bar::TitleBar;
 
 use crate::{
     container, keyboard, layout, mouse, row, text, Clipboard, Element, Event,
-    Hasher, Layout, Length, Point, Rectangle, Size, Widget,
+    Hasher, Layout, Length, Point, Rectangle, Size, Vector, Widget,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -273,9 +273,12 @@ where
         if let Some(((pane, content), layout)) = clicked_region.next() {
             match &self.on_drag {
                 Some(on_drag) => {
-                    if let Some(origin) =
-                        content.drag_origin(layout, cursor_position)
-                    {
+                    if content.can_be_picked_at(layout, cursor_position) {
+                        let pane_position = layout.position();
+
+                        let origin = cursor_position
+                            - Vector::new(pane_position.x, pane_position.y);
+
                         self.state.pick_pane(pane, origin);
 
                         messages
@@ -693,6 +696,17 @@ pub trait Renderer:
         cursor_position: Point,
     ) -> Self::Output;
 
+    /// Draws a [`TitleBar`].
+    ///
+    /// It receives:
+    /// - the bounds, style of the [`TitleBar`]
+    /// - the style of the [`TitleBar`]
+    /// - the title of the [`TitleBar`] with its size, font, and bounds
+    /// - the controls of the [`TitleBar`] with their [`Layout`+, if any
+    /// - the cursor position
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
+    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw_title_bar<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/pane_grid/configuration.rs
+++ b/native/src/widget/pane_grid/configuration.rs
@@ -1,0 +1,30 @@
+use crate::pane_grid::Axis;
+
+/// The arrangement of a [`PaneGrid`].
+///
+/// [`PaneGrid`]: struct.PaneGrid.html
+#[derive(Debug, Clone)]
+pub enum Configuration<T> {
+    /// A split of the available space.
+    Split {
+        /// The direction of the split.
+        axis: Axis,
+
+        /// The ratio of the split in [0.0, 1.0].
+        ratio: f32,
+
+        /// The left/top [`Content`] of the split.
+        ///
+        /// [`Configuration`]: enum.Node.html
+        a: Box<Configuration<T>>,
+
+        /// The right/bottom [`Content`] of the split.
+        ///
+        /// [`Configuration`]: enum.Node.html
+        b: Box<Configuration<T>>,
+    },
+    /// A [`Pane`].
+    ///
+    /// [`Pane`]: struct.Pane.html
+    Pane(T),
+}

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -1,30 +1,88 @@
-use crate::pane_grid::Axis;
+use crate::layout;
+use crate::pane_grid::{self, TitleBar};
+use crate::{Clipboard, Element, Event, Hasher, Layout, Point};
 
-/// The content of a [`PaneGrid`].
+/// The content of a [`Pane`].
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
-#[derive(Debug, Clone)]
-pub enum Content<T> {
-    /// A split of the available space.
-    Split {
-        /// The direction of the split.
-        axis: Axis,
+/// [`Pane`]: struct.Pane.html
+pub struct Content<'a, Message, Renderer> {
+    title_bar: Option<TitleBar<'a, Message, Renderer>>,
+    body: Element<'a, Message, Renderer>,
+}
 
-        /// The ratio of the split in [0.0, 1.0].
-        ratio: f32,
+impl<'a, Message, Renderer> Content<'a, Message, Renderer> {
+    pub fn new(body: impl Into<Element<'a, Message, Renderer>>) -> Self {
+        Self {
+            title_bar: None,
+            body: body.into(),
+        }
+    }
 
-        /// The left/top [`Content`] of the split.
-        ///
-        /// [`Content`]: enum.Node.html
-        a: Box<Content<T>>,
+    pub fn title_bar(
+        mut self,
+        title_bar: TitleBar<'a, Message, Renderer>,
+    ) -> Self {
+        self.title_bar = Some(title_bar);
+        self
+    }
+}
 
-        /// The right/bottom [`Content`] of the split.
-        ///
-        /// [`Content`]: enum.Node.html
-        b: Box<Content<T>>,
-    },
-    /// A [`Pane`].
-    ///
-    /// [`Pane`]: struct.Pane.html
-    Pane(T),
+impl<'a, Message, Renderer> Content<'a, Message, Renderer>
+where
+    Renderer: pane_grid::Renderer,
+{
+    pub fn draw(
+        &self,
+        renderer: &mut Renderer,
+        defaults: &Renderer::Defaults,
+        layout: Layout<'_>,
+        cursor_position: Point,
+    ) -> Renderer::Output {
+        renderer.draw_pane(
+            defaults,
+            self.title_bar.as_ref(),
+            &self.body,
+            layout,
+            cursor_position,
+        )
+    }
+
+    pub(crate) fn is_over_drag_target(
+        &self,
+        _layout: Layout<'_>,
+        _cursor_position: Point,
+    ) -> bool {
+        false
+    }
+
+    pub(crate) fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.body.layout(renderer, limits)
+    }
+
+    pub(crate) fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        messages: &mut Vec<Message>,
+        renderer: &Renderer,
+        clipboard: Option<&dyn Clipboard>,
+    ) {
+        self.body.on_event(
+            event,
+            layout,
+            cursor_position,
+            messages,
+            renderer,
+            clipboard,
+        )
+    }
+
+    pub(crate) fn hash_layout(&self, state: &mut Hasher) {
+        self.body.hash_layout(state);
+    }
 }

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -1,11 +1,12 @@
 use crate::container;
 use crate::layout;
 use crate::pane_grid::{self, TitleBar};
-use crate::{Clipboard, Element, Event, Hasher, Layout, Point, Size, Vector};
+use crate::{Clipboard, Element, Event, Hasher, Layout, Point, Size};
 
 /// The content of a [`Pane`].
 ///
 /// [`Pane`]: struct.Pane.html
+#[allow(missing_debug_implementations)]
 pub struct Content<'a, Message, Renderer: pane_grid::Renderer> {
     title_bar: Option<TitleBar<'a, Message, Renderer>>,
     body: Element<'a, Message, Renderer>,
@@ -16,6 +17,9 @@ impl<'a, Message, Renderer> Content<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {
+    /// Creates a new [`Content`] with the provided body.
+    ///
+    /// [`Content`]: struct.Content.html
     pub fn new(body: impl Into<Element<'a, Message, Renderer>>) -> Self {
         Self {
             title_bar: None,
@@ -24,6 +28,10 @@ where
         }
     }
 
+    /// Sets the [`TitleBar`] of this [`Content`].
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
+    /// [`Content`]: struct.Content.html
     pub fn title_bar(
         mut self,
         title_bar: TitleBar<'a, Message, Renderer>,
@@ -45,6 +53,11 @@ impl<'a, Message, Renderer> Content<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {
+    /// Draws the [`Content`] with the provided [`Renderer`] and [`Layout`].
+    ///
+    /// [`Content`]: struct.Content.html
+    /// [`Renderer`]: trait.Renderer.html
+    /// [`Layout`]: ../layout/struct.Layout.html
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -77,24 +90,23 @@ where
         }
     }
 
-    pub fn drag_origin(
+    /// Returns whether the [`Content`] with the given [`Layout`] can be picked
+    /// at the provided cursor position.
+    ///
+    /// [`Content`]: struct.Content.html
+    /// [`Layout`]: ../layout/struct.Layout.html
+    pub fn can_be_picked_at(
         &self,
         layout: Layout<'_>,
         cursor_position: Point,
-    ) -> Option<Point> {
+    ) -> bool {
         if let Some(title_bar) = &self.title_bar {
             let mut children = layout.children();
             let title_bar_layout = children.next().unwrap();
 
-            if title_bar.is_over_draggable(title_bar_layout, cursor_position) {
-                let position = layout.position();
-
-                Some(cursor_position - Vector::new(position.x, position.y))
-            } else {
-                None
-            }
+            title_bar.is_over_pick_area(title_bar_layout, cursor_position)
         } else {
-            None
+            false
         }
     }
 

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -6,7 +6,7 @@ use crate::{Clipboard, Element, Event, Hasher, Layout, Point, Size, Vector};
 /// The content of a [`Pane`].
 ///
 /// [`Pane`]: struct.Pane.html
-pub struct Content<'a, Message, Renderer: container::Renderer> {
+pub struct Content<'a, Message, Renderer: pane_grid::Renderer> {
     title_bar: Option<TitleBar<'a, Message, Renderer>>,
     body: Element<'a, Message, Renderer>,
     style: Renderer::Style,
@@ -14,7 +14,7 @@ pub struct Content<'a, Message, Renderer: container::Renderer> {
 
 impl<'a, Message, Renderer> Content<'a, Message, Renderer>
 where
-    Renderer: container::Renderer,
+    Renderer: pane_grid::Renderer,
 {
     pub fn new(body: impl Into<Element<'a, Message, Renderer>>) -> Self {
         Self {
@@ -43,7 +43,7 @@ where
 
 impl<'a, Message, Renderer> Content<'a, Message, Renderer>
 where
-    Renderer: pane_grid::Renderer + container::Renderer,
+    Renderer: pane_grid::Renderer,
 {
     pub fn draw(
         &self,

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -1,5 +1,4 @@
 use crate::{
-    keyboard,
     pane_grid::{Axis, Configuration, Direction, Node, Pane, Split},
     Hasher, Point, Rectangle, Size,
 };
@@ -25,7 +24,6 @@ use std::collections::HashMap;
 pub struct State<T> {
     pub(super) panes: HashMap<Pane, T>,
     pub(super) internal: Internal,
-    pub(super) modifiers: keyboard::ModifiersState,
 }
 
 /// The current focus of a [`Pane`].
@@ -76,7 +74,6 @@ impl<T> State<T> {
                 last_id,
                 action: Action::Idle { focus: None },
             },
-            modifiers: keyboard::ModifiersState::default(),
         }
     }
 

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     keyboard,
-    pane_grid::{Axis, Content, Direction, Node, Pane, Split},
+    pane_grid::{Axis, Configuration, Direction, Node, Pane, Split},
     Hasher, Point, Rectangle, Size,
 };
 
@@ -53,18 +53,21 @@ impl<T> State<T> {
     /// [`State`]: struct.State.html
     /// [`Pane`]: struct.Pane.html
     pub fn new(first_pane_state: T) -> (Self, Pane) {
-        (Self::with_content(Content::Pane(first_pane_state)), Pane(0))
+        (
+            Self::with_configuration(Configuration::Pane(first_pane_state)),
+            Pane(0),
+        )
     }
 
-    /// Creates a new [`State`] with the given [`Content`].
+    /// Creates a new [`State`] with the given [`Configuration`].
     ///
     /// [`State`]: struct.State.html
-    /// [`Content`]: enum.Content.html
-    pub fn with_content(content: impl Into<Content<T>>) -> Self {
+    /// [`Configuration`]: enum.Configuration.html
+    pub fn with_configuration(config: impl Into<Configuration<T>>) -> Self {
         let mut panes = HashMap::new();
 
         let (layout, last_id) =
-            Self::distribute_content(&mut panes, content.into(), 0);
+            Self::distribute_content(&mut panes, config.into(), 0);
 
         State {
             panes,
@@ -274,11 +277,11 @@ impl<T> State<T> {
 
     fn distribute_content(
         panes: &mut HashMap<Pane, T>,
-        content: Content<T>,
+        content: Configuration<T>,
         next_id: usize,
     ) -> (Node, usize) {
         match content {
-            Content::Split { axis, ratio, a, b } => {
+            Configuration::Split { axis, ratio, a, b } => {
                 let (a, next_id) = Self::distribute_content(panes, *a, next_id);
                 let (b, next_id) = Self::distribute_content(panes, *b, next_id);
 
@@ -293,7 +296,7 @@ impl<T> State<T> {
                     next_id + 1,
                 )
             }
-            Content::Pane(state) => {
+            Configuration::Pane(state) => {
                 let id = Pane(next_id);
                 let _ = panes.insert(id, state);
 

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -313,13 +313,14 @@ pub struct Internal {
     action: Action,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Action {
     Idle {
         focus: Option<Pane>,
     },
     Dragging {
         pane: Pane,
+        origin: Point,
     },
     Resizing {
         split: Split,
@@ -334,7 +335,7 @@ impl Action {
             Action::Idle { focus } | Action::Resizing { focus, .. } => {
                 focus.map(|pane| (pane, Focus::Idle))
             }
-            Action::Dragging { pane } => Some((*pane, Focus::Dragging)),
+            Action::Dragging { pane, .. } => Some((*pane, Focus::Dragging)),
         }
     }
 }
@@ -351,9 +352,9 @@ impl Internal {
         }
     }
 
-    pub fn picked_pane(&self) -> Option<Pane> {
+    pub fn picked_pane(&self) -> Option<(Pane, Point)> {
         match self.action {
-            Action::Dragging { pane } => Some(pane),
+            Action::Dragging { pane, origin } => Some((pane, origin)),
             _ => None,
         }
     }
@@ -385,8 +386,11 @@ impl Internal {
         self.action = Action::Idle { focus: Some(*pane) };
     }
 
-    pub fn pick_pane(&mut self, pane: &Pane) {
-        self.action = Action::Dragging { pane: *pane };
+    pub fn pick_pane(&mut self, pane: &Pane, origin: Point) {
+        self.action = Action::Dragging {
+            pane: *pane,
+            origin,
+        };
     }
 
     pub fn pick_split(&mut self, split: &Split, axis: Axis) {

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -97,7 +97,7 @@ where
                 layout.bounds(),
                 &self.style,
                 &self.title,
-                self.title_size.unwrap_or(Renderer::DEFAULT_SIZE),
+                self.title_size.unwrap_or(renderer.default_size()),
                 Renderer::Font::default(),
                 title_bounds,
                 controls,
@@ -109,7 +109,7 @@ where
                 layout.bounds(),
                 &self.style,
                 &self.title,
-                self.title_size.unwrap_or(Renderer::DEFAULT_SIZE),
+                self.title_size.unwrap_or(renderer.default_size()),
                 Renderer::Font::default(),
                 padded.bounds(),
                 None,
@@ -150,7 +150,7 @@ where
         let limits = limits.pad(padding);
         let max_size = limits.max();
 
-        let title_size = self.title_size.unwrap_or(Renderer::DEFAULT_SIZE);
+        let title_size = self.title_size.unwrap_or(renderer.default_size());
         let title_font = Renderer::Font::default();
 
         let (title_width, title_height) = renderer.measure(

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -202,7 +202,7 @@ where
                 vec![title_layout, controls_layout],
             )
         } else {
-            layout::Node::new(Size::new(title_width, title_height))
+            layout::Node::new(Size::new(max_size.width, title_height))
         };
 
         node.move_to(Point::new(padding, padding));

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -1,6 +1,119 @@
-use crate::Element;
+use crate::container;
+use crate::layout;
+use crate::pane_grid;
+use crate::{Element, Layout, Point, Size};
 
-pub struct TitleBar<'a, Message, Renderer> {
-    title: String,
-    buttons: Option<Element<'a, Message, Renderer>>,
+pub struct TitleBar<'a, Message, Renderer: container::Renderer> {
+    title: Element<'a, Message, Renderer>,
+    controls: Option<Element<'a, Message, Renderer>>,
+    padding: u16,
+    style: Renderer::Style,
+}
+
+impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
+where
+    Renderer: container::Renderer,
+{
+    pub fn new(title: impl Into<Element<'a, Message, Renderer>>) -> Self {
+        Self {
+            title: title.into(),
+            controls: None,
+            padding: 0,
+            style: Renderer::Style::default(),
+        }
+    }
+
+    pub fn controls(
+        mut self,
+        controls: impl Into<Element<'a, Message, Renderer>>,
+    ) -> Self {
+        self.controls = Some(controls.into());
+        self
+    }
+
+    /// Sets the padding of the [`TitleBar`].
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
+    pub fn padding(mut self, units: u16) -> Self {
+        self.padding = units;
+        self
+    }
+}
+
+impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
+where
+    Renderer: pane_grid::Renderer,
+{
+    pub fn draw(
+        &self,
+        renderer: &mut Renderer,
+        defaults: &Renderer::Defaults,
+        layout: Layout<'_>,
+        cursor_position: Point,
+    ) -> Renderer::Output {
+        if let Some(controls) = &self.controls {
+            let mut children = layout.children();
+            let title_layout = children.next().unwrap();
+            let controls_layout = children.next().unwrap();
+
+            renderer.draw_title_bar(
+                defaults,
+                &self.style,
+                (&self.title, title_layout),
+                Some((controls, controls_layout)),
+                cursor_position,
+            )
+        } else {
+            renderer.draw_title_bar(
+                defaults,
+                &self.style,
+                (&self.title, layout),
+                None,
+                cursor_position,
+            )
+        }
+    }
+
+    pub(crate) fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let padding = f32::from(self.padding);
+        let limits = limits.pad(padding);
+
+        let mut node = if let Some(controls) = &self.controls {
+            let max_size = limits.max();
+
+            let title_layout = self
+                .title
+                .layout(renderer, &layout::Limits::new(Size::ZERO, max_size));
+
+            let title_size = title_layout.size();
+
+            let mut controls_layout = controls.layout(
+                renderer,
+                &layout::Limits::new(
+                    Size::ZERO,
+                    Size::new(
+                        max_size.width - title_size.width,
+                        max_size.height,
+                    ),
+                ),
+            );
+
+            controls_layout.move_to(Point::new(title_size.width, 0.0));
+
+            layout::Node::with_children(
+                max_size,
+                vec![title_layout, controls_layout],
+            )
+        } else {
+            self.title.layout(renderer, &limits)
+        };
+
+        node.move_to(Point::new(padding, padding));
+
+        node
+    }
 }

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -2,6 +2,10 @@ use crate::layout;
 use crate::pane_grid;
 use crate::{Clipboard, Element, Event, Layout, Point, Rectangle, Size};
 
+/// The title bar of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+#[allow(missing_debug_implementations)]
 pub struct TitleBar<'a, Message, Renderer: pane_grid::Renderer> {
     title: String,
     title_size: Option<u16>,
@@ -14,6 +18,9 @@ impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {
+    /// Cretes a new [`TitleBar`] with the given title.
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
     pub fn new(title: impl Into<String>) -> Self {
         Self {
             title: title.into(),
@@ -26,7 +33,7 @@ where
 
     /// Sets the size of the title of the [`TitleBar`].
     ///
-    /// [`TitleBar`]: struct.Text.html
+    /// [`TitleBar`]: struct.TitleBar.html
     pub fn title_size(mut self, size: u16) -> Self {
         self.title_size = Some(size);
         self
@@ -64,6 +71,11 @@ impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {
+    /// Draws the [`TitleBar`] with the provided [`Renderer`] and [`Layout`].
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
+    /// [`Renderer`]: trait.Renderer.html
+    /// [`Layout`]: ../layout/struct.Layout.html
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -118,7 +130,13 @@ where
         }
     }
 
-    pub fn is_over_draggable(
+    /// Returns whether the mouse cursor is over the pick area of the
+    /// [`TitleBar`] or not.
+    ///
+    /// The whole [`TitleBar`] is a pick area, except its controls.
+    ///
+    /// [`TitleBar`]: struct.TitleBar.html
+    pub fn is_over_pick_area(
         &self,
         layout: Layout<'_>,
         cursor_position: Point,

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -1,0 +1,6 @@
+use crate::Element;
+
+pub struct TitleBar<'a, Message, Renderer> {
+    title: String,
+    buttons: Option<Element<'a, Message, Renderer>>,
+}

--- a/wgpu/src/widget/pane_grid.rs
+++ b/wgpu/src/widget/pane_grid.rs
@@ -11,8 +11,8 @@
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
-    Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
-    Node, Pane, ResizeEvent, Split, State,
+    Axis, Configuration, Direction, DragEvent, Focus, KeyPressEvent, Node,
+    Pane, ResizeEvent, Split, State,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -22,3 +22,15 @@ pub use iced_native::pane_grid::{
 ///
 /// This is an alias of an `iced_native` pane grid with an `iced_wgpu::Renderer`.
 pub type PaneGrid<'a, Message> = iced_native::PaneGrid<'a, Message, Renderer>;
+
+/// The content of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type Content<'a, Message> =
+    iced_native::pane_grid::Content<'a, Message, Renderer>;
+
+/// The title bar of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type TitleBar<'a, Message> =
+    iced_native::pane_grid::TitleBar<'a, Message, Renderer>;

--- a/wgpu/src/widget/pane_grid.rs
+++ b/wgpu/src/widget/pane_grid.rs
@@ -11,8 +11,8 @@
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
-    Axis, Content, Direction, DragEvent, Focus, KeyPressEvent, Node, Pane,
-    ResizeEvent, Split, State,
+    Axis, Configuration, Content, Direction, DragEvent, Focus, KeyPressEvent,
+    Node, Pane, ResizeEvent, Split, State,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits


### PR DESCRIPTION
This PR introduces a new `TitleBar` type that can be used with the `PaneGrid` widget to plug a title bar to a pane.

When the drag and drop interaction is enabled, the `TitleBar` becomes the grabbing target. Therefore, now it is possible to completely control the layout of a `PaneGrid` solely with mouse clicks (i.e. no modifier keys necessary).

<div align="center">
  <a href="https://gfycat.com/frailfreshairedaleterrier">
    <img src="https://thumbs.gfycat.com/FrailFreshAiredaleterrier-small.gif">
  </a>
</div>