### PR TITLE
Remove `executor::Null` from the root public API

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -65,7 +65,7 @@ use crate::{Color, Command, Element, Executor, Settings, Subscription};
 /// struct Hello;
 ///
 /// impl Application for Hello {
-///     type Executor = executor::Null;
+///     type Executor = executor::Default;
 ///     type Message = ();
 ///     type Flags = ();
 ///

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,5 @@
 //! Choose your preferred executor to power your application.
-pub use crate::runtime::{executor::Null, Executor};
+pub use crate::runtime::Executor;
 
 pub use platform::Default;
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,4 +1,3 @@
-use crate::executor;
 use crate::{
     Application, Color, Command, Element, Error, Settings, Subscription,
 };
@@ -172,7 +171,7 @@ impl<T> Application for T
 where
     T: Sandbox,
 {
-    type Executor = executor::Null;
+    type Executor = crate::runtime::executor::Null;
     type Flags = ();
     type Message = T::Message;
 


### PR DESCRIPTION
Removes `executor::Null` from the public API of the main crate: `iced`, as it is useless and can cause frustration.

Using an `Application` with `executor::Null` does not make sense, as the whole purpose of an `Application` is to allow executing async actions.

When async actions are not needed, `Sandbox` should be used instead.