### PR TITLE
Fix cursor position after a `CursorLeft` event

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -148,6 +148,7 @@ pub fn run<A, E, C>(
         .expect("Open window");
 
     let clipboard = Clipboard::new(&window);
+    // TODO: Encode cursor availability in the type-system
     let mut cursor_position = winit::dpi::PhysicalPosition::new(-1.0, -1.0);
     let mut mouse_interaction = mouse::Interaction::default();
     let mut modifiers = winit::event::ModifiersState::default();
@@ -377,6 +378,10 @@ pub fn handle_window_event(
         }
         WindowEvent::CursorMoved { position, .. } => {
             *cursor_position = *position;
+        }
+        WindowEvent::CursorLeft { .. } => {
+            // TODO: Encode cursor availability in the type-system
+            *cursor_position = winit::dpi::PhysicalPosition::new(-1.0, -1.0);
         }
         WindowEvent::ModifiersChanged(new_modifiers) => {
             *modifiers = *new_modifiers;

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -40,6 +40,12 @@ pub fn window_event(
                 y: position.y as f32,
             }))
         }
+        WindowEvent::CursorEntered { .. } => {
+            Some(Event::Mouse(mouse::Event::CursorEntered))
+        }
+        WindowEvent::CursorLeft { .. } => {
+            Some(Event::Mouse(mouse::Event::CursorLeft))
+        }
         WindowEvent::MouseInput { button, state, .. } => {
             let button = mouse_button(*button);
 


### PR DESCRIPTION
Fixes #490.