### PR TITLE
Fix lifetimes in `Layout::children`

### DIFF
--- a/native/src/layout.rs
+++ b/native/src/layout.rs
@@ -64,7 +64,7 @@ impl<'a> Layout<'a> {
     ///
     /// [`Layout`]: struct.Layout.html
     /// [`Node`]: struct.Node.html
-    pub fn children(&'a self) -> impl Iterator<Item = Layout<'a>> {
+    pub fn children(&self) -> impl Iterator<Item = Layout<'a>> + '_ {
         self.node.children().iter().map(move |node| {
             Layout::with_offset(
                 Vector::new(self.position.x, self.position.y),

--- a/native/src/layout.rs
+++ b/native/src/layout.rs
@@ -64,7 +64,7 @@ impl<'a> Layout<'a> {
     ///
     /// [`Layout`]: struct.Layout.html
     /// [`Node`]: struct.Node.html
-    pub fn children(&self) -> impl Iterator<Item = Layout<'a>> + '_ {
+    pub fn children(self) -> impl Iterator<Item = Layout<'a>> {
         self.node.children().iter().map(move |node| {
             Layout::with_offset(
                 Vector::new(self.position.x, self.position.y),


### PR DESCRIPTION
This change allows for chaining of `children` calls without having to bind the iterator to a local variable, and consequently also allows for the result to be returned from the current scope.

```rust
    pub fn get_content_layout_from_child_layout(child_layout: Layout<'_>) -> Layout<'_> {
        child_layout.children().nth(0).unwrap().children().nth(1).unwrap()
    }
```