### PR TITLE
Strawman implementation of blinking cursor in text input + animation 'WaitUntil'

### DIFF
--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -60,6 +60,7 @@ mod circle {
             _defaults: &Defaults,
             layout: Layout<'_>,
             _cursor_position: Point,
+            _draw_at: &mut Option<std::time::Instant>,
         ) -> (Primitive, mouse::Interaction) {
             (
                 Primitive::Quad {

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -57,6 +57,7 @@ mod rainbow {
             _defaults: &Defaults,
             layout: Layout<'_>,
             cursor_position: Point,
+            _draw_at: &mut Option<std::time::Instant>,
         ) -> (Primitive, mouse::Interaction) {
             let b = layout.bounds();
 

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -96,10 +96,11 @@ where
         widget: &dyn Widget<Message, Self>,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         color: Color,
     ) -> Self::Output {
         let (primitive, cursor) =
-            widget.draw(self, defaults, layout, cursor_position);
+            widget.draw(self, defaults, layout, cursor_position, draw_at);
 
         let mut primitives = Vec::new();
 

--- a/graphics/src/widget/button.rs
+++ b/graphics/src/widget/button.rs
@@ -33,6 +33,7 @@ where
         _defaults: &Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         is_disabled: bool,
         is_pressed: bool,
         style: &Box<dyn StyleSheet>,
@@ -62,6 +63,7 @@ where
             },
             content_layout,
             cursor_position,
+            draw_at,
         );
 
         (

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -196,6 +196,7 @@ where
         _defaults: &Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> (Primitive, mouse::Interaction) {
         let bounds = layout.bounds();
         let translation = Vector::new(bounds.x, bounds.y);

--- a/graphics/src/widget/column.rs
+++ b/graphics/src/widget/column.rs
@@ -27,12 +27,20 @@ where
                     .iter()
                     .zip(layout.children())
                     .map(|(child, layout)| {
+                        let mut draw_at_elem = None;
                         let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position, draw_at);
+                            child.draw(self, defaults, layout, cursor_position, &mut draw_at_elem);
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;
                         }
+
+                        // Set draw_at to lower of the child or current values.
+                        *draw_at = match (draw_at_elem, draw_at.is_some()) {
+                            (Some(dae), false) => Some(dae),
+                            (Some(dae), true) => Some(std::cmp::min(dae, draw_at.unwrap())),
+                            (None, _) => *draw_at,
+                        };
 
                         primitive
                     })

--- a/graphics/src/widget/column.rs
+++ b/graphics/src/widget/column.rs
@@ -17,6 +17,7 @@ where
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output {
         let mut mouse_interaction = mouse::Interaction::default();
 
@@ -27,7 +28,7 @@ where
                     .zip(layout.children())
                     .map(|(child, layout)| {
                         let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position);
+                            child.draw(self, defaults, layout, cursor_position, draw_at);
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;

--- a/graphics/src/widget/column.rs
+++ b/graphics/src/widget/column.rs
@@ -28,8 +28,13 @@ where
                     .zip(layout.children())
                     .map(|(child, layout)| {
                         let mut draw_at_elem = None;
-                        let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position, &mut draw_at_elem);
+                        let (primitive, new_mouse_interaction) = child.draw(
+                            self,
+                            defaults,
+                            layout,
+                            cursor_position,
+                            &mut draw_at_elem,
+                        );
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;
@@ -38,7 +43,9 @@ where
                         // Set draw_at to lower of the child or current values.
                         *draw_at = match (draw_at_elem, draw_at.is_some()) {
                             (Some(dae), false) => Some(dae),
-                            (Some(dae), true) => Some(std::cmp::min(dae, draw_at.unwrap())),
+                            (Some(dae), true) => {
+                                Some(std::cmp::min(dae, draw_at.unwrap()))
+                            }
                             (None, _) => *draw_at,
                         };
 

--- a/graphics/src/widget/container.rs
+++ b/graphics/src/widget/container.rs
@@ -24,6 +24,7 @@ where
         defaults: &Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         style_sheet: &Self::Style,
         content: &Element<'_, Message, Self>,
         content_layout: Layout<'_>,
@@ -37,7 +38,7 @@ where
         };
 
         let (content, mouse_interaction) =
-            content.draw(self, &defaults, content_layout, cursor_position);
+            content.draw(self, &defaults, content_layout, cursor_position, draw_at);
 
         if let Some(background) = background(bounds, &style) {
             (

--- a/graphics/src/widget/container.rs
+++ b/graphics/src/widget/container.rs
@@ -37,8 +37,13 @@ where
             },
         };
 
-        let (content, mouse_interaction) =
-            content.draw(self, &defaults, content_layout, cursor_position, draw_at);
+        let (content, mouse_interaction) = content.draw(
+            self,
+            &defaults,
+            content_layout,
+            cursor_position,
+            draw_at,
+        );
 
         if let Some(background) = background(bounds, &style) {
             (

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -63,8 +63,13 @@ where
             .zip(layout.children())
             .enumerate()
             .map(|(i, ((id, pane), layout))| {
-                let (primitive, new_mouse_interaction) =
-                    pane.draw(self, defaults, layout, pane_cursor_position, draw_at);
+                let (primitive, new_mouse_interaction) = pane.draw(
+                    self,
+                    defaults,
+                    layout,
+                    pane_cursor_position,
+                    draw_at,
+                );
 
                 if new_mouse_interaction > mouse_interaction {
                     mouse_interaction = new_mouse_interaction;

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -45,6 +45,7 @@ where
         resizing: Option<Axis>,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output {
         let pane_cursor_position = if dragging.is_some() {
             // TODO: Remove once cursor availability is encoded in the type
@@ -63,7 +64,7 @@ where
             .enumerate()
             .map(|(i, ((id, pane), layout))| {
                 let (primitive, new_mouse_interaction) =
-                    pane.draw(self, defaults, layout, pane_cursor_position);
+                    pane.draw(self, defaults, layout, pane_cursor_position, draw_at);
 
                 if new_mouse_interaction > mouse_interaction {
                     mouse_interaction = new_mouse_interaction;
@@ -132,12 +133,13 @@ where
         title_bar: Option<(&TitleBar<'_, Message, Self>, Layout<'_>)>,
         body: (&Element<'_, Message, Self>, Layout<'_>),
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output {
         let style = style_sheet.style();
         let (body, body_layout) = body;
 
         let (body_primitive, body_interaction) =
-            body.draw(self, defaults, body_layout, cursor_position);
+            body.draw(self, defaults, body_layout, cursor_position, draw_at);
 
         let background = crate::widget::container::background(bounds, &style);
 
@@ -151,6 +153,7 @@ where
                 defaults,
                 title_bar_layout,
                 cursor_position,
+                draw_at,
                 show_controls,
             );
 
@@ -195,6 +198,7 @@ where
         title_bounds: Rectangle,
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output {
         let style = style_sheet.style();
 
@@ -224,6 +228,7 @@ where
                 &defaults,
                 controls_layout,
                 cursor_position,
+                draw_at,
             );
 
             (

--- a/graphics/src/widget/row.rs
+++ b/graphics/src/widget/row.rs
@@ -27,12 +27,20 @@ where
                     .iter()
                     .zip(layout.children())
                     .map(|(child, layout)| {
+                        let mut draw_at_elem = None;
                         let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position, draw_at);
+                            child.draw(self, defaults, layout, cursor_position, &mut draw_at_elem);
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;
                         }
+
+                        // Set draw_at to lower of the child or current values.
+                        *draw_at = match (draw_at_elem, draw_at.is_some()) {
+                            (Some(dae), false) => Some(dae),
+                            (Some(dae), true) => Some(std::cmp::min(dae, draw_at.unwrap())),
+                            (None, _) => *draw_at,
+                        };
 
                         primitive
                     })

--- a/graphics/src/widget/row.rs
+++ b/graphics/src/widget/row.rs
@@ -17,6 +17,7 @@ where
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output {
         let mut mouse_interaction = mouse::Interaction::default();
 
@@ -27,7 +28,7 @@ where
                     .zip(layout.children())
                     .map(|(child, layout)| {
                         let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position);
+                            child.draw(self, defaults, layout, cursor_position, draw_at);
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;

--- a/graphics/src/widget/row.rs
+++ b/graphics/src/widget/row.rs
@@ -28,8 +28,13 @@ where
                     .zip(layout.children())
                     .map(|(child, layout)| {
                         let mut draw_at_elem = None;
-                        let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position, &mut draw_at_elem);
+                        let (primitive, new_mouse_interaction) = child.draw(
+                            self,
+                            defaults,
+                            layout,
+                            cursor_position,
+                            &mut draw_at_elem,
+                        );
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;
@@ -38,7 +43,9 @@ where
                         // Set draw_at to lower of the child or current values.
                         *draw_at = match (draw_at_elem, draw_at.is_some()) {
                             (Some(dae), false) => Some(dae),
-                            (Some(dae), true) => Some(std::cmp::min(dae, draw_at.unwrap())),
+                            (Some(dae), true) => {
+                                Some(std::cmp::min(dae, draw_at.unwrap()))
+                            }
                             (None, _) => *draw_at,
                         };
 

--- a/graphics/src/widget/text_input.rs
+++ b/graphics/src/widget/text_input.rs
@@ -129,97 +129,97 @@ where
             *draw_at = Some(next_draw);
         };
 
-        let (contents_primitive, offset) = if state.is_focused() && cursor.blink_visible() {
+        let (contents_primitive, offset) =
+            if state.is_focused() && cursor.blink_visible() {
+                let (cursor_primitive, offset) = match cursor.state(value) {
+                    cursor::State::Index(position) => {
+                        let (text_value_width, offset) =
+                            measure_cursor_and_scroll_offset(
+                                self,
+                                text_bounds,
+                                value,
+                                size,
+                                position,
+                                font,
+                            );
 
-            let (cursor_primitive, offset) = match cursor.state(value) {
-                cursor::State::Index(position) => {
-                    let (text_value_width, offset) =
-                        measure_cursor_and_scroll_offset(
-                            self,
-                            text_bounds,
-                            value,
-                            size,
-                            position,
-                            font,
-                        );
-
-                    (
-                        Primitive::Quad {
-                            bounds: Rectangle {
-                                x: text_bounds.x + text_value_width,
-                                y: text_bounds.y,
-                                width: 1.0,
-                                height: text_bounds.height,
+                        (
+                            Primitive::Quad {
+                                bounds: Rectangle {
+                                    x: text_bounds.x + text_value_width,
+                                    y: text_bounds.y,
+                                    width: 1.0,
+                                    height: text_bounds.height,
+                                },
+                                background: Background::Color(
+                                    style_sheet.value_color(),
+                                ),
+                                border_radius: 0,
+                                border_width: 0,
+                                border_color: Color::TRANSPARENT,
                             },
-                            background: Background::Color(
-                                style_sheet.value_color(),
-                            ),
-                            border_radius: 0,
-                            border_width: 0,
-                            border_color: Color::TRANSPARENT,
-                        },
-                        offset,
-                    )
-                }
-                cursor::State::Selection { start, end } => {
-                    let left = start.min(end);
-                    let right = end.max(start);
+                            offset,
+                        )
+                    }
+                    cursor::State::Selection { start, end } => {
+                        let left = start.min(end);
+                        let right = end.max(start);
 
-                    let (left_position, left_offset) =
-                        measure_cursor_and_scroll_offset(
-                            self,
-                            text_bounds,
-                            value,
-                            size,
-                            left,
-                            font,
-                        );
+                        let (left_position, left_offset) =
+                            measure_cursor_and_scroll_offset(
+                                self,
+                                text_bounds,
+                                value,
+                                size,
+                                left,
+                                font,
+                            );
 
-                    let (right_position, right_offset) =
-                        measure_cursor_and_scroll_offset(
-                            self,
-                            text_bounds,
-                            value,
-                            size,
-                            right,
-                            font,
-                        );
+                        let (right_position, right_offset) =
+                            measure_cursor_and_scroll_offset(
+                                self,
+                                text_bounds,
+                                value,
+                                size,
+                                right,
+                                font,
+                            );
 
-                    let width = right_position - left_position;
+                        let width = right_position - left_position;
 
-                    (
-                        Primitive::Quad {
-                            bounds: Rectangle {
-                                x: text_bounds.x + left_position,
-                                y: text_bounds.y,
-                                width,
-                                height: text_bounds.height,
+                        (
+                            Primitive::Quad {
+                                bounds: Rectangle {
+                                    x: text_bounds.x + left_position,
+                                    y: text_bounds.y,
+                                    width,
+                                    height: text_bounds.height,
+                                },
+                                background: Background::Color(
+                                    style_sheet.selection_color(),
+                                ),
+                                border_radius: 0,
+                                border_width: 0,
+                                border_color: Color::TRANSPARENT,
                             },
-                            background: Background::Color(
-                                style_sheet.selection_color(),
-                            ),
-                            border_radius: 0,
-                            border_width: 0,
-                            border_color: Color::TRANSPARENT,
-                        },
-                        if end == right {
-                            right_offset
-                        } else {
-                            left_offset
-                        },
-                    )
-                }
+                            if end == right {
+                                right_offset
+                            } else {
+                                left_offset
+                            },
+                        )
+                    }
+                };
+
+                (
+                    Primitive::Group {
+                        primitives: vec![cursor_primitive, text_value],
+                    },
+                    Vector::new(offset as u32, 0),
+                )
+            } else {
+                (text_value, Vector::new(0, 0))
             };
-
-            (
-                Primitive::Group {
-                    primitives: vec![cursor_primitive, text_value],
-                },
-                Vector::new(offset as u32, 0),
-            )
-        } else {
-            (text_value, Vector::new(0, 0))
-        };
 
         let text_width = self.measure_value(
             if text.is_empty() { placeholder } else { &text },

--- a/graphics/src/widget/text_input.rs
+++ b/graphics/src/widget/text_input.rs
@@ -74,6 +74,7 @@ where
         bounds: Rectangle,
         text_bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         font: Font,
         size: u16,
         placeholder: &str,
@@ -123,8 +124,12 @@ where
             vertical_alignment: VerticalAlignment::Center,
         };
 
-        let (contents_primitive, offset) = if state.is_focused() {
-            let cursor = state.cursor();
+        let cursor = state.cursor();
+        if let Some(next_draw) = cursor.next_draw() {
+            *draw_at = Some(next_draw);
+        };
+
+        let (contents_primitive, offset) = if state.is_focused() && cursor.blink_visible() {
 
             let (cursor_primitive, offset) = match cursor.state(value) {
                 cursor::State::Index(position) => {

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -260,9 +260,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self.widget
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, draw_at)
     }
 
     /// Computes the _layout_ hash of the [`Element`].
@@ -356,9 +357,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self.widget
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, draw_at)
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -437,12 +439,14 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.explain(
             defaults,
             self.element.widget.as_ref(),
             layout,
             cursor_position,
+            draw_at,
             self.color,
         )
     }

--- a/native/src/layout/debugger.rs
+++ b/native/src/layout/debugger.rs
@@ -21,6 +21,7 @@ pub trait Debugger: Renderer {
         widget: &dyn Widget<Message, Self>,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         color: Color,
     ) -> Self::Output;
 }

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -37,6 +37,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output;
 
     /// Computes the _layout_ hash of the [`Overlay`].

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -88,9 +88,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self.overlay
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, draw_at)
     }
 
     /// Computes the _layout_ hash of the [`Element`].
@@ -159,9 +160,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self.content
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, draw_at)
     }
 
     fn hash_layout(&self, state: &mut Hasher, position: Point) {

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -254,9 +254,13 @@ where
         cursor_position: Point,
         draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
-        let primitives =
-            self.container
-                .draw(renderer, defaults, layout, cursor_position, draw_at);
+        let primitives = self.container.draw(
+            renderer,
+            defaults,
+            layout,
+            cursor_position,
+            draw_at,
+        );
 
         renderer.decorate(
             layout.bounds(),

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -252,10 +252,11 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let primitives =
             self.container
-                .draw(renderer, defaults, layout, cursor_position);
+                .draw(renderer, defaults, layout, cursor_position, draw_at);
 
         renderer.decorate(
             layout.bounds(),
@@ -368,6 +369,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self::Renderer::draw(
             renderer,

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -44,7 +44,7 @@ where
         );
 
         debug.draw_started();
-        let primitive = user_interface.draw(renderer, cursor_position);
+        let primitive = user_interface.draw(renderer, cursor_position, &mut None);
         debug.draw_finished();
 
         let cache = Some(user_interface.into_cache());
@@ -133,7 +133,7 @@ where
 
         if messages.is_empty() {
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position);
+            self.primitive = user_interface.draw(renderer, cursor_position, &mut None);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());
@@ -164,7 +164,7 @@ where
             );
 
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position);
+            self.primitive = user_interface.draw(renderer, cursor_position, &mut None);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -45,7 +45,8 @@ where
         );
 
         debug.draw_started();
-        let primitive = user_interface.draw(renderer, cursor_position, &mut None);
+        let primitive =
+            user_interface.draw(renderer, cursor_position, &mut None);
         debug.draw_finished();
 
         let cache = Some(user_interface.into_cache());
@@ -142,7 +143,8 @@ where
 
         if messages.is_empty() {
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position, &mut next_draw);
+            self.primitive =
+                user_interface.draw(renderer, cursor_position, &mut next_draw);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());
@@ -174,7 +176,8 @@ where
             );
 
             debug.draw_started();
-            self.primitive = user_interface.draw(renderer, cursor_position, &mut next_draw);
+            self.primitive =
+                user_interface.draw(renderer, cursor_position, &mut next_draw);
             debug.draw_finished();
 
             self.cache = Some(user_interface.into_cache());

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -35,6 +35,7 @@ impl column::Renderer for Null {
         _content: &[Element<'_, Message, Self>],
         _layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) {
     }
 }
@@ -46,6 +47,7 @@ impl row::Renderer for Null {
         _content: &[Element<'_, Message, Self>],
         _layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) {
     }
 }
@@ -151,6 +153,7 @@ impl button::Renderer for Null {
         _defaults: &Self::Defaults,
         _bounds: Rectangle,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
         _is_disabled: bool,
         _is_pressed: bool,
         _style: &Self::Style,
@@ -234,6 +237,7 @@ impl container::Renderer for Null {
         _defaults: &Self::Defaults,
         _bounds: Rectangle,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
         _style: &Self::Style,
         _content: &Element<'_, Message, Self>,
         _content_layout: Layout<'_>,
@@ -250,6 +254,7 @@ impl pane_grid::Renderer for Null {
         _resizing: Option<pane_grid::Axis>,
         _layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) {
     }
 
@@ -264,6 +269,7 @@ impl pane_grid::Renderer for Null {
         )>,
         _body: (&Element<'_, Message, Self>, Layout<'_>),
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) {
     }
 
@@ -278,6 +284,7 @@ impl pane_grid::Renderer for Null {
         _title_bounds: Rectangle,
         _controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) {
     }
 }

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -133,6 +133,7 @@ impl text_input::Renderer for Null {
         _bounds: Rectangle,
         _text_bounds: Rectangle,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
         _font: Font,
         _size: u16,
         _placeholder: &str,

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -326,6 +326,7 @@ where
         &mut self,
         renderer: &mut Renderer,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let overlay = if let Some(mut overlay) =
             self.root.overlay(Layout::new(&self.base.layout))
@@ -344,6 +345,7 @@ where
                 &Renderer::Defaults::default(),
                 Layout::new(&layer.layout),
                 cursor_position,
+                draw_at,
             );
 
             self.overlay = Some(layer);
@@ -365,6 +367,7 @@ where
                 &Renderer::Defaults::default(),
                 Layout::new(&self.base.layout),
                 base_cursor,
+                draw_at,
             );
 
             renderer.overlay(
@@ -378,6 +381,7 @@ where
                 &Renderer::Defaults::default(),
                 Layout::new(&self.base.layout),
                 cursor_position,
+                draw_at,
             )
         }
     }

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -291,6 +291,7 @@ where
     /// let mut window_size = Size::new(1024.0, 768.0);
     /// let mut cursor_position = Point::default();
     /// let mut events = Vec::new();
+    /// let mut draw_at = None;
     ///
     /// loop {
     ///     // Process system events...
@@ -310,7 +311,7 @@ where
     ///     );
     ///
     ///     // Draw the user interface
-    ///     let mouse_cursor = user_interface.draw(&mut renderer, cursor_position);
+    ///     let mouse_cursor = user_interface.draw(&mut renderer, cursor_position, &mut draw_at);
     ///
     ///     cache = user_interface.into_cache();
     ///

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -137,6 +137,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output;
 
     /// Computes the _layout_ hash of the [`Widget`].

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -215,11 +215,13 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,
             layout.bounds(),
             cursor_position,
+            draw_at,
             self.on_press.is_none(),
             self.state.is_pressed,
             &self.style,
@@ -261,6 +263,7 @@ pub trait Renderer: crate::Renderer + Sized {
         defaults: &Self::Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         is_disabled: bool,
         is_pressed: bool,
         style: &Self::Style,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -180,6 +180,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let mut children = layout.children();

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -187,7 +187,13 @@ where
         cursor_position: Point,
         draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position, draw_at)
+        renderer.draw(
+            defaults,
+            &self.children,
+            layout,
+            cursor_position,
+            draw_at,
+        )
     }
 
     fn hash_layout(&self, state: &mut Hasher) {

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -185,8 +185,9 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position)
+        renderer.draw(defaults, &self.children, layout, cursor_position, draw_at)
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -240,6 +241,7 @@ pub trait Renderer: crate::Renderer + Sized {
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output;
 }
 

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -191,11 +191,13 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,
             layout.bounds(),
             cursor_position,
+            draw_at,
             &self.style,
             &self.content,
             layout.children().next().unwrap(),
@@ -242,6 +244,7 @@ pub trait Renderer: crate::Renderer {
         defaults: &Self::Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         style: &Self::Style,
         content: &Element<'_, Message, Self>,
         content_layout: Layout<'_>,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -97,6 +97,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(self.handle.clone(), layout)
     }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -588,6 +588,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let picked_split = self
             .state
@@ -623,6 +624,7 @@ where
             picked_split,
             layout,
             cursor_position,
+            draw_at,
         )
     }
 
@@ -683,6 +685,7 @@ pub trait Renderer:
         resizing: Option<Axis>,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output;
 
     /// Draws a [`Pane`].
@@ -703,6 +706,7 @@ pub trait Renderer:
         title_bar: Option<(&TitleBar<'_, Message, Self>, Layout<'_>)>,
         body: (&Element<'_, Message, Self>, Layout<'_>),
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output;
 
     /// Draws a [`TitleBar`].
@@ -727,6 +731,7 @@ pub trait Renderer:
         title_bounds: Rectangle,
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output;
 }
 

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -65,6 +65,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         if let Some(title_bar) = &self.title_bar {
             let mut children = layout.children();
@@ -78,6 +79,7 @@ where
                 Some((title_bar, title_bar_layout)),
                 (&self.body, body_layout),
                 cursor_position,
+                draw_at,
             )
         } else {
             renderer.draw_pane(
@@ -87,6 +89,7 @@ where
                 None,
                 (&self.body, layout),
                 cursor_position,
+                draw_at,
             )
         }
     }

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -100,6 +100,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         show_controls: bool,
     ) -> Renderer::Output {
         let mut children = layout.children();
@@ -133,6 +134,7 @@ where
                 title_bounds,
                 controls,
                 cursor_position,
+                draw_at,
             )
         } else {
             renderer.draw_title_bar::<()>(
@@ -145,6 +147,7 @@ where
                 padded.bounds(),
                 None,
                 cursor_position,
+                draw_at,
             )
         }
     }

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -256,6 +256,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         self::Renderer::draw(
             renderer,

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -104,6 +104,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(
             layout.bounds(),

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -181,6 +181,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let mut children = layout.children();

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -188,7 +188,13 @@ where
         cursor_position: Point,
         draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position, draw_at)
+        renderer.draw(
+            defaults,
+            &self.children,
+            layout,
+            cursor_position,
+            draw_at,
+        )
     }
 
     fn hash_layout(&self, state: &mut Hasher) {

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -186,8 +186,9 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position)
+        renderer.draw(defaults, &self.children, layout, cursor_position, draw_at)
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -242,6 +243,7 @@ pub trait Renderer: crate::Renderer + Sized {
         children: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Self::Output;
 }
 

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -77,6 +77,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(layout.bounds(), &self.style, self.is_horizontal)
     }

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -264,6 +264,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
@@ -289,6 +290,7 @@ where
                 defaults,
                 content_layout,
                 cursor_position,
