### PR TITLE
Fix panic on paste in TextInput after programmatic modification of contents

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -329,7 +329,7 @@ where
                 }
                 keyboard::KeyCode::Backspace => {
                     if platform::is_jump_modifier_pressed(modifiers)
-                        && self.state.cursor.selection().is_none()
+                        && self.state.cursor.selection(&self.value).is_none()
                     {
                         if self.is_secure {
                             let cursor_pos = self.state.cursor.end(&self.value);
@@ -349,7 +349,7 @@ where
                 }
                 keyboard::KeyCode::Delete => {
                     if platform::is_jump_modifier_pressed(modifiers)
-                        && self.state.cursor.selection().is_none()
+                        && self.state.cursor.selection(&self.value).is_none()
                     {
                         if self.is_secure {
                             let cursor_pos = self.state.cursor.end(&self.value);

--- a/native/src/widget/text_input/cursor.rs
+++ b/native/src/widget/text_input/cursor.rs
@@ -166,8 +166,8 @@ impl Cursor {
         end.min(value.len())
     }
 
-    pub(crate) fn selection(&self) -> Option<(usize, usize)> {
-        match self.state {
+    pub(crate) fn selection(&self, value: &Value) -> Option<(usize, usize)> {
+        match self.state(value) {
             State::Selection { start, end } => {
                 Some((start.min(end), start.max(end)))
             }

--- a/native/src/widget/text_input/editor.rs
+++ b/native/src/widget/text_input/editor.rs
@@ -15,12 +15,10 @@ impl<'a> Editor<'a> {
     }
 
     pub fn insert(&mut self, character: char) {
-        match self.cursor.selection() {
+        match self.cursor.selection(self.value) {
             Some((left, right)) => {
-                if left < self.value.len() {
-                    self.cursor.move_left(self.value);
-                    self.value.remove_many(left, right.min(self.value.len()));
-                }
+                self.cursor.move_left(self.value);
+                self.value.remove_many(left, right.min(self.value.len()));
             }
             _ => (),
         }
@@ -32,12 +30,10 @@ impl<'a> Editor<'a> {
     pub fn paste(&mut self, content: Value) {
         let length = content.len();
 
-        match self.cursor.selection() {
+        match self.cursor.selection(self.value) {
             Some((left, right)) => {
-                if left < self.value.len() {
-                    self.cursor.move_left(self.value);
-                    self.value.remove_many(left, right.min(self.value.len()));
-                }
+                self.cursor.move_left(self.value);
+                self.value.remove_many(left, right.min(self.value.len()));
             }
             _ => (),
         }
@@ -48,12 +44,10 @@ impl<'a> Editor<'a> {
     }
 
     pub fn backspace(&mut self) {
-        match self.cursor.selection() {
+        match self.cursor.selection(self.value) {
             Some((start, end)) => {
-                if start < self.value.len() {
-                    self.cursor.move_left(self.value);
-                    self.value.remove_many(start, end.min(self.value.len()));
-                }
+                self.cursor.move_left(self.value);
+                self.value.remove_many(start, end.min(self.value.len()));
             }
             None => {
                 let start = self.cursor.start(self.value);
@@ -67,7 +61,7 @@ impl<'a> Editor<'a> {
     }
 
     pub fn delete(&mut self) {
-        match self.cursor.selection() {
+        match self.cursor.selection(self.value) {
             Some(_) => {
                 self.backspace();
             }

--- a/native/src/widget/text_input/editor.rs
+++ b/native/src/widget/text_input/editor.rs
@@ -17,8 +17,10 @@ impl<'a> Editor<'a> {
     pub fn insert(&mut self, character: char) {
         match self.cursor.selection() {
             Some((left, right)) => {
-                self.cursor.move_left(self.value);
-                self.value.remove_many(left, right);
+                if left < self.value.len() {
+                    self.cursor.move_left(self.value);
+                    self.value.remove_many(left, right.min(self.value.len()));
+                }
             }
             _ => (),
         }
@@ -32,8 +34,10 @@ impl<'a> Editor<'a> {
 
         match self.cursor.selection() {
             Some((left, right)) => {
-                self.cursor.move_left(self.value);
-                self.value.remove_many(left, right);
+                if left < self.value.len() {
+                    self.cursor.move_left(self.value);
+                    self.value.remove_many(left, right.min(self.value.len()));
+                }
             }
             _ => (),
         }
@@ -46,8 +50,10 @@ impl<'a> Editor<'a> {
     pub fn backspace(&mut self) {
         match self.cursor.selection() {
             Some((start, end)) => {
-                self.cursor.move_left(self.value);
-                self.value.remove_many(start, end);
+                if start < self.value.len() {
+                    self.cursor.move_left(self.value);
+                    self.value.remove_many(start, end.min(self.value.len()));
+                }
             }
             None => {
                 let start = self.cursor.start(self.value);

--- a/native/src/widget/text_input/editor.rs
+++ b/native/src/widget/text_input/editor.rs
@@ -18,7 +18,7 @@ impl<'a> Editor<'a> {
         match self.cursor.selection(self.value) {
             Some((left, right)) => {
                 self.cursor.move_left(self.value);
-                self.value.remove_many(left, right.min(self.value.len()));
+                self.value.remove_many(left, right);
             }
             _ => (),
         }
@@ -33,7 +33,7 @@ impl<'a> Editor<'a> {
         match self.cursor.selection(self.value) {
             Some((left, right)) => {
                 self.cursor.move_left(self.value);
-                self.value.remove_many(left, right.min(self.value.len()));
+                self.value.remove_many(left, right);
             }
             _ => (),
         }
@@ -47,7 +47,7 @@ impl<'a> Editor<'a> {
         match self.cursor.selection(self.value) {
             Some((start, end)) => {
                 self.cursor.move_left(self.value);
-                self.value.remove_many(start, end.min(self.value.len()));
+                self.value.remove_many(start, end);
             }
             None => {
                 let start = self.cursor.start(self.value);


### PR DESCRIPTION
This fixes the panic mentioned in #443, where the end of the cursor selection might be larger than the length of the current input value.