### PR TITLE
Viewport aware drawing

### DIFF
--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -12,7 +12,7 @@ mod circle {
     use iced_graphics::{Backend, Defaults, Primitive, Renderer};
     use iced_native::{
         layout, mouse, Background, Color, Element, Hasher, Layout, Length,
-        Point, Size, Widget,
+        Point, Rectangle, Size, Widget,
     };
 
     pub struct Circle {
@@ -60,6 +60,7 @@ mod circle {
             _defaults: &Defaults,
             layout: Layout<'_>,
             _cursor_position: Point,
+            _viewport: &Rectangle,
         ) -> (Primitive, mouse::Interaction) {
             (
                 Primitive::Quad {

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -15,8 +15,8 @@ mod rainbow {
         Backend, Defaults, Primitive, Renderer,
     };
     use iced_native::{
-        layout, mouse, Element, Hasher, Layout, Length, Point, Size, Vector,
-        Widget,
+        layout, mouse, Element, Hasher, Layout, Length, Point, Rectangle, Size,
+        Vector, Widget,
     };
 
     pub struct Rainbow;
@@ -57,6 +57,7 @@ mod rainbow {
             _defaults: &Defaults,
             layout: Layout<'_>,
             cursor_position: Point,
+            _viewport: &Rectangle,
         ) -> (Primitive, mouse::Interaction) {
             let b = layout.bounds();
 

--- a/graphics/src/overlay/menu.rs
+++ b/graphics/src/overlay/menu.rs
@@ -42,6 +42,7 @@ where
         &mut self,
         bounds: Rectangle,
         cursor_position: Point,
+        viewport: &Rectangle,
         options: &[T],
         hovered_option: Option<usize>,
         padding: u16,
@@ -52,16 +53,24 @@ where
         use std::f32;
 
         let is_mouse_over = bounds.contains(cursor_position);
+        let option_height = text_size as usize + padding as usize * 2;
 
         let mut primitives = Vec::new();
 
-        for (i, option) in options.iter().enumerate() {
+        let offset = viewport.y - bounds.y;
+        let start = (offset / option_height as f32) as usize;
+        let end =
+            ((offset + viewport.height) / option_height as f32).ceil() as usize;
+
+        let visible_options = &options[start..end.min(options.len())];
+
+        for (i, option) in visible_options.iter().enumerate() {
+            let i = start + i;
             let is_selected = hovered_option == Some(i);
 
             let bounds = Rectangle {
                 x: bounds.x,
-                y: bounds.y
-                    + ((text_size as usize + padding as usize * 2) * i) as f32,
+                y: bounds.y + (option_height * i) as f32,
                 width: bounds.width,
                 height: f32::from(text_size + padding * 2),
             };

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -96,10 +96,11 @@ where
         widget: &dyn Widget<Message, Self>,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
         color: Color,
     ) -> Self::Output {
         let (primitive, cursor) =
-            widget.draw(self, defaults, layout, cursor_position);
+            widget.draw(self, defaults, layout, cursor_position, viewport);
 
         let mut primitives = Vec::new();
 

--- a/graphics/src/widget/button.rs
+++ b/graphics/src/widget/button.rs
@@ -62,6 +62,7 @@ where
             },
             content_layout,
             cursor_position,
+            &bounds,
         );
 
         (

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -8,8 +8,8 @@
 //! [`Frame`]: struct.Frame.html
 use crate::{Backend, Defaults, Primitive, Renderer};
 use iced_native::{
-    layout, mouse, Clipboard, Element, Hasher, Layout, Length, Point, Size,
-    Vector, Widget,
+    layout, mouse, Clipboard, Element, Hasher, Layout, Length, Point,
+    Rectangle, Size, Vector, Widget,
 };
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -196,6 +196,7 @@ where
         _defaults: &Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> (Primitive, mouse::Interaction) {
         let bounds = layout.bounds();
         let translation = Vector::new(bounds.x, bounds.y);

--- a/graphics/src/widget/column.rs
+++ b/graphics/src/widget/column.rs
@@ -1,7 +1,7 @@
 use crate::{Backend, Primitive, Renderer};
 use iced_native::column;
 use iced_native::mouse;
-use iced_native::{Element, Layout, Point};
+use iced_native::{Element, Layout, Point, Rectangle};
 
 /// A container that distributes its contents vertically.
 pub type Column<'a, Message, Backend> =
@@ -17,6 +17,7 @@ where
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Self::Output {
         let mut mouse_interaction = mouse::Interaction::default();
 
@@ -26,8 +27,13 @@ where
                     .iter()
                     .zip(layout.children())
                     .map(|(child, layout)| {
-                        let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position);
+                        let (primitive, new_mouse_interaction) = child.draw(
+                            self,
+                            defaults,
+                            layout,
+                            cursor_position,
+                            viewport,
+                        );
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;

--- a/graphics/src/widget/container.rs
+++ b/graphics/src/widget/container.rs
@@ -24,6 +24,7 @@ where
         defaults: &Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        viewport: &Rectangle,
         style_sheet: &Self::Style,
         content: &Element<'_, Message, Self>,
         content_layout: Layout<'_>,
@@ -36,8 +37,13 @@ where
             },
         };
 
-        let (content, mouse_interaction) =
-            content.draw(self, &defaults, content_layout, cursor_position);
+        let (content, mouse_interaction) = content.draw(
+            self,
+            &defaults,
+            content_layout,
+            cursor_position,
+            viewport,
+        );
 
         if let Some(background) = background(bounds, &style) {
             (

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -137,7 +137,7 @@ where
         let (body, body_layout) = body;
 
         let (body_primitive, body_interaction) =
-            body.draw(self, defaults, body_layout, cursor_position);
+            body.draw(self, defaults, body_layout, cursor_position, &bounds);
 
         let background = crate::widget::container::background(bounds, &style);
 
@@ -224,6 +224,7 @@ where
                 &defaults,
                 controls_layout,
                 cursor_position,
+                &bounds,
             );
 
             (

--- a/graphics/src/widget/row.rs
+++ b/graphics/src/widget/row.rs
@@ -1,7 +1,7 @@
 use crate::{Backend, Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::row;
-use iced_native::{Element, Layout, Point};
+use iced_native::{Element, Layout, Point, Rectangle};
 
 /// A container that distributes its contents horizontally.
 pub type Row<'a, Message, Backend> =
@@ -17,6 +17,7 @@ where
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Self::Output {
         let mut mouse_interaction = mouse::Interaction::default();
 
@@ -26,8 +27,13 @@ where
                     .iter()
                     .zip(layout.children())
                     .map(|(child, layout)| {
-                        let (primitive, new_mouse_interaction) =
-                            child.draw(self, defaults, layout, cursor_position);
+                        let (primitive, new_mouse_interaction) = child.draw(
+                            self,
+                            defaults,
+                            layout,
+                            cursor_position,
+                            viewport,
+                        );
 
                         if new_mouse_interaction > mouse_interaction {
                             mouse_interaction = new_mouse_interaction;

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -1,6 +1,7 @@
+use crate::layout;
+use crate::overlay;
 use crate::{
-    layout, overlay, Clipboard, Color, Event, Hasher, Layout, Length, Point,
-    Widget,
+    Clipboard, Color, Event, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 
 /// A generic [`Widget`].
@@ -260,9 +261,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
         self.widget
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, viewport)
     }
 
     /// Computes the _layout_ hash of the [`Element`].
@@ -356,9 +358,10 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
         self.widget
-            .draw(renderer, defaults, layout, cursor_position)
+            .draw(renderer, defaults, layout, cursor_position, viewport)
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -437,12 +440,14 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.explain(
             defaults,
             self.element.widget.as_ref(),
             layout,
             cursor_position,
+            viewport,
             self.color,
         )
     }

--- a/native/src/layout/debugger.rs
+++ b/native/src/layout/debugger.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Layout, Point, Renderer, Widget};
+use crate::{Color, Layout, Point, Rectangle, Renderer, Widget};
 
 /// A renderer able to graphically explain a [`Layout`].
 ///
@@ -21,6 +21,7 @@ pub trait Debugger: Renderer {
         widget: &dyn Widget<Message, Self>,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
         color: Color,
     ) -> Self::Output;
 }

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -372,12 +372,13 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
-        _viewport: &Rectangle,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
         self::Renderer::draw(
             renderer,
             layout.bounds(),
             cursor_position,
+            viewport,
             self.options,
             *self.hovered_option,
             self.padding,
@@ -423,6 +424,7 @@ pub trait Renderer:
         &mut self,
         bounds: Rectangle,
         cursor_position: Point,
+        viewport: &Rectangle,
         options: &[T],
         hovered_option: Option<usize>,
         padding: u16,

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -253,9 +253,13 @@ where
         layout: Layout<'_>,
         cursor_position: Point,
     ) -> Renderer::Output {
-        let primitives =
-            self.container
-                .draw(renderer, defaults, layout, cursor_position);
+        let primitives = self.container.draw(
+            renderer,
+            defaults,
+            layout,
+            cursor_position,
+            &layout.bounds(),
+        );
 
         renderer.decorate(
             layout.bounds(),
@@ -368,6 +372,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         self::Renderer::draw(
             renderer,

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -35,6 +35,7 @@ impl column::Renderer for Null {
         _content: &[Element<'_, Message, Self>],
         _layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) {
     }
 }
@@ -46,6 +47,7 @@ impl row::Renderer for Null {
         _content: &[Element<'_, Message, Self>],
         _layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) {
     }
 }
@@ -237,6 +239,7 @@ impl container::Renderer for Null {
         _defaults: &Self::Defaults,
         _bounds: Rectangle,
         _cursor_position: Point,
+        _viewport: &Rectangle,
         _style: &Self::Style,
         _content: &Element<'_, Message, Self>,
         _content_layout: Layout<'_>,

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -1,4 +1,6 @@
-use crate::{layout, overlay, Clipboard, Element, Event, Layout, Point, Size};
+use crate::layout;
+use crate::overlay;
+use crate::{Clipboard, Element, Event, Layout, Point, Rectangle, Size};
 
 use std::hash::Hasher;
 
@@ -327,6 +329,8 @@ where
         renderer: &mut Renderer,
         cursor_position: Point,
     ) -> Renderer::Output {
+        let viewport = Rectangle::with_size(self.bounds);
+
         let overlay = if let Some(mut overlay) =
             self.root.overlay(Layout::new(&self.base.layout))
         {
@@ -365,6 +369,7 @@ where
                 &Renderer::Defaults::default(),
                 Layout::new(&self.base.layout),
                 base_cursor,
+                &viewport,
             );
 
             renderer.overlay(
@@ -378,6 +383,7 @@ where
                 &Renderer::Defaults::default(),
                 Layout::new(&self.base.layout),
                 cursor_position,
+                &viewport,
             )
         }
     }

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -73,7 +73,9 @@ pub use text::Text;
 #[doc(no_inline)]
 pub use text_input::TextInput;
 
-use crate::{layout, overlay, Clipboard, Event, Hasher, Layout, Length, Point};
+use crate::{
+    layout, overlay, Clipboard, Event, Hasher, Layout, Length, Point, Rectangle,
+};
 
 /// A component that displays information and allows interaction.
 ///
@@ -137,6 +139,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output;
 
     /// Computes the _layout_ hash of the [`Widget`].

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -217,6 +217,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -180,6 +180,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let mut children = layout.children();

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -1,9 +1,11 @@
 //! Distribute content vertically.
 use std::hash::Hash;
 
+use crate::layout;
+use crate::overlay;
 use crate::{
-    layout, overlay, Align, Clipboard, Element, Event, Hasher, Layout, Length,
-    Point, Widget,
+    Align, Clipboard, Element, Event, Hasher, Layout, Length, Point, Rectangle,
+    Widget,
 };
 
 use std::u32;
@@ -181,8 +183,15 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position)
+        renderer.draw(
+            defaults,
+            &self.children,
+            layout,
+            cursor_position,
+            viewport,
+        )
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -237,6 +246,7 @@ pub trait Renderer: crate::Renderer + Sized {
         content: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Self::Output;
 }
 

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -191,11 +191,13 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,
             layout.bounds(),
             cursor_position,
+            viewport,
             &self.style,
             &self.content,
             layout.children().next().unwrap(),
@@ -242,6 +244,7 @@ pub trait Renderer: crate::Renderer {
         defaults: &Self::Defaults,
         bounds: Rectangle,
         cursor_position: Point,
+        viewport: &Rectangle,
         style: &Self::Style,
         content: &Element<'_, Message, Self>,
         content_layout: Layout<'_>,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -1,5 +1,6 @@
 //! Display images in your user interface.
-use crate::{layout, Element, Hasher, Layout, Length, Point, Size, Widget};
+use crate::layout;
+use crate::{Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget};
 
 use std::{
     hash::{Hash, Hasher as _},
@@ -97,6 +98,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(self.handle.clone(), layout)
     }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -588,6 +588,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let picked_split = self
             .state

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -256,6 +256,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         self::Renderer::draw(
             renderer,

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -104,6 +104,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(
             layout.bounds(),

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -183,6 +183,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let mut children = layout.children();

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -1,11 +1,12 @@
 //! Distribute content horizontally.
-use std::hash::Hash;
-
+use crate::layout;
+use crate::overlay;
 use crate::{
-    layout, overlay, Align, Clipboard, Element, Event, Hasher, Layout, Length,
-    Point, Widget,
+    Align, Clipboard, Element, Event, Hasher, Layout, Length, Point, Rectangle,
+    Widget,
 };
 
+use std::hash::Hash;
 use std::u32;
 
 /// A container that distributes its contents horizontally.
@@ -182,8 +183,15 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Renderer::Output {
-        renderer.draw(defaults, &self.children, layout, cursor_position)
+        renderer.draw(
+            defaults,
+            &self.children,
+            layout,
+            cursor_position,
+            viewport,
+        )
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -238,6 +246,7 @@ pub trait Renderer: crate::Renderer + Sized {
         children: &[Element<'_, Message, Self>],
         layout: Layout<'_>,
         cursor_position: Point,
+        viewport: &Rectangle,
     ) -> Self::Output;
 }
 

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -77,6 +77,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(layout.bounds(), &self.style, self.is_horizontal)
     }

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -303,6 +303,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
@@ -335,6 +336,10 @@ where
                 defaults,
                 content_layout,
                 cursor_position,
+                &Rectangle {
+                    y: bounds.y + offset as f32,
+                    ..bounds
+                },
             )
         };
 

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -259,6 +259,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let start = *self.range.start();
         let end = *self.range.end();

--- a/native/src/widget/space.rs
+++ b/native/src/widget/space.rs
@@ -71,6 +71,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(layout.bounds())
     }

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -1,5 +1,6 @@
 //! Display vector graphics in your application.
-use crate::{layout, Element, Hasher, Layout, Length, Point, Size, Widget};
+use crate::layout;
+use crate::{Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget};
 
 use std::{
     hash::{Hash, Hasher as _},
@@ -103,6 +104,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(self.handle.clone(), layout)
     }

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -149,6 +149,7 @@ where
         defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         _cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         renderer.draw(
             defaults,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -497,6 +497,7 @@ where
         _defaults: &Renderer::Defaults,
         layout: Layout<'_>,
         cursor_position: Point,
+        _viewport: &Rectangle,
     ) -> Renderer::Output {
         let bounds = layout.bounds();
         let text_bounds = layout.children().next().unwrap().bounds();


### PR DESCRIPTION
This PR introduces a new `viewport` argument to `Widget::draw` that represents the region of the `layout` that will be visible on screen.

This new argument can be used to generate graphics primitives more efficiently (e.g. discarding elements that fall out of bounds).

Currently, only the `overlay::Menu` takes advantage of the `viewport` to produce primitives only for the visible options based on the scrolling offset. In practice, this means that a `PickList` now should be able to handle a practically infinite amount of options without a performance impact.

Eventually, we should be able to introduce similar optimizations to the `Scrollable` widget.