### PR TITLE
Fixes #591 DimensionsMismatch error message

### DIFF
--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -112,7 +112,7 @@ impl fmt::Display for Error {
                 write!(f,
                 "The number of RGBA pixels ({:?}) does not match the provided \
                 dimensions ({:?}x{:?}).",
-                width, height, pixel_count,
+                pixel_count, width, height,
             )
             }
             Error::OsError(e) => write!(


### PR DESCRIPTION
The values passed to write! were shifted 1 to the left.

Fixes #591