### PR TITLE
Adds From<Point> and From<Size> for [f32; 2]

### DIFF
--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -46,6 +46,12 @@ impl From<[u16; 2]> for Point {
     }
 }
 
+impl From<Point> for [f32; 2] {
+    fn from(point: Point) -> [f32; 2] {
+        [point.x, point.y]
+    }
+}
+
 impl std::ops::Add<Vector> for Point {
     type Output = Self;
 

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -56,3 +56,9 @@ impl From<[u16; 2]> for Size {
         Size::new(width.into(), height.into())
     }
 }
+
+impl From<Size> for [f32; 2] {
+    fn from(size: Size) -> [f32; 2] {
+        [size.width, size.height]
+    }
+}


### PR DESCRIPTION
Example use case:
An `Axis { X, Y }` enum with useful generic methods such as:
`with_major<T: Into<[f32; 2]> + From<[f32; 2]>>(&self, coords: T, value: f32) -> T`
(replace the corresponding coordinate in coords with value)