+                draw_at,
             )
         };
 

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -257,6 +257,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let start = *self.range.start();
         let end = *self.range.end();

--- a/native/src/widget/space.rs
+++ b/native/src/widget/space.rs
@@ -71,6 +71,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(layout.bounds())
     }

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -103,6 +103,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(self.handle.clone(), layout)
     }

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -149,6 +149,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -280,6 +280,9 @@ where
 
                 self.state.is_dragging = is_clicked;
                 self.state.is_focused = is_clicked;
+                if is_clicked {
+                    self.state.cursor.on_click();
+                };
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 self.state.is_dragging = false;
@@ -493,7 +496,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
-        _draw_at: &mut Option<std::time::Instant>,
+        draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let text_bounds = layout.children().next().unwrap().bounds();
@@ -504,6 +507,7 @@ where
                 bounds,
                 text_bounds,
                 cursor_position,
+                draw_at,
                 self.font,
                 self.size.unwrap_or(renderer.default_size()),
                 &self.placeholder,
@@ -517,6 +521,7 @@ where
                 bounds,
                 text_bounds,
                 cursor_position,
+                draw_at,
                 self.font,
                 self.size.unwrap_or(renderer.default_size()),
                 &self.placeholder,
@@ -590,6 +595,7 @@ pub trait Renderer: text::Renderer + Sized {
         bounds: Rectangle,
         text_bounds: Rectangle,
         cursor_position: Point,
+        draw_at: &mut Option<std::time::Instant>,
         font: Self::Font,
         size: u16,
         placeholder: &str,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -493,6 +493,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _draw_at: &mut Option<std::time::Instant>,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let text_bounds = layout.children().next().unwrap().bounds();

--- a/native/src/widget/text_input/cursor.rs
+++ b/native/src/widget/text_input/cursor.rs
@@ -1,8 +1,7 @@
 //! Track the cursor of a text input.
 use crate::widget::text_input::Value;
 
-use std::time::{Instant, Duration};
-
+use std::time::{Duration, Instant};
 
 const BLINK_MAX: Duration = Duration::from_secs(5);
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -272,7 +272,8 @@ where
             }
 
             if let Some(next_draw) = state.next_draw() {
-                *control_flow = winit::event_loop::ControlFlow::WaitUntil(next_draw);
+                *control_flow =
+                    winit::event_loop::ControlFlow::WaitUntil(next_draw);
             };
             window.request_redraw();
         }
