### PR TITLE
Add wayland app_id

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -58,6 +58,7 @@ where
                 &application.title(),
                 application.mode(),
                 event_loop.primary_monitor(),
+                settings.id,
             )
             .with_menu(Some(conversion::menu(&application.menu())));
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,12 +4,18 @@ use crate::window;
 /// The settings of an application.
 #[derive(Debug, Clone)]
 pub struct Settings<Flags> {
+    /// The identifier of the application.
+    ///
+    /// If provided, this identifier may be used to identify the application or
+    /// communicate with it through the windowing system.
+    pub id: Option<String>,
+
     /// The window settings.
     ///
     /// They will be ignored on the Web.
     pub window: window::Settings,
 
-    /// The data needed to initialize an [`Application`].
+    /// The data needed to initialize the [`Application`].
     ///
     /// [`Application`]: crate::Application
     pub flags: Flags,
@@ -58,6 +64,7 @@ impl<Flags> Settings<Flags> {
 
         Self {
             flags,
+            id: default_settings.id,
             window: default_settings.window,
             default_font: default_settings.default_font,
             default_text_size: default_settings.default_text_size,
@@ -74,8 +81,9 @@ where
 {
     fn default() -> Self {
         Self {
-            flags: Default::default(),
+            id: None,
             window: Default::default(),
+            flags: Default::default(),
             default_font: Default::default(),
             default_text_size: 20,
             text_multithreading: false,
@@ -89,6 +97,7 @@ where
 impl<Flags> From<Settings<Flags>> for iced_winit::Settings<Flags> {
     fn from(settings: Settings<Flags>) -> iced_winit::Settings<Flags> {
         iced_winit::Settings {
+            id: settings.id,
             window: settings.window.into(),
             flags: settings.flags,
             exit_on_close_request: settings.exit_on_close_request,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -152,6 +152,7 @@ where
             &application.title(),
             application.mode(),
             event_loop.primary_monitor(),
+            settings.id,
         )
         .with_menu(Some(conversion::menu(&application.menu())))
         .build(&event_loop)

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -16,6 +16,12 @@ use winit::window::WindowBuilder;
 /// The settings of an application.
 #[derive(Debug, Clone, Default)]
 pub struct Settings<Flags> {
+    /// The identifier of the application.
+    ///
+    /// If provided, this identifier may be used to identify the application or
+    /// communicate with it through the windowing system.
+    pub id: Option<String>,
+
     /// The [`Window`] settings
     pub window: Window,
 
@@ -70,6 +76,7 @@ impl Window {
         title: &str,
         mode: Mode,
         primary_monitor: Option<MonitorHandle>,
+        _id: Option<String>,
     ) -> WindowBuilder {
         let mut window_builder = WindowBuilder::new();
 
@@ -112,7 +119,10 @@ impl Window {
         ))]
         {
             use ::winit::platform::unix::WindowBuilderExtUnix;
-            window_builder = window_builder.with_app_id(title.to_string());
+
+            if let Some(id) = _id {
+                window_builder = window_builder.with_app_id(id);
+            }
         }
 
         #[cfg(target_os = "windows")]
@@ -122,6 +132,7 @@ impl Window {
             if let Some(parent) = self.platform_specific.parent {
                 window_builder = window_builder.with_parent_window(parent);
             }
+
             window_builder = window_builder
                 .with_drag_and_drop(self.platform_specific.drag_and_drop);
         }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -103,7 +103,13 @@ impl Window {
                 .with_max_inner_size(winit::dpi::LogicalSize { width, height });
         }
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
         {
             use ::winit::platform::unix::WindowBuilderExtUnix;
             window_builder = window_builder.with_app_id(title.to_string());

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -103,6 +103,12 @@ impl Window {
                 .with_max_inner_size(winit::dpi::LogicalSize { width, height });
         }
 
+        #[cfg(target_os = "linux")]
+        {
+            use ::winit::platform::unix::WindowBuilderExtUnix;
+            window_builder = window_builder.with_app_id(title.to_string());
+        }
+
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;


### PR DESCRIPTION
This add  wayland `app_id` for linux targets

**Links to the spec** : 

-  https://github.com/wayland-project/wayland-protocols/blob/4ed0cafeefd9f81b974465ca495cbd9118508cdb/stable/xdg-shell/xdg-shell.xml#L640
- https://wayland-book.com/xdg-shell-basics/xdg-toplevel.html

**Why ?** : 

It allow to send specific commands to the app via the wayland compositor. 

For example this will tell [sway](https://github.com/swaywm/sway) to always start the app in floating mode : 
```
for_window [app_id="my-iced-app"] floating enable
```

**Note** : 

I have set the default value for wayland `app_id` to `Application::title` in `iced_winit::settings::Window` but it might be interesting to expose a public setter for this to build apps that conforms to freedesktop's [desktop-file-id specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)

**Suggestion on X11** : 

The following X11 window properties can also be set via winit : `visual_infos`, `screen_id`, `resize_increments`, `base_size`, `class`, `override_redirect`, `gtk_theme_variant`. I am not sure if they are relevant for iced apps but from my experience, exposing at least  `class`  (or setting a default value) would be useful for i3 user (and maybe for other X11 wm) . 