### PR TITLE
Update `glow` to `0.5` in `iced_glow`

### DIFF
--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -15,8 +15,8 @@ image = []
 svg = []
 
 [dependencies]
-glow = "0.4"
-glow_glyph = "0.2"
+glow = "0.5"
+glow_glyph = "0.3"
 glyph_brush = "0.7"
 euclid = "0.20"
 bytemuck = "1.2"

--- a/glow/src/quad.rs
+++ b/glow/src/quad.rs
@@ -48,13 +48,13 @@ impl Pipeline {
 
             let matrix: [f32; 16] = Transformation::identity().into();
             gl.uniform_matrix_4_f32_slice(
-                Some(transform_location),
+                Some(&transform_location),
                 false,
                 &matrix,
             );
 
-            gl.uniform_1_f32(Some(scale_location), 1.0);
-            gl.uniform_1_f32(Some(screen_height_location), 0.0);
+            gl.uniform_1_f32(Some(&scale_location), 1.0);
+            gl.uniform_1_f32(Some(&screen_height_location), 0.0);
 
             gl.use_program(None);
         }
@@ -102,7 +102,7 @@ impl Pipeline {
             unsafe {
                 let matrix: [f32; 16] = transformation.into();
                 gl.uniform_matrix_4_f32_slice(
-                    Some(self.transform_location),
+                    Some(&self.transform_location),
                     false,
                     &matrix,
                 );
@@ -113,7 +113,7 @@ impl Pipeline {
 
         if scale != self.current_scale {
             unsafe {
-                gl.uniform_1_f32(Some(self.scale_location), scale);
+                gl.uniform_1_f32(Some(&self.scale_location), scale);
             }
 
             self.current_scale = scale;
@@ -122,7 +122,7 @@ impl Pipeline {
         if target_height != self.current_target_height {
             unsafe {
                 gl.uniform_1_f32(
-                    Some(self.screen_height_location),
+                    Some(&self.screen_height_location),
                     target_height as f32,
                 );
             }

--- a/glow/src/triangle.rs
+++ b/glow/src/triangle.rs
@@ -44,7 +44,7 @@ impl Pipeline {
 
             let transform: [f32; 16] = Transformation::identity().into();
             gl.uniform_matrix_4_f32_slice(
-                Some(transform_location),
+                Some(&transform_location),
                 false,
                 &transform,
             );
@@ -182,7 +182,7 @@ impl Pipeline {
                 if self.current_transform != transform {
                     let matrix: [f32; 16] = transform.into();
                     gl.uniform_matrix_4_f32_slice(
-                        Some(self.transform_location),
+                        Some(&self.transform_location),
                         false,
                         &matrix,
                     );


### PR DESCRIPTION
This PR updates `iced_glow` to use the new releases of `glow` and `glow_glyph`.