### PR TITLE
Add textinput focus method

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -693,6 +693,20 @@ impl State {
         self.cursor
     }
 
+    /// Focuses the [`TextInput`].
+    ///
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn focus(&mut self) {
+        self.is_focused = true;
+    }
+
+    /// Unfocuses the [`TextInput`].
+    ///
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn unfocus(&mut self) {
+        self.is_focused = false;
+    }
+
     /// Moves the [`Cursor`] of the [`TextInput`] to the front of the input text.
     ///
     /// [`Cursor`]: struct.Cursor.html
@@ -715,12 +729,6 @@ impl State {
     /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to(&mut self, position: usize) {
         self.cursor.move_to(position);
-    }
-
-    /// Change the focus of the [`TextInput`] state.
-    /// [`TextInput`]: struct.TextInput.html
-    pub fn focus(&mut self, state: bool) {
-        self.is_focused = state
     }
 }
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -716,6 +716,12 @@ impl State {
     pub fn move_cursor_to(&mut self, position: usize) {
         self.cursor.move_to(position);
     }
+
+    /// Change the focus of the [`TextInput`] state.
+    /// [`TextInput`]: struct.TextInput.html
+    pub fn focus(&mut self, state: bool) {
+        self.is_focused = state
+    }
 }
 
 // TODO: Reduce allocations


### PR DESCRIPTION
This is just a small addition : 
- Add a`focus` method` to control `TextInput` focus state. 

A simple use case  would be to force the focus on every call to the `Application::update`, but this could be used 
to move the focus around whenever a specific event occurs.  