### PR TITLE
Fixes #549: Implements preload() method on images to help users avoid jank

### DIFF
--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -8,3 +8,4 @@ publish = false
 [dependencies]
 iced = { path = "../..", features = ["image", "debug"] }
 env_logger = "0.7"
+lazy_static = "1.4.0"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ debug = []
 twox-hash = "1.5"
 unicode-segmentation = "1.6"
 num-traits = "0.2"
+image = "0.23"
 
 [dependencies.iced_core]
 version = "0.2"

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -39,6 +39,8 @@ pub mod text;
 pub mod text_input;
 
 #[doc(no_inline)]
+pub use self::image::Image;
+#[doc(no_inline)]
 pub use button::Button;
 #[doc(no_inline)]
 pub use checkbox::Checkbox;
@@ -46,8 +48,6 @@ pub use checkbox::Checkbox;
 pub use column::Column;
 #[doc(no_inline)]
 pub use container::Container;
-#[doc(no_inline)]
-pub use image::Image;
 #[doc(no_inline)]
 pub use pane_grid::PaneGrid;
 #[doc(no_inline)]

--- a/web/src/widget/image.rs
+++ b/web/src/widget/image.rs
@@ -17,7 +17,7 @@ use std::{
 ///
 /// let image = Image::new("resources/ferris.png");
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Image {
     /// The image path
     pub handle: Handle,


### PR DESCRIPTION
 * Implements a `preload()` method to make it easier for users to setup an `Image` they can share about, which has the BGRA data loaded.
 * Update the `tour` example to use this technique.