### PR TITLE
Error propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
 [dependencies]
 iced_core = { version = "0.2", path = "core" }
 iced_futures = { version = "0.1", path = "futures" }
+thiserror = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.1", path = "winit" }

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -3,11 +3,11 @@ use iced::{
     button, Align, Button, Column, Element, Length, Sandbox, Settings, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings {
         antialiasing: true,
         ..Settings::default()
-    });
+    })
 }
 
 #[derive(Default)]

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -4,7 +4,7 @@ use iced::{
     Point, Rectangle, Settings, Subscription, Vector,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Clock::run(Settings {
         antialiasing: true,
         ..Settings::default()

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -8,7 +8,7 @@ use palette::{self, Hsl, Limited, Srgb};
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 
-pub fn main() {
+pub fn main() -> iced::Result {
     ColorPalette::run(Settings {
         antialiasing: true,
         ..Settings::default()

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,6 +1,6 @@
 use iced::{button, Align, Button, Column, Element, Sandbox, Settings, Text};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Counter::run(Settings::default())
 }
 

--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -90,7 +90,7 @@ use iced::{
     Slider, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings::default())
 }
 

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -5,7 +5,7 @@ use iced::{
 
 mod download;
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings::default())
 }
 

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -3,7 +3,7 @@ use iced::{
     Element, Length, Settings, Subscription, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Events::run(Settings::default())
 }
 

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -16,7 +16,7 @@ use iced::{
 use preset::Preset;
 use std::time::{Duration, Instant};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     GameOfLife::run(Settings {
         antialiasing: true,
         ..Settings::default()

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -165,7 +165,7 @@ use iced::{
 };
 use rainbow::Rainbow;
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings::default())
 }
 

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -4,7 +4,7 @@ use iced::{
     Settings, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings::default())
 }
 

--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -3,7 +3,7 @@ use iced::{
     Sandbox, Scrollable, Settings, Space, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Example::run(Settings::default())
 }
 

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -3,7 +3,7 @@ use iced::{
     Container, Element, Image, Length, Row, Settings, Text,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Pokedex::run(Settings::default())
 }
 

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,6 +1,6 @@
 use iced::{slider, Column, Element, ProgressBar, Sandbox, Settings, Slider};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Progress::run(Settings::default())
 }
 

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -14,7 +14,7 @@ use iced::{
 
 use std::time::Instant;
 
-pub fn main() {
+pub fn main() -> iced::Result {
     SolarSystem::run(Settings {
         antialiasing: true,
         ..Settings::default()

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -5,7 +5,7 @@ use iced::{
 };
 use std::time::{Duration, Instant};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Stopwatch::run(Settings::default())
 }
 

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -4,7 +4,7 @@ use iced::{
     Scrollable, Settings, Slider, Space, Text, TextInput,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Styling::run(Settings::default())
 }
 

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -1,6 +1,6 @@
 use iced::{Container, Element, Length, Sandbox, Settings, Svg};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Tiger::run(Settings::default())
 }
 

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -5,7 +5,7 @@ use iced::{
 };
 use serde::{Deserialize, Serialize};
 
-pub fn main() {
+pub fn main() -> iced::Result {
     Todos::run(Settings::default())
 }
 

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -4,7 +4,7 @@ use iced::{
     Sandbox, Scrollable, Settings, Slider, Space, Text, TextInput,
 };
 
-pub fn main() {
+pub fn main() -> iced::Result {
     env_logger::init();
 
     Tour::run(Settings::default())

--- a/glow/src/lib.rs
+++ b/glow/src/lib.rs
@@ -26,7 +26,7 @@ pub(crate) use iced_graphics::Transformation;
 #[doc(no_inline)]
 pub use widget::*;
 
-pub use iced_graphics::Viewport;
+pub use iced_graphics::{Error, Viewport};
 pub use iced_native::{
     Background, Color, Command, HorizontalAlignment, Length, Vector,
     VerticalAlignment,

--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Backend, Color, Renderer, Settings, Viewport};
+use crate::{Backend, Color, Error, Renderer, Settings, Viewport};
 
 use core::ffi::c_void;
 use glow::HasContext;
@@ -18,7 +18,7 @@ impl iced_graphics::window::GLCompositor for Compositor {
     unsafe fn new(
         settings: Self::Settings,
         loader_function: impl FnMut(&str) -> *const c_void,
-    ) -> (Self, Self::Renderer) {
+    ) -> Result<(Self, Self::Renderer), Error> {
         let gl = glow::Context::from_loader_function(loader_function);
 
         // Enable auto-conversion from/to sRGB
@@ -33,7 +33,7 @@ impl iced_graphics::window::GLCompositor for Compositor {
 
         let renderer = Renderer::new(Backend::new(&gl, settings));
 
-        (Self { gl }, renderer)
+        Ok((Self { gl }, renderer))
     }
 
     fn sample_count(settings: &Settings) -> u32 {

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -15,7 +15,7 @@ pub use iced_native::*;
 pub mod application;
 
 pub use iced_winit::settings;
-pub use iced_winit::Mode;
+pub use iced_winit::{Error, Mode};
 
 #[doc(no_inline)]
 pub use application::Application;

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -15,6 +15,7 @@ opengl = []
 bytemuck = "1.2"
 glam = "0.9"
 raw-window-handle = "0.3"
+thiserror = "1.0"
 
 [dependencies.iced_native]
 version = "0.2"

--- a/graphics/src/error.rs
+++ b/graphics/src/error.rs
@@ -1,0 +1,7 @@
+/// A graphical error that occurred while running an application.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A suitable graphics adapter or device could not be found
+    #[error("a suitable graphics adapter or device could not be found")]
+    AdapterNotFound,
+}

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -9,6 +9,7 @@
 #![forbid(rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 mod antialiasing;
+mod error;
 mod primitive;
 mod renderer;
 mod transformation;
@@ -29,6 +30,7 @@ pub use widget::*;
 pub use antialiasing::Antialiasing;
 pub use backend::Backend;
 pub use defaults::Defaults;
+pub use error::Error;
 pub use layer::Layer;
 pub use primitive::Primitive;
 pub use renderer::Renderer;

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Viewport};
+use crate::{Color, Error, Viewport};
 use iced_native::mouse;
 use raw_window_handle::HasRawWindowHandle;
 
@@ -19,7 +19,7 @@ pub trait Compositor: Sized {
     /// Creates a new [`Backend`].
     ///
     /// [`Backend`]: trait.Backend.html
-    fn new(settings: Self::Settings) -> (Self, Self::Renderer);
+    fn new(settings: Self::Settings) -> Result<(Self, Self::Renderer), Error>;
 
     /// Crates a new [`Surface`] for the given window.
     ///

--- a/graphics/src/window/gl_compositor.rs
+++ b/graphics/src/window/gl_compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Size, Viewport};
+use crate::{Color, Error, Size, Viewport};
 use iced_native::mouse;
 
 use core::ffi::c_void;
@@ -41,7 +41,7 @@ pub trait GLCompositor: Sized {
     unsafe fn new(
         settings: Self::Settings,
         loader_function: impl FnMut(&str) -> *const c_void,
-    ) -> (Self, Self::Renderer);
+    ) -> Result<(Self, Self::Renderer), Error>;
 
     /// Returns the amount of samples that should be used when configuring
     /// an OpenGL context for this [`Compositor`].

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,6 +1,5 @@
-use crate::{
-    window, Color, Command, Element, Executor, Settings, Subscription,
-};
+use crate::window;
+use crate::{Color, Command, Element, Executor, Settings, Subscription};
 
 /// An interactive cross-platform application.
 ///
@@ -59,7 +58,7 @@ use crate::{
 /// ```no_run
 /// use iced::{executor, Application, Command, Element, Settings, Text};
 ///
-/// pub fn main() {
+/// pub fn main() -> iced::Result {
 ///     Hello::run(Settings::default())
 /// }
 ///
@@ -204,12 +203,13 @@ pub trait Application: Sized {
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread
-    /// and __will NOT return__.
+    /// and __will NOT return__ unless there is an [`Error`] during startup.
     ///
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Application`]: trait.Application.html
-    fn run(settings: Settings<Self::Flags>)
+    /// [`Error`]: enum.Error.html
+    fn run(settings: Settings<Self::Flags>) -> crate::Result
     where
         Self: 'static,
     {
@@ -226,15 +226,19 @@ pub trait Application: Sized {
                 ..crate::renderer::Settings::default()
             };
 
-            crate::runtime::application::run::<
+            Ok(crate::runtime::application::run::<
                 Instance<Self>,
                 Self::Executor,
                 crate::renderer::window::Compositor,
-            >(settings.into(), renderer_settings);
+            >(settings.into(), renderer_settings)?)
         }
 
         #[cfg(target_arch = "wasm32")]
-        <Instance<Self> as iced_web::Application>::run(settings.flags);
+        {
+            <Instance<Self> as iced_web::Application>::run(settings.flags);
+
+            Ok(())
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+use iced_futures::futures;
+
+/// An error that occurred while running an application.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The futures executor could not be created.
+    #[error("the futures executor could not be created")]
+    ExecutorCreationFailed(futures::io::Error),
+
+    /// The application window could not be created.
+    #[error("the application window could not be created")]
+    WindowCreationFailed(Box<dyn std::error::Error>),
+
+    /// A suitable graphics adapter or device could not be found.
+    #[error("a suitable graphics adapter or device could not be found")]
+    GraphicsAdapterNotFound,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<iced_winit::Error> for Error {
+    fn from(error: iced_winit::Error) -> Error {
+        match error {
+            iced_winit::Error::ExecutorCreationFailed(error) => {
+                Error::ExecutorCreationFailed(error)
+            }
+            iced_winit::Error::WindowCreationFailed(error) => {
+                Error::WindowCreationFailed(Box::new(error))
+            }
+            iced_winit::Error::GraphicsAdapterNotFound => {
+                Error::GraphicsAdapterNotFound
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 mod application;
 mod element;
+mod error;
+mod result;
 mod sandbox;
 
 pub mod executor;
@@ -225,7 +227,9 @@ pub use widget::*;
 
 pub use application::Application;
 pub use element::Element;
+pub use error::Error;
 pub use executor::Executor;
+pub use result::Result;
 pub use sandbox::Sandbox;
 pub use settings::Settings;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,6 @@
+use crate::Error;
+
+/// The result of running an [`Application`].
+///
+/// [`Application`]: trait.Application.html
+pub type Result = std::result::Result<(), Error>;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,5 +1,6 @@
+use crate::executor;
 use crate::{
-    executor, Application, Color, Command, Element, Settings, Subscription,
+    Application, Color, Command, Element, Error, Settings, Subscription,
 };
 
 /// A sandboxed [`Application`].
@@ -64,7 +65,7 @@ use crate::{
 /// ```no_run
 /// use iced::{Element, Sandbox, Settings, Text};
 ///
-/// pub fn main() {
+/// pub fn main() -> iced::Result {
 ///     Hello::run(Settings::default())
 /// }
 ///
@@ -159,7 +160,7 @@ pub trait Sandbox {
     /// It should probably be that last thing you call in your `main` function.
     ///
     /// [`Sandbox`]: trait.Sandbox.html
-    fn run(settings: Settings<()>)
+    fn run(settings: Settings<()>) -> Result<(), Error>
     where
         Self: 'static + Sized,
     {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -36,7 +36,9 @@ mod backend;
 mod quad;
 mod text;
 
-pub use iced_graphics::{Antialiasing, Color, Defaults, Primitive, Viewport};
+pub use iced_graphics::{
+    Antialiasing, Color, Defaults, Error, Primitive, Viewport,
+};
 pub use wgpu;
 
 pub use backend::Backend;

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -1,7 +1,6 @@
-use crate::{Backend, Color, Renderer, Settings};
+use crate::{Backend, Color, Error, Renderer, Settings, Viewport};
 
 use futures::task::SpawnExt;
-use iced_graphics::Viewport;
 use iced_native::{futures, mouse};
 use raw_window_handle::HasRawWindowHandle;
 
@@ -82,13 +81,13 @@ impl iced_graphics::window::Compositor for Compositor {
     type Surface = wgpu::Surface;
     type SwapChain = wgpu::SwapChain;
 
-    fn new(settings: Self::Settings) -> (Self, Renderer) {
+    fn new(settings: Self::Settings) -> Result<(Self, Renderer), Error> {
         let compositor = futures::executor::block_on(Self::request(settings))
-            .expect("Could not find a suitable graphics adapter");
+            .ok_or(Error::AdapterNotFound)?;
 
         let backend = compositor.create_backend();
 
-        (compositor, Renderer::new(backend))
+        Ok((compositor, Renderer::new(backend)))
     }
 
     fn create_surface<W: HasRawWindowHandle>(

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -17,6 +17,7 @@ debug = ["iced_native/debug"]
 winit = "0.22"
 window_clipboard = "0.1"
 log = "0.4"
+thiserror = "1.0"
 
 [dependencies.iced_native]
 version = "0.2"
@@ -25,6 +26,10 @@ path = "../native"
 [dependencies.iced_graphics]
 version = "0.1"
 path = "../graphics"
+
+[dependencies.iced_futures]
+version = "0.1"
+path = "../futures"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "0.3.6"

--- a/winit/src/error.rs
+++ b/winit/src/error.rs
@@ -1,0 +1,27 @@
+use iced_futures::futures;
+
+/// An error that occurred while running an application.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The futures executor could not be created.
+    #[error("the futures executor could not be created")]
+    ExecutorCreationFailed(futures::io::Error),
+
+    /// The application window could not be created.
+    #[error("the application window could not be created")]
+    WindowCreationFailed(winit::error::OsError),
+
+    /// A suitable graphics adapter or device could not be found.
+    #[error("a suitable graphics adapter or device could not be found")]
+    GraphicsAdapterNotFound,
+}
+
+impl From<iced_graphics::Error> for Error {
+    fn from(error: iced_graphics::Error) -> Error {
+        match error {
+            iced_graphics::Error::AdapterNotFound => {
+                Error::GraphicsAdapterNotFound
+            }
+        }
+    }
+}

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -30,11 +30,13 @@ pub mod conversion;
 pub mod settings;
 
 mod clipboard;
+mod error;
 mod mode;
 mod proxy;
 
 pub use application::Application;
 pub use clipboard::Clipboard;
+pub use error::Error;
 pub use mode::Mode;
 pub use proxy::Proxy;
 pub use settings::Settings;


### PR DESCRIPTION
Introduces `Error` types in `iced`, `iced_winit`, and `iced_graphics` while propagating them all the way to the `run` method in both `Application` and `Sandbox`.

In other words, `Application::run` and `Sandbox::run` return a `Result` now, instead of panicking. Therefore, it is now possible to handle startup errors and properly display them to the user.