### PR TITLE
Feature/keyboard handling

### DIFF
--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -1,7 +1,7 @@
 use iced::{
-    button, executor, time, Align, Application, Button, Column, Command,
-    Container, Element, HorizontalAlignment, Length, Row, Settings,
-    Subscription, Text, keyboard,
+    button, executor, keyboard, time, Align, Application, Button, Column,
+    Command, Container, Element, HorizontalAlignment, Length, Row, Settings,
+    Subscription, Text,
 };
 use std::time::{Duration, Instant};
 
@@ -141,7 +141,10 @@ impl Application for Stopwatch {
             .center_x()
             .center_y()
             .on_key_event(|event| {
-                if let keyboard::Event::KeyPressed {key_code,modifiers: _,} = event
+                if let keyboard::Event::KeyPressed {
+                    key_code,
+                    modifiers: _,
+                } = event
                 {
                     if let keyboard::KeyCode::Space = key_code {
                         return Some(Message::Toggle);

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -1,7 +1,7 @@
 use iced::{
     button, executor, time, Align, Application, Button, Column, Command,
     Container, Element, HorizontalAlignment, Length, Row, Settings,
-    Subscription, Text,
+    Subscription, Text, keyboard,
 };
 use std::time::{Duration, Instant};
 
@@ -140,6 +140,18 @@ impl Application for Stopwatch {
             .height(Length::Fill)
             .center_x()
             .center_y()
+            .on_key_event(|event| {
+                if let keyboard::Event::KeyPressed {key_code,modifiers: _,} = event
+                {
+                    if let keyboard::KeyCode::Space = key_code {
+                        return Some(Message::Toggle);
+                    }
+                    if let keyboard::KeyCode::R = key_code {
+                        return Some(Message::Reset);
+                    }
+                }
+                None
+            })
             .into()
     }
 }

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -22,7 +22,8 @@ pub struct Container<'a, Message, Renderer: self::Renderer> {
     vertical_alignment: Align,
     style: Renderer::Style,
     content: Element<'a, Message, Renderer>,
-    key_event_handler: Option<Box<dyn Fn(crate::keyboard::Event) -> Option<Message> + 'a>>,
+    key_event_handler:
+        Option<Box<dyn Fn(crate::keyboard::Event) -> Option<Message> + 'a>>,
 }
 
 impl<'a, Message, Renderer> Container<'a, Message, Renderer>


### PR DESCRIPTION
Hey!
I am using Iced for a small applicaiton and I wanted to add the abaility to exit by pressing Escape. 
But it seems that there isn't a straight forward way to subscribe to keyboard events as far as I can tell.

There is a way to do it in PaneGrids but the handling is a bit more complicated and it seems you can't handle different combinations of moddifiers (For example handle `ctrl + d` differently from `alt + d`)

I've implemented a small keyboard handler for `container` and I updated the stopwatch exmaple to show it I would use this.
If this is something you like, I'd be interested in extending it to other widgets or including mouse events.

Also Iced is really cool!
