### PR TITLE
Implement clipboard cut & copy on text_input widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ tokio = ["iced_futures/tokio"]
 async-std = ["iced_futures/async-std"]
 # Enables advanced color conversion via `palette`
 palette = ["iced_core/palette"]
+# Enables cut & copy feature on text_input widget via `clipboard` crate
+clipboard = ["iced_wgpu/clipboard"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ debug = []
 twox-hash = "1.5"
 unicode-segmentation = "1.6"
 num-traits = "0.2"
+clipboard = { version = "0.5.0", optional = true }
 
 [dependencies.iced_core]
 version = "0.2"
@@ -23,6 +24,3 @@ path = "../core"
 version = "0.1"
 path = "../futures"
 features = ["thread-pool"]
-
-[target.'cfg(target_os = "macos")'.dependencies]
-clipboard = "0.5.0"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -23,3 +23,6 @@ path = "../core"
 version = "0.1"
 path = "../futures"
 features = ["thread-pool"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+clipboard = "0.5.0"

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -7,9 +7,9 @@ pub trait Clipboard {
     fn content(&self) -> Option<String>;
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "clipboard")]
 use ::clipboard::{ClipboardContext, ClipboardProvider};
-#[cfg(target_os = "macos")]
+#[cfg(feature = "clipboard")]
 pub fn copy_to_clipboard<S: Into<String>>(text: S) {
     let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
     ctx.set_contents(text.into()).unwrap();

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -6,3 +6,11 @@ pub trait Clipboard {
     /// [`Clipboard`]: trait.Clipboard.html
     fn content(&self) -> Option<String>;
 }
+
+#[cfg(target_os = "macos")]
+use ::clipboard::{ClipboardContext, ClipboardProvider};
+#[cfg(target_os = "macos")]
+pub fn copy_to_clipboard<S: Into<String>>(text: S) {
+    let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+    ctx.set_contents(text.into()).unwrap();
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -70,7 +70,7 @@ pub use iced_futures::{executor, futures, Command};
 #[doc(no_inline)]
 pub use executor::Executor;
 
-pub use clipboard::Clipboard;
+pub use crate::clipboard::Clipboard;
 pub use debug::Debug;
 pub use element::Element;
 pub use event::Event;

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -463,7 +463,7 @@ where
                         self.state.is_pasting = None;
                     }
                 }
-                #[cfg(target_os = "macos")]
+                #[cfg(feature = "clipboard")]
                 keyboard::KeyCode::C => {
                     if platform::is_copy_paste_modifier_pressed(modifiers) {
                         if let Some((start, end)) =
@@ -475,7 +475,7 @@ where
                         }
                     }
                 }
-                #[cfg(target_os = "macos")]
+                #[cfg(feature = "clipboard")]
                 keyboard::KeyCode::X => {
                     if platform::is_copy_paste_modifier_pressed(modifiers) {
                         if let Some((start, end)) =

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/hecrj/iced"
 svg = ["resvg"]
 canvas = ["iced_graphics/canvas"]
 default_system_font = ["iced_graphics/font-source"]
+clipboard = ["iced_native/clipboard"]
 
 [dependencies]
 wgpu = "0.5"


### PR DESCRIPTION
I implemented "cut" & "copy" on TextInput using a crate "[clipboard](https://github.com/aweinstock314/rust-clipboard)".

As I know there is a clipboard project ([window_clipboard](https://github.com/hecrj/window_clipboard)), I'm not sure this is okay.

And I changed behavior of TextInput "while pressing copy_paste_modifier_key".
I guess this is expected behavior for most case on TextInput though,..

(I tested only on macOS 10.15.6)

Discussion @ #295
