### PR TITLE
Support glow backend on wasm target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
-default = ["wgpu", "default_system_font"]
+default = ["wgpu", "winit", "default_system_font"]
 # Enables the `iced_wgpu` renderer
 wgpu = ["iced_wgpu"]
+# Enables the `iced_web` renderer
+winit = ["iced_winit", "iced_web_winit"]
+# Enables the `iced_web` renderer
+#web = ["iced_web"]
 # Enables the `Image` widget
 image = ["iced_wgpu/image"]
 # Enables the `Svg` widget
@@ -23,7 +27,7 @@ svg = ["iced_wgpu/svg"]
 canvas = ["iced_wgpu/canvas"]
 # Enables using system fonts.
 default_system_font = ["iced_wgpu/default_system_font"]
-# Enables the `iced_glow` renderer. Overrides `iced_wgpu`
+# Enables the `iced_glow` renderer. Overrides `iced_wgpu` on native and `iced_web` on wasm32.
 glow = ["iced_glow", "iced_glutin"]
 # Enables the `Canvas` widget for `iced_glow`
 glow_canvas = ["iced_glow/canvas"]
@@ -51,6 +55,7 @@ members = [
     "native",
     "style",
     "web",
+    "web_winit",
     "wgpu",
     "winit",
     "examples/bezier_tool",
@@ -78,15 +83,17 @@ members = [
 [dependencies]
 iced_core = { version = "0.2", path = "core" }
 iced_futures = { version = "0.1", path = "futures" }
+iced_glow = { version = "0.1", path = "glow", optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.1", path = "winit" }
 iced_glutin = { version = "0.1", path = "glutin", optional = true }
 iced_wgpu = { version = "0.2", path = "wgpu", optional = true }
-iced_glow = { version = "0.1", path = "glow", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iced_web = { version = "0.2", path = "web" }
+iced_winit = { version = "0.1", path = "winit", optional = true }
+iced_web_winit = { version = "0.1", path = "web_winit", optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,11 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
-default = ["wgpu", "winit", "default_system_font"]
+default = ["wgpu", "web", "default_system_font"]
 # Enables the `iced_wgpu` renderer
 wgpu = ["iced_wgpu"]
 # Enables the `iced_web` renderer
-winit = ["iced_winit", "iced_web_winit"]
-# Enables the `iced_web` renderer
-#web = ["iced_web"]
+web = ["iced_web"]
 # Enables the `Image` widget
 image = ["iced_wgpu/image"]
 # Enables the `Svg` widget
@@ -92,9 +90,9 @@ iced_wgpu = { version = "0.2", path = "wgpu", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-timer = "0.2"
-iced_web = { version = "0.2", path = "web" }
+iced_web_winit = { version = "0.1", path = "web_winit" }
+iced_web = { version = "0.2", path = "web", optional = true }
 iced_winit = { version = "0.1", path = "winit", optional = true }
-iced_web_winit = { version = "0.1", path = "web_winit", optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 [features]
 default = ["wgpu", "web", "default_system_font"]
 # Enables the `iced_wgpu` renderer
-wgpu = ["iced_wgpu"]
+wgpu = ["iced_wgpu", "iced_winit"]
 # Enables the `iced_web` renderer
 web = ["iced_web"]
 # Enables the `Image` widget
@@ -26,7 +26,7 @@ canvas = ["iced_wgpu/canvas"]
 # Enables using system fonts.
 default_system_font = ["iced_wgpu/default_system_font"]
 # Enables the `iced_glow` renderer. Overrides `iced_wgpu` on native and `iced_web` on wasm32.
-glow = ["iced_glow", "iced_glutin"]
+glow = ["iced_glow", "iced_glutin", "iced_winit", "iced_web_winit"]
 # Enables the `Canvas` widget for `iced_glow`
 glow_canvas = ["iced_glow/canvas"]
 # Enables using system fonts for `iced_glow`.
@@ -84,15 +84,15 @@ iced_futures = { version = "0.1", path = "futures" }
 iced_glow = { version = "0.1", path = "glow", optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iced_winit = { version = "0.1", path = "winit" }
+iced_winit = { version = "0.1", path = "winit", optional = true }
 iced_glutin = { version = "0.1", path = "glutin", optional = true }
 iced_wgpu = { version = "0.2", path = "wgpu", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-timer = "0.2"
-iced_web_winit = { version = "0.1", path = "web_winit" }
 iced_web = { version = "0.2", path = "web", optional = true }
 iced_winit = { version = "0.1", path = "winit", optional = true }
+iced_web_winit = { version = "0.1", path = "web_winit", optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ iced_glutin = { version = "0.1", path = "glutin", optional = true }
 iced_wgpu = { version = "0.2", path = "wgpu", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-timer = "0.2"
 iced_web = { version = "0.2", path = "web" }
 iced_winit = { version = "0.1", path = "winit", optional = true }
 iced_web_winit = { version = "0.1", path = "web_winit", optional = true }

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -5,16 +5,23 @@ authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2018"
 publish = false
 
+[features]
+default = ["wgpu"]
+wgpu = ["iced/wgpu"]
+glow = ["iced/glow"]
+web = ["iced/web"]
+
 [dependencies]
-iced = { path = "../..", features = ["async-std", "debug"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+iced = { path = "../..", default_features = false, features = ["async-std", "debug"] }
 async-std = "1.0"
 directories = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+iced = { path = "../..", default_features = false, features = ["debug"] }
 web-sys = { version = "0.3", features = ["Window", "Storage"] }
 wasm-timer = "0.2"
 

--- a/examples/todos/web/bundle-web.sh
+++ b/examples/todos/web/bundle-web.sh
@@ -1,0 +1,3 @@
+cargo build --release --target wasm32-unknown-unknown
+wasm-bindgen ../../target/wasm32-unknown-unknown/release/todos.wasm --out-dir ../../target/web --web
+cp web/index.html ../../target/web/

--- a/examples/todos/web/index.html
+++ b/examples/todos/web/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Iced Todos</title>
+  </head>
+  <body>
+
+<style>
+* { margin:0; padding:0; } /* to remove the top and left whitespace */
+
+html, body { width:100%; height:100%; } /* just to be sure these are full screen*/
+
+canvas { display:block; } /* To remove the scrollbars */
+</style>
+
+    <script type="module">
+      import init from "./todos.js";
+      init('./todos_bg.wasm');
+    </script>
+  </body>
+</html>

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -31,6 +31,7 @@ features = ["unstable"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
+wasm-timer = "0.2"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -14,10 +14,15 @@ mod runtime;
 pub mod executor;
 pub mod subscription;
 
-#[cfg(any(
-    feature = "tokio", feature = "async-std", target_arch = "wasm32"
-))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std", target_arch = "wasm32"))))]
+#[cfg(any(feature = "tokio", feature = "async-std", target_arch = "wasm32"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "tokio",
+        feature = "async-std",
+        target_arch = "wasm32"
+    )))
+)]
 pub mod time;
 
 pub use command::Command;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -14,11 +14,10 @@ mod runtime;
 pub mod executor;
 pub mod subscription;
 
-#[cfg(all(
-    any(feature = "tokio", feature = "async-std"),
-    not(target_arch = "wasm32")
+#[cfg(any(
+    feature = "tokio", feature = "async-std", target_arch = "wasm32"
 ))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std"))))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std", target_arch = "wasm32"))))]
 pub mod time;
 
 pub use command::Command;

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -21,6 +21,7 @@ pub struct Runtime<Hasher, Event, Executor, Sender, Message> {
     _message: PhantomData<Message>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Hasher, Event, Executor, Sender, Message>
     Runtime<Hasher, Event, Executor, Sender, Message>
 where
@@ -30,6 +31,109 @@ where
     Sender:
         Sink<Message, Error = mpsc::SendError> + Unpin + Send + Clone + 'static,
     Message: Send + 'static,
+{
+    /// Creates a new empty [`Runtime`].
+    ///
+    /// You need to provide:
+    /// - an [`Executor`] to spawn futures
+    /// - a `Sender` implementing `Sink` to receive the results
+    ///
+    /// [`Runtime`]: struct.Runtime.html
+    pub fn new(executor: Executor, sender: Sender) -> Self {
+        Self {
+            executor,
+            sender,
+            subscriptions: subscription::Tracker::new(),
+            _message: PhantomData,
+        }
+    }
+
+    /// Runs the given closure inside the [`Executor`] of the [`Runtime`].
+    ///
+    /// See [`Executor::enter`] to learn more.
+    ///
+    /// [`Executor`]: executor/trait.Executor.html
+    /// [`Runtime`]: struct.Runtime.html
+    /// [`Executor::enter`]: executor/trait.Executor.html#method.enter
+    pub fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
+        self.executor.enter(f)
+    }
+
+    /// Spawns a [`Command`] in the [`Runtime`].
+    ///
+    /// The resulting `Message` will be forwarded to the `Sender` of the
+    /// [`Runtime`].
+    ///
+    /// [`Command`]: struct.Command.html
+    /// [`Runtime`]: struct.Runtime.html
+    pub fn spawn(&mut self, command: Command<Message>) {
+        use futures::{FutureExt, SinkExt};
+
+        let futures = command.futures();
+
+        for future in futures {
+            let mut sender = self.sender.clone();
+
+            let future = future.then(|message| async move {
+                let _ = sender.send(message).await;
+
+                ()
+            });
+
+            self.executor.spawn(future);
+        }
+    }
+
+    /// Tracks a [`Subscription`] in the [`Runtime`].
+    ///
+    /// It will spawn new streams or close old ones as necessary! See
+    /// [`Tracker::update`] to learn more about this!
+    ///
+    /// [`Subscription`]: subscription/struct.Subscription.html
+    /// [`Runtime`]: struct.Runtime.html
+    /// [`Tracker::update`]: subscription/struct.Tracker.html#method.update
+    pub fn track(
+        &mut self,
+        subscription: Subscription<Hasher, Event, Message>,
+    ) {
+        let Runtime {
+            executor,
+            subscriptions,
+            sender,
+            ..
+        } = self;
+
+        let futures = executor
+            .enter(|| subscriptions.update(subscription, sender.clone()));
+
+        for future in futures {
+            executor.spawn(future);
+        }
+    }
+
+    /// Broadcasts an event to all the subscriptions currently alive in the
+    /// [`Runtime`].
+    ///
+    /// See [`Tracker::broadcast`] to learn more.
+    ///
+    /// [`Runtime`]: struct.Runtime.html
+    /// [`Tracker::broadcast`]:
+    /// subscription/struct.Tracker.html#method.broadcast
+    pub fn broadcast(&mut self, event: Event) {
+        self.subscriptions.broadcast(event);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Hasher, Event, Executor, Sender, Message>
+    Runtime<Hasher, Event, Executor, Sender, Message>
+where
+    Hasher: std::hash::Hasher + Default,
+    Event: Send + Clone + 'static,
+    Executor: self::Executor,
+    Sender:
+        Sink<Message, Error = mpsc::SendError> + Unpin + Clone + 'static,
+    Message: 'static,
 {
     /// Creates a new empty [`Runtime`].
     ///

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -131,8 +131,7 @@ where
     Hasher: std::hash::Hasher + Default,
     Event: Send + Clone + 'static,
     Executor: self::Executor,
-    Sender:
-        Sink<Message, Error = mpsc::SendError> + Unpin + Clone + 'static,
+    Sender: Sink<Message, Error = mpsc::SendError> + Unpin + Clone + 'static,
     Message: 'static,
 {
     /// Creates a new empty [`Runtime`].

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -192,10 +192,8 @@ where
     ) -> Vec<BoxFuture<()>>
     where
         Message: 'static,
-        Receiver: 'static
-            + Sink<Message, Error = mpsc::SendError>
-            + Unpin
-            + Clone,
+        Receiver:
+            'static + Sink<Message, Error = mpsc::SendError> + Unpin + Clone,
     {
         use futures::{future::FutureExt, stream::StreamExt};
 

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -20,6 +20,7 @@ pub struct Execution<Event> {
     listener: Option<futures::channel::mpsc::Sender<Event>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Hasher, Event> Tracker<Hasher, Event>
 where
     Hasher: std::hash::Hasher + Default,
@@ -66,6 +67,134 @@ where
             + Sink<Message, Error = mpsc::SendError>
             + Unpin
             + Send
+            + Clone,
+    {
+        use futures::{future::FutureExt, stream::StreamExt};
+
+        let mut futures: Vec<BoxFuture<()>> = Vec::new();
+
+        let recipes = subscription.recipes();
+        let mut alive = std::collections::HashSet::new();
+
+        for recipe in recipes {
+            let id = {
+                let mut hasher = Hasher::default();
+                recipe.hash(&mut hasher);
+
+                hasher.finish()
+            };
+
+            let _ = alive.insert(id);
+
+            if self.subscriptions.contains_key(&id) {
+                continue;
+            }
+
+            let (cancel, cancelled) = futures::channel::oneshot::channel();
+
+            // TODO: Use bus if/when it supports async
+            let (event_sender, event_receiver) =
+                futures::channel::mpsc::channel(100);
+
+            let stream = recipe.stream(event_receiver.boxed());
+
+            let future = futures::future::select(
+                cancelled,
+                stream.map(Ok).forward(receiver.clone()),
+            )
+            .map(|_| ());
+
+            let _ = self.subscriptions.insert(
+                id,
+                Execution {
+                    _cancel: cancel,
+                    listener: if event_sender.is_closed() {
+                        None
+                    } else {
+                        Some(event_sender)
+                    },
+                },
+            );
+
+            futures.push(Box::pin(future));
+        }
+
+        self.subscriptions.retain(|id, _| alive.contains(&id));
+
+        futures
+    }
+
+    /// Broadcasts an event to the subscriptions currently alive.
+    ///
+    /// A subscription's [`Recipe::stream`] always receives a stream of events
+    /// as input. This stream can be used by some subscription to listen to
+    /// shell events.
+    ///
+    /// This method publishes the given event to all the subscription streams
+    /// currently open.
+    ///
+    /// [`Recipe::stream`]: trait.Recipe.html#tymethod.stream
+    pub fn broadcast(&mut self, event: Event) {
+        self.subscriptions
+            .values_mut()
+            .filter_map(|connection| connection.listener.as_mut())
+            .for_each(|listener| {
+                if let Err(error) = listener.try_send(event.clone()) {
+                    log::error!(
+                        "Error sending event to subscription: {:?}",
+                        error
+                    );
+                }
+            });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<Hasher, Event> Tracker<Hasher, Event>
+where
+    Hasher: std::hash::Hasher + Default,
+    Event: 'static + Send + Clone,
+{
+    /// Creates a new empty [`Tracker`].
+    ///
+    /// [`Tracker`]: struct.Tracker.html
+    pub fn new() -> Self {
+        Self {
+            subscriptions: HashMap::new(),
+            _hasher: PhantomData,
+        }
+    }
+
+    /// Updates the [`Tracker`] with the given [`Subscription`].
+    ///
+    /// A [`Subscription`] can cause new streams to be spawned or old streams
+    /// to be closed.
+    ///
+    /// The [`Tracker`] keeps track of these streams between calls to this
+    /// method:
+    ///
+    /// - If the provided [`Subscription`] contains a new [`Recipe`] that is
+    /// currently not being run, it will spawn a new stream and keep it alive.
+    /// - On the other hand, if a [`Recipe`] is currently in execution and the
+    /// provided [`Subscription`] does not contain it anymore, then the
+    /// [`Tracker`] will close and drop the relevant stream.
+    ///
+    /// It returns a list of futures that need to be spawned to materialize
+    /// the [`Tracker`] changes.
+    ///
+    /// [`Tracker`]: struct.Tracker.html
+    /// [`Subscription`]: struct.Subscription.html
+    /// [`Recipe`]: trait.Recipe.html
+    pub fn update<Message, Receiver>(
+        &mut self,
+        subscription: Subscription<Hasher, Event, Message>,
+        receiver: Receiver,
+    ) -> Vec<BoxFuture<()>>
+    where
+        Message: 'static,
+        Receiver: 'static
+            + Sink<Message, Error = mpsc::SendError>
+            + Unpin
             + Clone,
     {
         use futures::{future::FutureExt, stream::StreamExt};

--- a/futures/src/time.rs
+++ b/futures/src/time.rs
@@ -56,7 +56,11 @@ where
     }
 }
 
-#[cfg(all(feature = "tokio", not(feature = "async-std"), not(target_arch = "wasm32")))]
+#[cfg(all(
+    feature = "tokio",
+    not(feature = "async-std"),
+    not(target_arch = "wasm32")
+))]
 impl<H, E> subscription::Recipe<H, E> for Every
 where
     H: std::hash::Hasher,
@@ -106,7 +110,7 @@ where
 
         Box::pin(
             wasm_timer::Interval::new(self.0)
-                .map(|_| wasm_timer::Instant::now())
+                .map(|_| wasm_timer::Instant::now()),
         )
     }
 }

--- a/futures/src/time.rs
+++ b/futures/src/time.rs
@@ -30,7 +30,7 @@ pub fn every<H: std::hash::Hasher, E>(
 
 struct Every(std::time::Duration);
 
-#[cfg(feature = "async-std")]
+#[cfg(all(feature = "async-std", not(target_arch = "wasm32")))]
 impl<H, E> subscription::Recipe<H, E> for Every
 where
     H: std::hash::Hasher,
@@ -56,7 +56,7 @@ where
     }
 }
 
