### PR TITLE
Remove outdated `Fill` comment for `Column` and `Row`

### DIFF
--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -42,7 +42,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         Column {
             spacing: 0,
             padding: 0,
-            width: Length::Shrink,
+            width: Length::Fill,
             height: Length::Shrink,
             max_width: u32::MAX,
             max_height: u32::MAX,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -10,9 +10,10 @@ use std::u32;
 
 /// A container that distributes its contents vertically.
 ///
-/// A [`Column`] will try to fill the horizontal space of its container.
+/// A [`Column`] will not fill the horizontal space of its container. (set to [`Length::shrink`] by defualt)
 ///
 /// [`Column`]: struct.Column.html
+/// [`Length::shrink`]: ../../enum.Length.html
 #[allow(missing_debug_implementations)]
 pub struct Column<'a, Message, Renderer> {
     spacing: u16,
@@ -42,7 +43,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         Column {
             spacing: 0,
             padding: 0,
-            width: Length::Fill,
+            width: Length::Shrink,
             height: Length::Shrink,
             max_width: u32::MAX,
             max_height: u32::MAX,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -9,11 +9,6 @@ use crate::{
 use std::u32;
 
 /// A container that distributes its contents vertically.
-///
-/// A [`Column`] will not fill the horizontal space of its container. (set to [`Length::shrink`] by defualt)
-///
-/// [`Column`]: struct.Column.html
-/// [`Length::shrink`]: ../../enum.Length.html
 #[allow(missing_debug_implementations)]
 pub struct Column<'a, Message, Renderer> {
     spacing: u16,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -9,11 +9,6 @@ use crate::{
 use std::u32;
 
 /// A container that distributes its contents horizontally.
-///
-/// A [`Row`] will not fill the horizontal space of its container. (set to [`Length::shrink`] by defualt)
-///
-/// [`Row`]: struct.Row.html
-/// [`Length::shrink`]: ../../enum.Length.html
 #[allow(missing_debug_implementations)]
 pub struct Row<'a, Message, Renderer> {
     spacing: u16,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -10,9 +10,10 @@ use std::u32;
 
 /// A container that distributes its contents horizontally.
 ///
-/// A [`Row`] will try to fill the horizontal space of its container.
+/// A [`Row`] will not fill the horizontal space of its container. (set to [`Length::shrink`] by defualt)
 ///
 /// [`Row`]: struct.Row.html
+/// [`Length::shrink`]: ../../enum.Length.html
 #[allow(missing_debug_implementations)]
 pub struct Row<'a, Message, Renderer> {
     spacing: u16,


### PR DESCRIPTION
This PR makes the default width `Length::Fill` for the column widget.
Fixes #544.