### PR TITLE
Fix: ignoring all `target` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 pkg/
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
The `.gitignore` file contained the line `/target` which ignores the `target` directory on the root but not in subdirectories like `core/target/`, `examples/custom_widget/target/`, ... . For me, this directories should also be ignored. This PR fixes this by changing the line to `target/`.