### PR TITLE
Require `Clone` for `Message` early when needed

### DIFF
--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -284,7 +284,7 @@ impl<C: 'static + ColorSpace + Copy> ColorPicker<C> {
         let [s1, s2, s3] = &mut self.sliders;
         let [cr1, cr2, cr3] = C::COMPONENT_RANGES;
 
-        fn slider<C>(
+        fn slider<C: Clone>(
             state: &mut slider::State,
             range: RangeInclusive<f64>,
             component: f32,

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -689,7 +689,7 @@ fn ferris<'a>(width: u16) -> Container<'a, StepMessage> {
     .center_x()
 }
 
-fn button<'a, Message>(
+fn button<'a, Message: Clone>(
     state: &'a mut button::State,
     label: &str,
 ) -> Button<'a, Message> {

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -18,6 +18,7 @@ use std::hash::Hash;
 /// # type Button<'a, Message> =
 /// #     iced_native::Button<'a, Message, iced_native::renderer::Null>;
 /// #
+/// #[derive(Clone)]
 /// enum Message {
 ///     ButtonPressed,
 /// }
@@ -41,6 +42,7 @@ pub struct Button<'a, Message, Renderer: self::Renderer> {
 
 impl<'a, Message, Renderer> Button<'a, Message, Renderer>
 where
+    Message: Clone,
     Renderer: self::Renderer,
 {
     /// Creates a new [`Button`] with some local [`State`] and the given
@@ -142,8 +144,8 @@ impl State {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Button<'a, Message, Renderer>
 where
-    Renderer: self::Renderer,
     Message: Clone,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -272,8 +274,8 @@ pub trait Renderer: crate::Renderer + Sized {
 impl<'a, Message, Renderer> From<Button<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'a + self::Renderer,
     Message: 'a + Clone,
+    Renderer: 'a + self::Renderer,
 {
     fn from(
         button: Button<'a, Message, Renderer>,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -47,6 +47,8 @@ pub struct Radio<Message, Renderer: self::Renderer + text::Renderer> {
 
 impl<Message, Renderer: self::Renderer + text::Renderer>
     Radio<Message, Renderer>
+where
+    Message: Clone,
 {
     /// Creates a new [`Radio`] button.
     ///
@@ -123,8 +125,8 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
 
 impl<Message, Renderer> Widget<Message, Renderer> for Radio<Message, Renderer>
 where
-    Renderer: self::Renderer + text::Renderer + row::Renderer,
     Message: Clone,
+    Renderer: self::Renderer + text::Renderer + row::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -264,8 +266,8 @@ pub trait Renderer: crate::Renderer {
 impl<'a, Message, Renderer> From<Radio<Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'a + self::Renderer + row::Renderer + text::Renderer,
     Message: 'a + Clone,
+    Renderer: 'a + self::Renderer + row::Renderer + text::Renderer,
 {
     fn from(radio: Radio<Message, Renderer>) -> Element<'a, Message, Renderer> {
         Element::new(radio)

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -26,6 +26,7 @@ use std::{hash::Hash, ops::RangeInclusive};
 /// # use iced_native::{slider, renderer::Null};
 /// #
 /// # pub type Slider<'a, T, Message> = iced_native::Slider<'a, T, Message, Null>;
+/// #[derive(Clone)]
 /// pub enum Message {
 ///     SliderChanged(f32),
 /// }
@@ -53,6 +54,7 @@ pub struct Slider<'a, T, Message, Renderer: self::Renderer> {
 impl<'a, T, Message, Renderer> Slider<'a, T, Message, Renderer>
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
+    Message: Clone,
     Renderer: self::Renderer,
 {
     /// Creates a new [`Slider`].
@@ -168,8 +170,8 @@ impl<'a, T, Message, Renderer> Widget<Message, Renderer>
     for Slider<'a, T, Message, Renderer>
 where
     T: Copy + Into<f64> + num_traits::FromPrimitive,
-    Renderer: self::Renderer,
     Message: Clone,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -322,8 +324,8 @@ impl<'a, T, Message, Renderer> From<Slider<'a, T, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
     T: 'a + Copy + Into<f64> + num_traits::FromPrimitive,
-    Renderer: 'a + self::Renderer,
     Message: 'a + Clone,
+    Renderer: 'a + self::Renderer,
 {
     fn from(
         slider: Slider<'a, T, Message, Renderer>,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -63,7 +63,11 @@ pub struct TextInput<'a, Message, Renderer: self::Renderer> {
     style: Renderer::Style,
 }
 
-impl<'a, Message, Renderer: self::Renderer> TextInput<'a, Message, Renderer> {
+impl<'a, Message, Renderer> TextInput<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
     /// Creates a new [`TextInput`].
     ///
     /// It expects:
@@ -175,8 +179,8 @@ impl<'a, Message, Renderer: self::Renderer> TextInput<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for TextInput<'a, Message, Renderer>
 where
-    Renderer: self::Renderer,
     Message: Clone,
+    Renderer: self::Renderer,
 {
     fn width(&self) -> Length {
         self.width
@@ -629,8 +633,8 @@ pub trait Renderer: text::Renderer + Sized {
 impl<'a, Message, Renderer> From<TextInput<'a, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    Renderer: 'a + self::Renderer,
     Message: 'a + Clone,
+    Renderer: 'a + self::Renderer,
 {
     fn from(
         text_input: TextInput<'a, Message, Renderer>,


### PR DESCRIPTION
Prior to this change, the widgets that needed a `Clone` bound on `Message` to implement the `Widget` trait could be created with a non-cloneable `Message`.

As a consequence, the compiler complained only when actually trying to use the `Widget` trait. Normally, this happens when trying to `push` the widget in a container or turn it into an `Element`.

Furthermore, the compiler error in this case does not mention `Message` nor the `Clone` bound, but instead complains about a missing `From` implementation. Thus, it can easily cause confusion!

This change introduces `Clone` bounds in the main implementation of the widgets that need it to properly implement the `Widget` trait. As a result, the compiler complains early when trying to create one of these widgets with a non-cloneable `Message` and explicitly mentions that the `Message` needs to implement `Clone`.

# Example

Given this code:

```rust
use iced::{button, Button, Container, Element, Text};

enum Message {
    ButtonPressed,
}

fn view(button: &mut button::State) -> Element<Message> {
    let button = Button::new(button, Text::new("Press me!"))
        .on_press(Message::ButtonPressed);

    Container::new(button).into()
}
```

Before these changes, the compiler error was:

```
error[E0277]: the trait bound `Message: std::convert::From<iced_native::widget::button::Button<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>>` is not satisfied
  --> examples/clone_bound/src/main.rs:12:20
   |
12 |     Container::new(button).into()
   |                    ^^^^^^
   |                    |
   |                    expected an implementor of trait `std::convert::From<iced_native::widget::button::Button<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>>`
   |                    help: consider borrowing here: `&button`
   |
   = note: required because of the requirements on the impl of `std::convert::From<iced_native::widget::button::Button<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>>` for `iced_native::element::Element<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>`
   = note: required because of the requirements on the impl of `std::convert::Into<iced_native::element::Element<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>>` for `iced_native::widget::button::Button<'_, Message, iced_graphics::renderer::Renderer<iced_wgpu::backend::Backend>>`
   = note: required by `iced_native::widget::container::Container::<'a, Message, Renderer>::new`
```

After these changes, the compiler now complains earlier:

```
error[E0277]: the trait bound `Message: std::clone::Clone` is not satisfied
 --> examples/clone_bound/src/main.rs:9:18
  |
9 |     let button = Button::new(button, Text::new("Press me!"))
  |                  ^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `Message`
  |
  = note: required by `iced_native::widget::button::Button::<'a, Message, Renderer>::new`
```