-#[cfg(all(feature = "tokio", not(feature = "async-std")))]
+#[cfg(all(feature = "tokio", not(feature = "async-std"), not(target_arch = "wasm32")))]
 impl<H, E> subscription::Recipe<H, E> for Every
 where
     H: std::hash::Hasher,

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -16,7 +16,8 @@ svg = []
 
 [dependencies]
 glow = "0.5"
-glow_glyph = "0.3"
+#glow_glyph = "0.3"
+glow_glyph = { git = "https://github.com/tedsta/glow_glyph", rev = "cf3462437b9db59ff9c953c05e0f91f9ba7e28e1" }
 glyph_brush = "0.7"
 euclid = "0.20"
 bytemuck = "1.2"
@@ -34,3 +35,12 @@ features = ["font-fallback", "font-icons", "opengl"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3"
+features = [
+  "CanvasRenderingContext2d",
+]

--- a/glow/src/program.rs
+++ b/glow/src/program.rs
@@ -17,6 +17,7 @@ pub unsafe fn create(
         gl.compile_shader(shader);
 
         if !gl.get_shader_compile_status(shader) {
+            panic!("{}", shader_source);
             panic!(gl.get_shader_info_log(shader));
         }
 

--- a/glow/src/program.rs
+++ b/glow/src/program.rs
@@ -17,7 +17,6 @@ pub unsafe fn create(
         gl.compile_shader(shader);
 
         if !gl.get_shader_compile_status(shader) {
-            panic!("{}", shader_source);
             panic!(gl.get_shader_info_log(shader));
         }
 

--- a/glow/src/shader/quad.frag
+++ b/glow/src/shader/quad.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision mediump float;
 
 uniform float u_ScreenHeight;
 
@@ -11,7 +13,7 @@ in float v_BorderWidth;
 
 out vec4 o_Color;
 
-float distance(in vec2 frag_coord, in vec2 position, in vec2 size, float radius)
+float quad_distance(vec2 frag_coord, vec2 position, vec2 size, float radius)
 {
     // TODO: Try SDF approach: https://www.shadertoy.com/view/wd3XRN
     vec2 inner_size = size - vec2(radius, radius) * 2.0;
@@ -35,10 +37,10 @@ void main() {
     vec2 fragCoord = vec2(gl_FragCoord.x, u_ScreenHeight - gl_FragCoord.y);
 
     // TODO: Remove branching (?)
-    if(v_BorderWidth > 0) {
+    if (v_BorderWidth > 0.0) {
         float internal_border = max(v_BorderRadius - v_BorderWidth, 0.0);
 
-        float internal_distance = distance(
+        float internal_distance = quad_distance(
             fragCoord,
             v_Pos + vec2(v_BorderWidth),
             v_Scale - vec2(v_BorderWidth * 2.0),
@@ -56,7 +58,7 @@ void main() {
         mixed_color = v_Color;
     }
 
-    float d = distance(
+    float d = quad_distance(
         fragCoord,
         v_Pos,
         v_Scale,

--- a/glow/src/shader/quad.frag
+++ b/glow/src/shader/quad.frag
@@ -13,22 +13,22 @@ in float v_BorderWidth;
 
 out vec4 o_Color;
 
-float quad_distance(vec2 frag_coord, vec2 position, vec2 size, float radius)
+float quad_distance(in vec2 frag_coord, in vec2 position, in vec2 size, float radius)
 {
     // TODO: Try SDF approach: https://www.shadertoy.com/view/wd3XRN
     vec2 inner_size = size - vec2(radius, radius) * 2.0;
     vec2 top_left = position + vec2(radius, radius);
     vec2 bottom_right = top_left + inner_size;
 
-    vec2 top_left_distance = top_left - frag_coord;
-    vec2 bottom_right_distance = frag_coord - bottom_right;
+    vec2 top_left_quad_distance = top_left - frag_coord;
+    vec2 bottom_right_quad_distance = frag_coord - bottom_right;
 
-    vec2 distance = vec2(
-        max(max(top_left_distance.x, bottom_right_distance.x), 0.0),
-        max(max(top_left_distance.y, bottom_right_distance.y), 0.0)
+    vec2 quad_distance = vec2(
+        max(max(top_left_quad_distance.x, bottom_right_quad_distance.x), 0.0),
+        max(max(top_left_quad_distance.y, bottom_right_quad_distance.y), 0.0)
     );
 
-    return sqrt(distance.x * distance.x + distance.y * distance.y);
+    return sqrt(quad_distance.x * quad_distance.x + quad_distance.y * quad_distance.y);
 }
 
 void main() {
@@ -40,7 +40,7 @@ void main() {
     if (v_BorderWidth > 0.0) {
         float internal_border = max(v_BorderRadius - v_BorderWidth, 0.0);
 
-        float internal_distance = quad_distance(
+        float internal_quad_distance = quad_distance(
             fragCoord,
             v_Pos + vec2(v_BorderWidth),
             v_Scale - vec2(v_BorderWidth * 2.0),
@@ -50,7 +50,7 @@ void main() {
         float border_mix = smoothstep(
             max(internal_border - 0.5, 0.0),
             internal_border + 0.5,
-            internal_distance
+            internal_quad_distance
         );
 
         mixed_color = mix(v_Color, v_BorderColor, border_mix);

--- a/glow/src/shader/quad.vert
+++ b/glow/src/shader/quad.vert
@@ -1,4 +1,8 @@
-#version 330
+#version 300 es
+
+precision mediump float;
+
+// #version 330
 
 uniform mat4 u_Transform;
 uniform float u_Scale;

--- a/glow/src/shader/triangle.frag
+++ b/glow/src/shader/triangle.frag
@@ -1,4 +1,8 @@
-#version 330
+#version 300 es
+
+precision mediump float;
+
+// #version 330
 
 in vec4 v_Color;
 

--- a/glow/src/shader/triangle.vert
+++ b/glow/src/shader/triangle.vert
@@ -1,4 +1,8 @@
-#version 330
+#version 300 es
+
+precision mediump float;
+
+// #version 330
 
 uniform mat4 u_Transform;
 

--- a/glow/src/triangle.rs
+++ b/glow/src/triangle.rs
@@ -164,7 +164,11 @@ impl Pipeline {
                 {
                     // XXX allocating a big ol' array for every mesh on every draw because WebGL
                     // doesn't support `draw_elements_base_vertex`.
-                    let indices: Vec<_> = buffers.indices.iter().map(|x| *x + last_vertex as u32).collect();
+                    let indices: Vec<_> = buffers
+                        .indices
+                        .iter()
+                        .map(|x| *x + last_vertex as u32)
+                        .collect();
                     gl.buffer_sub_data_u8_slice(
                         glow::ELEMENT_ARRAY_BUFFER,
                         (last_index * std::mem::size_of::<u32>()) as i32,

--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -23,7 +23,7 @@ impl iced_graphics::window::GLCompositor for Compositor {
         let gl = glow::Context::from_loader_function(loader_function);
 
         #[cfg(all(target_arch = "wasm32"))]
-        let (gl, render_loop, shader_version) = {
+        let (gl, _render_loop, _shader_version) = {
             use wasm_bindgen::JsCast;
             let canvas = web_sys::window()
                 .expect("iced web_sys window")

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -28,7 +28,7 @@ path = "../style"
 version = "0.15"
 optional = true
 
-[dependencies.font-kit]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.font-kit]
 version = "0.6"
 optional = true
 

--- a/graphics/src/font.rs
+++ b/graphics/src/font.rs
@@ -1,13 +1,13 @@
 //! Find system fonts or use the built-in ones.
-#[cfg(feature = "font-source")]
+#[cfg(all(feature = "font-source", not(target_arch = "wasm32")))]
 mod source;
 
-#[cfg(feature = "font-source")]
-#[cfg_attr(docsrs, doc(cfg(feature = "font-source")))]
+#[cfg(all(feature = "font-source", not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "font-source", not(target_arch = "wasm32")))))]
 pub use source::Source;
 
-#[cfg(feature = "font-source")]
-#[cfg_attr(docsrs, doc(cfg(feature = "font-source")))]
+#[cfg(all(feature = "font-source", not(target_arch = "wasm32")))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "font-source", not(target_arch = "wasm32")))))]
 pub use font_kit::{
     error::SelectionError as LoadError, family_name::FamilyName as Family,
 };

--- a/graphics/src/font.rs
+++ b/graphics/src/font.rs
@@ -3,11 +3,17 @@
 mod source;
 
 #[cfg(all(feature = "font-source", not(target_arch = "wasm32")))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "font-source", not(target_arch = "wasm32")))))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "font-source", not(target_arch = "wasm32"))))
+)]
 pub use source::Source;
 
 #[cfg(all(feature = "font-source", not(target_arch = "wasm32")))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "font-source", not(target_arch = "wasm32")))))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "font-source", not(target_arch = "wasm32"))))
+)]
 pub use font_kit::{
     error::SelectionError as LoadError, family_name::FamilyName as Family,
 };

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -23,3 +23,6 @@ path = "../core"
 version = "0.1"
 path = "../futures"
 features = ["thread-pool"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-timer = "0.2"

--- a/native/src/debug/basic.rs
+++ b/native/src/debug/basic.rs
@@ -1,30 +1,36 @@
 #![allow(missing_docs)]
-use std::{collections::VecDeque, time};
+use std::{collections::VecDeque, time::Duration};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_timer::Instant;
 
 /// A bunch of time measurements for debugging purposes.
 #[derive(Debug)]
 pub struct Debug {
     is_enabled: bool,
 
-    startup_start: time::Instant,
-    startup_duration: time::Duration,
+    startup_start: Instant,
+    startup_duration: Duration,
 
-    update_start: time::Instant,
+    update_start: Instant,
     update_durations: TimeBuffer,
 
-    view_start: time::Instant,
+    view_start: Instant,
     view_durations: TimeBuffer,
 
-    layout_start: time::Instant,
+    layout_start: Instant,
     layout_durations: TimeBuffer,
 
-    event_start: time::Instant,
+    event_start: Instant,
     event_durations: TimeBuffer,
 
-    draw_start: time::Instant,
+    draw_start: Instant,
     draw_durations: TimeBuffer,
 
-    render_start: time::Instant,
+    render_start: Instant,
     render_durations: TimeBuffer,
 
     message_count: usize,
@@ -36,12 +42,12 @@ impl Debug {
     ///
     /// [`Debug`]: struct.Debug.html
     pub fn new() -> Self {
-        let now = time::Instant::now();
+        let now = Instant::now();
 
         Self {
             is_enabled: false,
             startup_start: now,
-            startup_duration: time::Duration::from_secs(0),
+            startup_duration: Duration::from_secs(0),
 
             update_start: now,
             update_durations: TimeBuffer::new(200),
@@ -71,65 +77,65 @@ impl Debug {
     }
 
     pub fn startup_started(&mut self) {
-        self.startup_start = time::Instant::now();
+        self.startup_start = Instant::now();
     }
 
     pub fn startup_finished(&mut self) {
-        self.startup_duration = time::Instant::now() - self.startup_start;
+        self.startup_duration = Instant::now() - self.startup_start;
     }
 
     pub fn update_started(&mut self) {
-        self.update_start = time::Instant::now();
+        self.update_start = Instant::now();
     }
 
     pub fn update_finished(&mut self) {
         self.update_durations
-            .push(time::Instant::now() - self.update_start);
+            .push(Instant::now() - self.update_start);
     }
 
     pub fn view_started(&mut self) {
-        self.view_start = time::Instant::now();
+        self.view_start = Instant::now();
     }
 
     pub fn view_finished(&mut self) {
         self.view_durations
-            .push(time::Instant::now() - self.view_start);
+            .push(Instant::now() - self.view_start);
     }
 
     pub fn layout_started(&mut self) {
-        self.layout_start = time::Instant::now();
+        self.layout_start = Instant::now();
     }
 
     pub fn layout_finished(&mut self) {
         self.layout_durations
-            .push(time::Instant::now() - self.layout_start);
+            .push(Instant::now() - self.layout_start);
     }
 
     pub fn event_processing_started(&mut self) {
-        self.event_start = time::Instant::now();
+        self.event_start = Instant::now();
     }
 
     pub fn event_processing_finished(&mut self) {
         self.event_durations
-            .push(time::Instant::now() - self.event_start);
+            .push(Instant::now() - self.event_start);
     }
 
     pub fn draw_started(&mut self) {
-        self.draw_start = time::Instant::now();
+        self.draw_start = Instant::now();
     }
 
     pub fn draw_finished(&mut self) {
         self.draw_durations
-            .push(time::Instant::now() - self.draw_start);
+            .push(Instant::now() - self.draw_start);
     }
 
     pub fn render_started(&mut self) {
-        self.render_start = time::Instant::now();
+        self.render_start = Instant::now();
     }
 
     pub fn render_finished(&mut self) {
         self.render_durations
-            .push(time::Instant::now() - self.render_start);
+            .push(Instant::now() - self.render_start);
     }
 
     pub fn log_message<Message: std::fmt::Debug>(&mut self, message: &Message) {
@@ -190,7 +196,7 @@ impl Debug {
 struct TimeBuffer {
     head: usize,
     size: usize,
-    contents: Vec<time::Duration>,
+    contents: Vec<Duration>,
 }
 
 impl TimeBuffer {
@@ -198,18 +204,18 @@ impl TimeBuffer {
         TimeBuffer {
             head: 0,
             size: 0,
-            contents: vec![time::Duration::from_secs(0); capacity],
+            contents: vec![Duration::from_secs(0); capacity],
         }
     }
 
-    fn push(&mut self, duration: time::Duration) {
+    fn push(&mut self, duration: Duration) {
         self.head = (self.head + 1) % self.contents.len();
         self.contents[self.head] = duration;
         self.size = (self.size + 1).min(self.contents.len());
     }
 
-    fn average(&self) -> time::Duration {
-        let sum: time::Duration = if self.size == self.contents.len() {
+    fn average(&self) -> Duration {
+        let sum: Duration = if self.size == self.contents.len() {
             self.contents[..].iter().sum()
         } else {
             self.contents[..self.size].iter().sum()

--- a/native/src/debug/basic.rs
+++ b/native/src/debug/basic.rs
@@ -98,8 +98,7 @@ impl Debug {
     }
 
     pub fn view_finished(&mut self) {
-        self.view_durations
-            .push(Instant::now() - self.view_start);
+        self.view_durations.push(Instant::now() - self.view_start);
     }
 
     pub fn layout_started(&mut self) {
@@ -116,8 +115,7 @@ impl Debug {
     }
 
     pub fn event_processing_finished(&mut self) {
-        self.event_durations
-            .push(Instant::now() - self.event_start);
+        self.event_durations.push(Instant::now() - self.event_start);
     }
 
     pub fn draw_started(&mut self) {
@@ -125,8 +123,7 @@ impl Debug {
     }
 
     pub fn draw_finished(&mut self) {
-        self.draw_durations
-            .push(Instant::now() - self.draw_start);
+        self.draw_durations.push(Instant::now() - self.draw_start);
     }
 
     pub fn render_started(&mut self) {

--- a/native/src/mouse/click.rs
+++ b/native/src/mouse/click.rs
@@ -1,6 +1,11 @@
 //! Track mouse clicks.
 use crate::Point;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_timer::Instant;
 
 /// A mouse click.
 #[derive(Debug, Clone, Copy)]
@@ -67,10 +72,19 @@ impl Click {
     }
 
     fn is_consecutive(&self, new_position: Point, time: Instant) -> bool {
-        self.position == new_position
-            && time
-                .checked_duration_since(self.time)
-                .map(|duration| duration.as_millis() <= 300)
-                .unwrap_or(false)
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.position == new_position
+                && time
+                    .checked_duration_since(self.time)
+                    .map(|duration| duration.as_millis() <= 300)
+                    .unwrap_or(false)
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.position == new_position
+                && time.duration_since(self.time).as_millis() <= 300
+        }
     }
 }

--- a/native/src/program.rs
+++ b/native/src/program.rs
@@ -15,7 +15,14 @@ pub trait Program: Sized {
     /// The type of __messages__ your [`Program`] will produce.
     ///
     /// [`Program`]: trait.Program.html
+    #[cfg(not(target_arch = "wasm32"))]
     type Message: std::fmt::Debug + Send;
+
+    /// The type of __messages__ your [`Program`] will produce.
+    ///
+    /// [`Program`]: trait.Program.html
+    #[cfg(target_arch = "wasm32")]
+    type Message: std::fmt::Debug;
 
     /// Handles a __message__ and updates the state of the [`Program`].
     ///

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,6 +1,6 @@
 //! Listen to external events in your application.
 use crate::{Event, Hasher};
-use iced_futures::futures::stream::BoxStream;
+use iced_futures::BoxStream;
 
 /// A request to listen to external events.
 ///
@@ -22,7 +22,7 @@ pub type Subscription<T> = iced_futures::Subscription<Hasher, Event, T>;
 /// It is the input of a [`Subscription`] in the native runtime.
 ///
 /// [`Subscription`]: type.Subscription.html
-pub type EventStream = BoxStream<'static, Event>;
+pub type EventStream = BoxStream<Event>;
 
 /// A native [`Subscription`] tracker.
 ///

--- a/src/application.rs
+++ b/src/application.rs
@@ -213,7 +213,7 @@ pub trait Application: Sized {
     where
         Self: 'static,
     {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(feature = "web"))]
         {
             let renderer_settings = crate::renderer::Settings {
                 default_font: settings.default_font,
@@ -233,14 +233,14 @@ pub trait Application: Sized {
             >(settings.into(), renderer_settings);
         }
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(feature = "web")]
         <Instance<Self> as iced_web::Application>::run(settings.flags);
     }
 }
 
 struct Instance<A: Application>(A);
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 impl<A> iced_winit::Program for Instance<A>
 where
     A: Application,
@@ -257,7 +257,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 impl<A> crate::runtime::Application for Instance<A>
 where
     A: Application,
@@ -294,7 +294,7 @@ where
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "web")]
 impl<A> iced_web::Application for Instance<A>
 where
     A: Application,

--- a/src/application.rs
+++ b/src/application.rs
@@ -213,7 +213,7 @@ pub trait Application: Sized {
     where
         Self: 'static,
     {
-        #[cfg(not(feature = "web"))]
+        #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
         {
             let renderer_settings = crate::renderer::Settings {
                 default_font: settings.default_font,
@@ -233,14 +233,14 @@ pub trait Application: Sized {
             >(settings.into(), renderer_settings);
         }
 
-        #[cfg(feature = "web")]
+        #[cfg(all(feature = "web", target_arch = "wasm32"))]
         <Instance<Self> as iced_web::Application>::run(settings.flags);
     }
 }
 
 struct Instance<A: Application>(A);
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl<A> iced_winit::Program for Instance<A>
 where
     A: Application,
@@ -257,7 +257,7 @@ where
     }
 }
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl<A> crate::runtime::Application for Instance<A>
 where
     A: Application,
@@ -294,7 +294,7 @@ where
     }
 }
 
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 impl<A> iced_web::Application for Instance<A>
 where
     A: Application,

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,9 +1,9 @@
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 pub type Element<'a, Message> =
     crate::runtime::Element<'a, Message, crate::renderer::Renderer>;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "web")]
 pub use iced_web::Element;

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,9 +1,9 @@
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 pub type Element<'a, Message> =
     crate::runtime::Element<'a, Message, crate::renderer::Renderer>;
 
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use iced_web::Element;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,10 +214,12 @@ use iced_glutin as runtime;
 ))]
 use iced_wgpu as renderer;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
+#[cfg(feature = "glow")]
 use iced_glow as renderer;
+#[cfg(all(target_arch = "wasm32", feature = "winit"))]
+use iced_web_winit as runtime;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "web")]
 use iced_web as runtime;
 
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,8 @@ pub mod time;
     feature = "wgpu"
 ))]
 use iced_winit as runtime;
+#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
+use iced_web_winit as runtime;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
 use iced_glutin as runtime;
@@ -215,10 +217,8 @@ use iced_wgpu as renderer;
 
 #[cfg(feature = "glow")]
 use iced_glow as renderer;
-#[cfg(all(target_arch = "wasm32", feature = "winit"))]
-use iced_web_winit as runtime;
 
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 use iced_web as runtime;
 
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,7 @@ pub mod widget;
 pub mod window;
 
 #[cfg(all(
-    any(feature = "tokio", feature = "async-std"),
-    not(target_arch = "wasm32")
+    any(feature = "tokio", feature = "async-std", target_arch = "wasm32"),
 ))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std"))))]
 pub mod time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,14 +198,15 @@ pub mod window;
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std"))))]
 pub mod time;
 
-#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
-use iced_web_winit as runtime;
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(feature = "glow"),
     feature = "wgpu"
 ))]
 use iced_winit as runtime;
+
+#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
+use iced_web_winit as runtime;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
 use iced_glutin as runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,20 +190,22 @@ pub mod settings;
 pub mod widget;
 pub mod window;
 
-#[cfg(all(
-    any(feature = "tokio", feature = "async-std", target_arch = "wasm32"),
-))]
+#[cfg(all(any(
+    feature = "tokio",
+    feature = "async-std",
+    target_arch = "wasm32"
+),))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio", feature = "async-std"))))]
 pub mod time;
 
+#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
+use iced_web_winit as runtime;
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(feature = "glow"),
     feature = "wgpu"
 ))]
 use iced_winit as runtime;
-#[cfg(all(target_arch = "wasm32", not(feature = "web")))]
-use iced_web_winit as runtime;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
 use iced_glutin as runtime;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -71,7 +71,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 impl<Flags> From<Settings<Flags>> for iced_winit::Settings<Flags> {
     fn from(settings: Settings<Flags>) -> iced_winit::Settings<Flags> {
         iced_winit::Settings {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -71,7 +71,7 @@ where
     }
 }
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl<Flags> From<Settings<Flags>> for iced_winit::Settings<Flags> {
     fn from(settings: Settings<Flags>) -> iced_winit::Settings<Flags> {
         iced_winit::Settings {

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,8 +7,22 @@ use crate::Subscription;
 /// produce more messages every `duration` after that.
 ///
 /// [`Subscription`]: ../subscription/struct.Subscription.html
+#[cfg(not(target_arch = "wasm32"))]
 pub fn every(
     duration: std::time::Duration,
 ) -> Subscription<std::time::Instant> {
+    iced_futures::time::every(duration)
+}
+
+/// Returns a [`Subscription`] that produces messages at a set interval.
+///
+/// The first message is produced after a `duration`, and then continues to
+/// produce more messages every `duration` after that.
+///
+/// [`Subscription`]: ../subscription/struct.Subscription.html
+#[cfg(target_arch = "wasm32")]
+pub fn every(
+    duration: std::time::Duration,
+) -> Subscription<wasm_timer::Instant> {
     iced_futures::time::every(duration)
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,7 +16,7 @@
 //!
 //! [`TextInput`]: text_input/struct.TextInput.html
 //! [`text_input::State`]: text_input/struct.State.html
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 mod platform {
     pub use crate::renderer::widget::{
         button, checkbox, container, pane_grid, pick_list, progress_bar, radio,
@@ -55,7 +55,7 @@ mod platform {
     pub use canvas::Canvas;
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "web")]
 mod platform {
     pub use iced_web::widget::*;
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,7 +16,7 @@
 //!
 //! [`TextInput`]: text_input/struct.TextInput.html
 //! [`text_input::State`]: text_input/struct.State.html
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 mod platform {
     pub use crate::renderer::widget::{
         button, checkbox, container, pane_grid, pick_list, progress_bar, radio,
@@ -55,7 +55,7 @@ mod platform {
     pub use canvas::Canvas;
 }
 
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 mod platform {
     pub use iced_web::widget::*;
 }

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -3,18 +3,18 @@ use std::fmt;
 use std::io;
 
 /// The icon of a window.
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 #[derive(Debug, Clone)]
 pub struct Icon(iced_winit::winit::window::Icon);
 
 /// The icon of a window.
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
 pub struct Icon;
 
 impl Icon {
     /// Creates an icon from 32bpp RGBA data.
-    #[cfg(not(feature = "web"))]
+    #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
     pub fn from_rgba(
         rgba: Vec<u8>,
         width: u32,
@@ -27,7 +27,7 @@ impl Icon {
     }
 
     /// Creates an icon from 32bpp RGBA data.
-    #[cfg(feature = "web")]
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
     pub fn from_rgba(
         _rgba: Vec<u8>,
         _width: u32,
@@ -62,7 +62,7 @@ pub enum Error {
     OsError(io::Error),
 }
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl From<iced_winit::winit::window::BadIcon> for Error {
     fn from(error: iced_winit::winit::window::BadIcon) -> Self {
         use iced_winit::winit::window::BadIcon;
@@ -86,7 +86,7 @@ impl From<iced_winit::winit::window::BadIcon> for Error {
     }
 }
 
-#[cfg(not(feature = "web "))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl From<Icon> for iced_winit::winit::window::Icon {
     fn from(icon: Icon) -> Self {
         icon.0

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -3,18 +3,18 @@ use std::fmt;
 use std::io;
 
 /// The icon of a window.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 #[derive(Debug, Clone)]
 pub struct Icon(iced_winit::winit::window::Icon);
 
 /// The icon of a window.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "web")]
 #[derive(Debug, Clone)]
 pub struct Icon;
 
 impl Icon {
     /// Creates an icon from 32bpp RGBA data.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(feature = "web"))]
     pub fn from_rgba(
         rgba: Vec<u8>,
         width: u32,
@@ -27,7 +27,7 @@ impl Icon {
     }
 
     /// Creates an icon from 32bpp RGBA data.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(feature = "web")]
     pub fn from_rgba(
         _rgba: Vec<u8>,
         _width: u32,
@@ -62,7 +62,7 @@ pub enum Error {
     OsError(io::Error),
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 impl From<iced_winit::winit::window::BadIcon> for Error {
     fn from(error: iced_winit::winit::window::BadIcon) -> Self {
         use iced_winit::winit::window::BadIcon;
@@ -86,7 +86,7 @@ impl From<iced_winit::winit::window::BadIcon> for Error {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web "))]
 impl From<Icon> for iced_winit::winit::window::Icon {
     fn from(icon: Icon) -> Self {
         icon.0

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -39,7 +39,7 @@ impl Default for Settings {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "web"))]
 impl From<Settings> for iced_winit::settings::Window {
     fn from(settings: Settings) -> Self {
         Self {

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -39,7 +39,7 @@ impl Default for Settings {
     }
 }
 
-#[cfg(not(feature = "web"))]
+#[cfg(not(all(feature = "web", target_arch = "wasm32")))]
 impl From<Settings> for iced_winit::settings::Window {
     fn from(settings: Settings) -> Self {
         Self {

--- a/web_winit/Cargo.toml
+++ b/web_winit/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "iced_web_winit"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2018"
+description = "A web-only winit runtime for Iced"
+license = "MIT"
+repository = "https://github.com/hecrj/iced"
+documentation = "https://docs.rs/iced_web_winit"
+keywords = ["gui", "ui", "graphics", "interface", "widgets"]
+categories = ["gui"]
+
+[features]
+debug = ["iced_winit/debug"]
+
+[dependencies]
+winit = "0.22"
+web-sys = "0.3"
+wasm-bindgen = "0.2"
+
+[dependencies.iced_native]
+version = "0.2"
+path = "../native"
+
+[dependencies.iced_winit]
+version = "0.1"
+path = "../winit"
+
+[dependencies.iced_graphics]
+version = "0.1"
+path = "../graphics"

--- a/web_winit/src/application.rs
+++ b/web_winit/src/application.rs
@@ -25,7 +25,7 @@ pub fn run<A, E, C>(
     use winit::{
         event,
         event_loop::{ControlFlow, EventLoop},
-	platform::web::WindowExtWebSys,
+        platform::web::WindowExtWebSys,
     };
 
     let mut debug = Debug::new();
@@ -72,19 +72,23 @@ pub fn run<A, E, C>(
         canvas.set_width(width);
         canvas.set_height(height);
 
-        let _ = body.append_child(&canvas)
+        let _ = body
+            .append_child(&canvas)
             .expect("Append canvas to HTML body");
 
         let onresize_callback = {
             wasm_bindgen::closure::Closure::wrap(Box::new(move || {
                 let window = web_sys::window().unwrap();
 
-                let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
-                let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
+                let width =
+                    window.inner_width().unwrap().as_f64().unwrap() as u32;
+                let height =
+                    window.inner_height().unwrap().as_f64().unwrap() as u32;
 
                 canvas.set_width(width);
                 canvas.set_height(height);
-            }) as Box<dyn FnMut()>)
+            })
+                as Box<dyn FnMut()>)
         };
         window.set_onresize(Some(onresize_callback.as_ref().unchecked_ref()));
         onresize_callback.forget();
@@ -103,11 +107,8 @@ pub fn run<A, E, C>(
     let mut resized = false;
 
     #[allow(unsafe_code)]
-    let (mut compositor, mut renderer) = unsafe {
-        C::new(compositor_settings, |address| {
-            std::ptr::null()
-        })
-    };
+    let (mut compositor, mut renderer) =
+        unsafe { C::new(compositor_settings, |address| std::ptr::null()) };
 
     let mut state = program::State::new(
         application,
@@ -231,9 +232,9 @@ pub fn run<A, E, C>(
                 debug.render_finished();
 
                 if new_mouse_interaction != mouse_interaction {
-                    window.set_cursor_icon(
-                        conversion::mouse_interaction(new_mouse_interaction),
-                    );
+                    window.set_cursor_icon(conversion::mouse_interaction(
+                        new_mouse_interaction,
+                    ));
 
                     mouse_interaction = new_mouse_interaction;
                 }

--- a/web_winit/src/application.rs
+++ b/web_winit/src/application.rs
@@ -1,0 +1,274 @@
+//! Create interactive, native cross-platform applications.
+
+use crate::{mouse, Executor, Runtime, Size};
+use iced_graphics::window;
+use iced_graphics::Viewport;
+use iced_winit::application;
+use iced_winit::conversion;
+use iced_winit::{Clipboard, Debug, Proxy, Settings};
+
+pub use iced_winit::Application;
+pub use iced_winit::{program, Program};
+
+/// Runs an [`Application`] with an executor, compositor, and the provided
+/// settings.
+///
+/// [`Application`]: trait.Application.html
+pub fn run<A, E, C>(
+    settings: Settings<A::Flags>,
+    compositor_settings: C::Settings,
+) where
+    A: Application + 'static,
+    E: Executor + 'static,
+    C: window::GLCompositor<Renderer = A::Renderer> + 'static,
+{
+    use winit::{
+        event,
+        event_loop::{ControlFlow, EventLoop},
+	platform::web::WindowExtWebSys,
+    };
+
+    let mut debug = Debug::new();
+    debug.startup_started();
+
+    let event_loop = EventLoop::with_user_event();
+    let mut runtime = {
+        let executor = E::new().expect("Create executor");
+        let proxy = Proxy::new(event_loop.create_proxy());
+
+        Runtime::new(executor, proxy)
+    };
+
+    let flags = settings.flags;
+    let (application, init_command) = runtime.enter(|| A::new(flags));
+    runtime.spawn(init_command);
+
+    let subscription = application.subscription();
+    runtime.track(subscription);
+
+    let mut title = application.title();
+    let mut mode = application.mode();
+    let mut background_color = application.background_color();
+    let mut scale_factor = application.scale_factor();
+
+    let window = settings
+        .window
+        .into_builder(&title, mode, event_loop.primary_monitor())
+        .build(&event_loop)
+        .expect("Open window");
+
+    {
+        use wasm_bindgen::JsCast;
+
+        let canvas = window.canvas();
+        let window = web_sys::window().unwrap();
+        let document = window.document().unwrap();
+        let body = document.body().unwrap();
+
+        let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
+        let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
+
+        canvas.set_id("iced-is-good-gui");
+        canvas.set_width(width);
+        canvas.set_height(height);
+
+        let _ = body.append_child(&canvas)
+            .expect("Append canvas to HTML body");
+
+        let onresize_callback = {
+            wasm_bindgen::closure::Closure::wrap(Box::new(move || {
+                let window = web_sys::window().unwrap();
+
+                let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
+                let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
+
+                canvas.set_width(width);
+                canvas.set_height(height);
+            }) as Box<dyn FnMut()>)
+        };
+        window.set_onresize(Some(onresize_callback.as_ref().unchecked_ref()));
+        onresize_callback.forget();
+    }
+
+    let clipboard = Clipboard::new(&window);
+    let mut cursor_position = winit::dpi::PhysicalPosition::new(-1.0, -1.0);
+    let mut mouse_interaction = mouse::Interaction::default();
+    let mut modifiers = winit::event::ModifiersState::default();
+
+    let physical_size = window.inner_size();
+    let mut viewport = Viewport::with_physical_size(
+        Size::new(physical_size.width, physical_size.height),
+        window.scale_factor() * scale_factor,
+    );
+    let mut resized = false;
+
+    #[allow(unsafe_code)]
+    let (mut compositor, mut renderer) = unsafe {
+        C::new(compositor_settings, |address| {
+            std::ptr::null()
+        })
+    };
+
+    let mut state = program::State::new(
+        application,
+        viewport.logical_size(),
+        conversion::cursor_position(cursor_position, viewport.scale_factor()),
+        &mut renderer,
+        &mut debug,
+    );
+    debug.startup_finished();
+
+    event_loop.run(move |event, _, control_flow| {
+        match event {
+            event::Event::MainEventsCleared => {
+                if state.is_queue_empty() {
+                    window.request_redraw();
+                    return;
+                }
+
+                let command = runtime.enter(|| {
+                    state.update(
+                        viewport.logical_size(),
+                        conversion::cursor_position(
+                            cursor_position,
+                            viewport.scale_factor(),
+                        ),
+                        clipboard.as_ref().map(|c| c as _),
+                        &mut renderer,
+                        &mut debug,
+                    )
+                });
+
+                // If the application was updated
+                if let Some(command) = command {
+                    runtime.spawn(command);
+
+                    let program = state.program();
+
+                    // Update subscriptions
+                    let subscription = program.subscription();
+                    runtime.track(subscription);
+
+                    // Update window title
+                    let new_title = program.title();
+
+                    if title != new_title {
+                        window.set_title(&new_title);
+
+                        title = new_title;
+                    }
+
+                    // Update window mode
+                    let new_mode = program.mode();
+
+                    if mode != new_mode {
+                        window.set_fullscreen(conversion::fullscreen(
+                            window.current_monitor(),
+                            new_mode,
+                        ));
+
+                        mode = new_mode;
+                    }
+
+                    // Update background color
+                    background_color = program.background_color();
+
+                    // Update scale factor
+                    let new_scale_factor = program.scale_factor();
+
+                    if scale_factor != new_scale_factor {
+                        let size = window.inner_size();
+
+                        viewport = Viewport::with_physical_size(
+                            Size::new(size.width, size.height),
+                            window.scale_factor() * new_scale_factor,
+                        );
+
+                        // We relayout the UI with the new logical size.
+                        // The queue is empty, therefore this will never produce
+                        // a `Command`.
+                        //
+                        // TODO: Properly queue `WindowResized`
+                        let _ = state.update(
+                            viewport.logical_size(),
+                            conversion::cursor_position(
+                                cursor_position,
+                                viewport.scale_factor(),
+                            ),
+                            clipboard.as_ref().map(|c| c as _),
+                            &mut renderer,
+                            &mut debug,
+                        );
+
+                        scale_factor = new_scale_factor;
+                    }
+                }
+
+                window.request_redraw();
+            }
+            event::Event::UserEvent(message) => {
+                state.queue_message(message);
+            }
+            event::Event::RedrawRequested(_) => {
+                debug.render_started();
+
+                if resized {
+                    let physical_size = viewport.physical_size();
+
+                    compositor.resize_viewport(physical_size);
+
+                    resized = false;
+                }
+
+                let new_mouse_interaction = compositor.draw(
+                    &mut renderer,
+                    &viewport,
+                    background_color,
+                    state.primitive(),
+                    &debug.overlay(),
+                );
+
+                debug.render_finished();
+
+                if new_mouse_interaction != mouse_interaction {
+                    window.set_cursor_icon(
+                        conversion::mouse_interaction(new_mouse_interaction),
+                    );
+
+                    mouse_interaction = new_mouse_interaction;
+                }
+
+                // TODO: Handle animations!
+                // Maybe we can use `ControlFlow::WaitUntil` for this.
+            }
+            event::Event::WindowEvent {
+                event: window_event,
+                ..
+            } => {
+                application::handle_window_event(
+                    &window_event,
+                    &window,
+                    scale_factor,
+                    control_flow,
+                    &mut cursor_position,
+                    &mut modifiers,
+                    &mut viewport,
+                    &mut resized,
+                    &mut debug,
+                );
+
+                if let Some(event) = conversion::window_event(
+                    &window_event,
+                    viewport.scale_factor(),
+                    modifiers,
+                ) {
+                    state.queue_event(event.clone());
+                    runtime.broadcast(event);
+                }
+            }
+            _ => {
+                *control_flow = ControlFlow::Wait;
+            }
+        }
+    })
+}

--- a/web_winit/src/application.rs
+++ b/web_winit/src/application.rs
@@ -108,7 +108,7 @@ pub fn run<A, E, C>(
 
     #[allow(unsafe_code)]
     let (mut compositor, mut renderer) =
-        unsafe { C::new(compositor_settings, |address| std::ptr::null()) };
+        unsafe { C::new(compositor_settings, |_| std::ptr::null()) };
 
     let mut state = program::State::new(
         application,

--- a/web_winit/src/lib.rs
+++ b/web_winit/src/lib.rs
@@ -11,11 +11,13 @@
 #[doc(no_inline)]
 pub use iced_native::*;
 
+#[cfg(target_arch = "wasm32")]
 pub mod application;
 
 pub use iced_winit::settings;
 pub use iced_winit::Mode;
 
+#[cfg(target_arch = "wasm32")]
 #[doc(no_inline)]
 pub use application::Application;
 #[doc(no_inline)]

--- a/web_winit/src/lib.rs
+++ b/web_winit/src/lib.rs
@@ -1,0 +1,22 @@
+//! A windowing shell for [`iced`] for the Web, on top of [`winit`].
+//!
+//! [`iced`]: https://github.com/hecrj/iced
+//! [`winit`]: https://github.com/rust-windowing/winit
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![deny(unused_results)]
+#![deny(unsafe_code)]
+#![forbid(rust_2018_idioms)]
+
+#[doc(no_inline)]
+pub use iced_native::*;
+
+pub mod application;
+
+pub use iced_winit::settings;
+pub use iced_winit::Mode;
+
+#[doc(no_inline)]
+pub use application::Application;
+#[doc(no_inline)]
+pub use settings::Settings;

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -14,8 +14,6 @@ categories = ["gui"]
 debug = ["iced_native/debug"]
 
 [dependencies]
-winit = "0.22"
-window_clipboard = "0.1"
 log = "0.4"
 
 [dependencies.iced_native]
@@ -28,3 +26,12 @@ path = "../graphics"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.6"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+window_clipboard = "0.1"
+winit = "0.22"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.winit]
+version = "0.22"
+default_features = false
+features = ["web-sys"]

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -1,19 +1,47 @@
-/// A buffer for short-term storage and transfer within and between
-/// applications.
-#[allow(missing_debug_implementations)]
-pub struct Clipboard(window_clipboard::Clipboard);
+pub use inner::*;
 
-impl Clipboard {
-    /// Creates a new [`Clipboard`] for the given window.
-    ///
-    /// [`Clipboard`]: struct.Clipboard.html
-    pub fn new(window: &winit::window::Window) -> Option<Clipboard> {
-        window_clipboard::Clipboard::new(window).map(Clipboard).ok()
+#[cfg(target_arch = "wasm32-unknown-unknown")]
+mod inner {
+    /// A buffer for short-term storage and transfer within and between
+    /// applications.
+    #[allow(missing_debug_implementations)]
+    pub struct Clipboard(window_clipboard::Clipboard);
+
+    impl Clipboard {
+        /// Creates a new [`Clipboard`] for the given window.
+        ///
+        /// [`Clipboard`]: struct.Clipboard.html
+        pub fn new(window: &winit::window::Window) -> Option<Clipboard> {
+            window_clipboard::Clipboard::new(window).map(Clipboard).ok()
+        }
+    }
+
+    impl iced_native::Clipboard for Clipboard {
+        fn content(&self) -> Option<String> {
+            self.0.read().ok()
+        }
     }
 }
 
-impl iced_native::Clipboard for Clipboard {
-    fn content(&self) -> Option<String> {
-        self.0.read().ok()
+#[cfg(not(target_arch = "wasm32-unknown-unknown"))]
+mod inner {
+    /// A buffer for short-term storage and transfer within and between
+    /// applications.
+    #[allow(missing_debug_implementations)]
+    pub struct Clipboard;
+
+    impl Clipboard {
+        /// Creates a new [`Clipboard`] for the given window.
+        ///
+        /// [`Clipboard`]: struct.Clipboard.html
+        pub fn new(_window: &winit::window::Window) -> Option<Clipboard> {
+            Some(Clipboard)
+        }
+    }
+
+    impl iced_native::Clipboard for Clipboard {
+        fn content(&self) -> Option<String> {
+            Some("".to_string())
+        }
     }
 }


### PR DESCRIPTION
Hello!

This PR adds proof-of-concept support for the glow backend on web. I did this because I wanted the `Canvas` widget for the web in my application. I had to modify modify the version in the shaders to be `#version 300 es`, and they still work on the native target for me so maybe it's fine to just leave them that way? Otherwise I can put logic in to have it be `#version 330` for native and `#version 300 es` for web.

This allows you to build the solar system example if you use the following features:
`iced = { path = "../..", default-features = false, features = ["glow", "glow_canvas", "winit"] }`
I also had trouble with the `rand` crate on wasm so had to remove the random star position generation.

I had to do some questionable things to make things `!Send` for the `wasm32` target...

I have to do more tests so definitely not merge-able as-is. One thing I know is broken is text boxes on the web with the glow backend.

![iced-solar-system](https://user-images.githubusercontent.com/1218723/92192080-152c3300-ee1a-11ea-8679-1df8ea2f9ff3.png)

![image](https://user-images.githubusercontent.com/1218723/92274903-ef973c00-eea2-11ea-8ee4-db8428d53c6d.png)