@@ -316,7 +317,8 @@ where
             // TODO: Handle animations!
             // Maybe we can use `ControlFlow::WaitUntil` for this.
             if let Some(next_draw) = state.next_draw() {
-                *control_flow = winit::event_loop::ControlFlow::WaitUntil(next_draw);
+                *control_flow =
+                    winit::event_loop::ControlFlow::WaitUntil(next_draw);
             };
         }
         event::Event::WindowEvent {
@@ -346,7 +348,8 @@ where
 
             if *control_flow == ControlFlow::Wait {
                 if let Some(next_draw) = state.next_draw() {
-                    *control_flow = winit::event_loop::ControlFlow::WaitUntil(next_draw);
+                    *control_flow =
+                        winit::event_loop::ControlFlow::WaitUntil(next_draw);
                 };
             };
         }


### PR DESCRIPTION
This is just a demo, I agree we need to wait until we have a better idea of the API before we tackle animations

Anyway, this is what it would look like to hack it in XD

A few lessons here:

1. Adding stuffing into `draw()` is a pain in the ass, theres over 80 instances to update XD
2. Adding stuff into `draw()` is probably a bad idea - the current event loop in `application.rs` seems to assume state changes only happen on `update()`, and `draw()` just, draws. The concept of 'next draw me at X moment/event' doesnt neatly fit into either.