### PR TITLE
[idea] iced_native: Add methods to tell if UI should capture events to help with integration

### DIFF
--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -17,12 +17,26 @@ where
     primitive: <P::Renderer as Renderer>::Output,
     queued_events: Vec<Event>,
     queued_messages: Vec<P::Message>,
+    is_wanting_mouse_events: bool,
+    has_focus: bool,
 }
 
 impl<P> State<P>
 where
     P: Program + 'static,
 {
+    /// Returns whether any widgets in this state is wanting mouse events, for
+    /// example when the cursor is over a widget or when the widget is
+    /// performing a dragging action.
+    pub fn is_wanting_mouse_events(&self) -> bool {
+        self.is_wanting_mouse_events
+    }
+
+    /// Returns whether any widgets in this state is receiving focus.
+    pub fn has_focus(&self) -> bool {
+        self.has_focus
+    }
+
     /// Creates a new [`State`] with the provided [`Program`], initializing its
     /// primitive with the given logical bounds and renderer.
     ///
@@ -55,6 +69,8 @@ where
             primitive,
             queued_events: Vec::new(),
             queued_messages: Vec::new(),
+            is_wanting_mouse_events: false,
+            has_focus: false,
         }
     }
 
@@ -136,6 +152,8 @@ where
             self.primitive = user_interface.draw(renderer, cursor_position);
             debug.draw_finished();
 
+            self.is_wanting_mouse_events = user_interface.is_wanting_mouse_events();
+            self.has_focus = user_interface.has_focus().unwrap_or(false);
             self.cache = Some(user_interface.into_cache());
 
             None
@@ -167,6 +185,8 @@ where
             self.primitive = user_interface.draw(renderer, cursor_position);
             debug.draw_finished();
 
+            self.is_wanting_mouse_events = user_interface.is_wanting_mouse_events();
+            self.has_focus = user_interface.has_focus().unwrap_or(false);
             self.cache = Some(user_interface.into_cache());
 
             Some(commands)

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -29,6 +29,14 @@ impl<'a, Message, Renderer> UserInterface<'a, Message, Renderer>
 where
     Renderer: crate::Renderer,
 {
+    pub(crate) fn is_wanting_mouse_events(&self) -> bool {
+        self.root.widget.is_wanting_mouse_events()
+    }
+
+    pub(crate) fn has_focus(&self) -> Option<bool> {
+        self.root.widget.has_focus()
+    }
+
     /// Builds a user interface for an [`Element`].
     ///
     /// It is able to avoid expensive computations when using a [`Cache`]

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -101,6 +101,23 @@ pub trait Widget<Message, Renderer>
 where
     Renderer: crate::Renderer,
 {
+    /// Returns whether this or any child widgets is wanting mouse events, for
+    /// example when the cursor is over the widget or when the widget is
+    /// performing a dragging action. Container widgets should return an
+    /// aggregated result by iterating through all child widgets.
+    fn is_wanting_mouse_events(&self) -> bool {
+        false
+    }
+
+    /// Returns whether this or any child widgets can receive and is receiving
+    /// focus. If this or any child widgets can receive focus, `Some(focused)`
+    /// is returned where `focused` indicates whether this or any child widgets
+    /// are focused, otherwise `None` is returned. Container widgets should
+    /// return an aggregated result by iterating through all child widgets.
+    fn has_focus(&self) -> Option<bool> {
+        None
+    }
+
     /// Returns the width of the [`Widget`].
     ///
     /// [`Widget`]: trait.Widget.html

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -127,6 +127,7 @@ where
 /// [`Button`]: struct.Button.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State {
+    is_cursor_over: bool,
     is_pressed: bool,
 }
 
@@ -145,6 +146,10 @@ where
     Renderer: self::Renderer,
     Message: Clone,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.state.is_cursor_over || self.state.is_pressed
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -204,6 +209,10 @@ where
                         messages.push(on_press);
                     }
                 }
+            }
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                self.state.is_cursor_over =
+                    layout.bounds().contains(cursor_position);
             }
             _ => {}
         }

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -126,6 +126,22 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: self::Renderer,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.children
+            .iter()
+            .any(|x| x.widget.is_wanting_mouse_events())
+    }
+
+    fn has_focus(&self) -> Option<bool> {
+        self.children
+            .iter()
+            .filter_map(|x| x.widget.has_focus())
+            .fold(None, |acc, x| match acc {
+                None => Some(x),
+                Some(v) => Some(v || x),
+            })
+    }
+
     fn width(&self) -> Length {
         self.width
     }

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -134,6 +134,14 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: self::Renderer,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.content.widget.is_wanting_mouse_events()
+    }
+
+    fn has_focus(&self) -> Option<bool> {
+        self.content.widget.has_focus()
+    }
+
     fn width(&self) -> Length {
         self.width
     }

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -127,6 +127,22 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: self::Renderer,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.children
+            .iter()
+            .any(|x| x.widget.is_wanting_mouse_events())
+    }
+
+    fn has_focus(&self) -> Option<bool> {
+        self.children
+            .iter()
+            .filter_map(|x| x.widget.has_focus())
+            .fold(None, |acc, x| match acc {
+                None => Some(x),
+                Some(v) => Some(v || x),
+            })
+    }
+
     fn width(&self) -> Length {
         self.width
     }

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -142,6 +142,7 @@ where
 /// [`Slider`]: struct.Slider.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State {
+    is_cursor_over: bool,
     is_dragging: bool,
 }
 
@@ -161,6 +162,10 @@ where
     Renderer: self::Renderer,
     Message: Clone,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.state.is_cursor_over || self.state.is_dragging
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -235,6 +240,8 @@ where
                     if self.state.is_dragging {
                         change();
                     }
+                    self.state.is_cursor_over =
+                        layout.bounds().contains(cursor_position);
                 }
                 _ => {}
             },

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -171,6 +171,14 @@ where
     Renderer: self::Renderer,
     Message: Clone,
 {
+    fn is_wanting_mouse_events(&self) -> bool {
+        self.state.is_cursor_over || self.state.is_dragging
+    }
+
+    fn has_focus(&self) -> Option<bool> {
+        Some(self.state.is_focused)
+    }
+
     fn width(&self) -> Length {
         self.width
     }
@@ -304,6 +312,8 @@ where
                         );
                     }
                 }
+                self.state.is_cursor_over =
+                    layout.bounds().contains(cursor_position);
             }
             Event::Keyboard(keyboard::Event::CharacterReceived(c))
                 if self.state.is_focused
@@ -633,6 +643,7 @@ where
 #[derive(Debug, Default, Clone)]
 pub struct State {
     is_focused: bool,
+    is_cursor_over: bool,
     is_dragging: bool,
     is_pasting: Option<Value>,
     last_click: Option<mouse::Click>,
@@ -654,6 +665,7 @@ impl State {
     pub fn focused() -> Self {
         Self {
             is_focused: true,
+            is_cursor_over: false,
             is_dragging: false,
             is_pasting: None,
             last_click: None,


### PR DESCRIPTION
This adds two properties to `Widget` - `is_wanting_mouse_events` and `has_focus`. The idea is that a widget can use these properties to indicate whether mouse and keyboard events should be captured. After a state update, the embedding engine can know whether mouse and keyboard events are being captured by the UI through the program state.

My WIP attempt of integrating into Kiss3d (sebcrozet/kiss3d#235) shows how it works.

This PR is incomplete as I have not implement the required changes for some widgets.

Related to: #408 