### PR TITLE
Fixes #539: Allow windows to be set always_on_top

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -18,8 +18,11 @@ pub struct Settings {
     /// Whether the window should have a border, a title bar, etc. or not.
     pub decorations: bool,
 
-    /// Whether the window should be transparent
+    /// Whether the window should be transparent.
     pub transparent: bool,
+
+    /// Whether the window will always be on top of other windows.
+    pub always_on_top: bool,
 
     /// The icon of the window.
     pub icon: Option<Icon>,
@@ -34,6 +37,7 @@ impl Default for Settings {
             resizable: true,
             decorations: true,
             transparent: false,
+            always_on_top: false,
             icon: None,
         }
     }
@@ -49,6 +53,7 @@ impl From<Settings> for iced_winit::settings::Window {
             resizable: settings.resizable,
             decorations: settings.decorations,
             transparent: settings.transparent,
+            always_on_top: settings.always_on_top,
             icon: settings.icon.map(Icon::into),
             platform_specific: Default::default(),
         }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -45,8 +45,11 @@ pub struct Window {
     /// Whether the window should have a border, a title bar, etc.
     pub decorations: bool,
 
-    /// Whether the window should be transparent
+    /// Whether the window should be transparent.
     pub transparent: bool,
+
+    /// Whether the window will always be on top of other windows.
+    pub always_on_top: bool,
 
     /// The window icon, which is also usually used in the taskbar
     pub icon: Option<winit::window::Icon>,
@@ -74,6 +77,7 @@ impl Window {
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon)
+            .with_always_on_top(self.always_on_top)
             .with_fullscreen(conversion::fullscreen(primary_monitor, mode));
 
         if let Some((width, height)) = self.min_size {
@@ -108,6 +112,7 @@ impl Default for Window {
             resizable: true,
             decorations: true,
             transparent: false,
+            always_on_top: false,
             icon: None,
             platform_specific: Default::default(),
         }


### PR DESCRIPTION
Fixes #539.

```shell
[xxx@xxx]:~/projects/iced> cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.10s
     Running target/debug/deps/iced-cbc05f1843ac8fee

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests iced

running 7 tests
test src/lib.rs -  (line 69) ... ok
test src/sandbox.rs - sandbox::Sandbox (line 65) ... ok
test src/application.rs - application::Application (line 58) ... ok
test src/widget.rs - widget (line 7) ... ok
test src/lib.rs -  (line 53) ... ok
test src/lib.rs -  (line 127) ... ok
test src/lib.rs -  (line 80) ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```