### PR TITLE
Add methods to control `Scrollable` programmatically

### DIFF
--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -17,6 +17,8 @@ struct ScrollableDemo {
 #[derive(Debug, Clone)]
 enum Message {
     ThemeChanged(style::Theme),
+    ScrollToTop(usize),
+    ScrollToBottom(usize),
 }
 
 impl Sandbox for ScrollableDemo {
@@ -36,6 +38,16 @@ impl Sandbox for ScrollableDemo {
     fn update(&mut self, message: Message) {
         match message {
             Message::ThemeChanged(theme) => self.theme = theme,
+            Message::ScrollToTop(i) => {
+                if let Some(variant) = self.variants.get_mut(i) {
+                    variant.scrollable.snap_to(0.0);
+                }
+            }
+            Message::ScrollToBottom(i) => {
+                if let Some(variant) = self.variants.get_mut(i) {
+                    variant.scrollable.snap_to(1.0);
+                }
+            }
         }
     }
 
@@ -62,7 +74,8 @@ impl Sandbox for ScrollableDemo {
         let scrollable_row = Row::with_children(
             variants
                 .iter_mut()
-                .map(|variant| {
+                .enumerate()
+                .map(|(i, variant)| {
                     let mut scrollable =
                         Scrollable::new(&mut variant.scrollable)
                             .padding(10)
@@ -70,7 +83,16 @@ impl Sandbox for ScrollableDemo {
                             .width(Length::Fill)
                             .height(Length::Fill)
                             .style(*theme)
-                            .push(Text::new(variant.title));
+                            .push(Text::new(variant.title))
+                            .push(
+                                Button::new(
+                                    &mut variant.scroll_to_bottom,
+                                    Text::new("Scroll to bottom"),
+                                )
+                                .width(Length::Fill)
+                                .padding(10)
+                                .on_press(Message::ScrollToBottom(i)),
+                            );
 
                     if let Some(scrollbar_width) = variant.scrollbar_width {
                         scrollable = scrollable
@@ -110,15 +132,16 @@ impl Sandbox for ScrollableDemo {
                         .push(Space::with_height(Length::Units(1200)))
                         .push(Text::new("Middle"))
                         .push(Space::with_height(Length::Units(1200)))
+                        .push(Text::new("The End."))
                         .push(
                             Button::new(
-                                &mut variant.button,
-                                Text::new("I am a button"),
+                                &mut variant.scroll_to_top,
+                                Text::new("Scroll to top"),
                             )
                             .width(Length::Fill)
-                            .padding(10),
-                        )
-                        .push(Text::new("The End."));
+                            .padding(10)
+                            .on_press(Message::ScrollToTop(i)),
+                        );
 
                     Container::new(scrollable)
                         .width(Length::Fill)
@@ -153,7 +176,8 @@ impl Sandbox for ScrollableDemo {
 struct Variant {
     title: &'static str,
     scrollable: scrollable::State,
-    button: button::State,
+    scroll_to_top: button::State,
+    scroll_to_bottom: button::State,
     scrollbar_width: Option<u16>,
     scrollbar_margin: Option<u16>,
     scroller_width: Option<u16>,
@@ -165,7 +189,8 @@ impl Variant {
             Self {
                 title: "Default Scrollbar",
                 scrollable: scrollable::State::new(),
-                button: button::State::new(),
+                scroll_to_top: button::State::new(),
+                scroll_to_bottom: button::State::new(),
                 scrollbar_width: None,
                 scrollbar_margin: None,
                 scroller_width: None,
@@ -173,7 +198,8 @@ impl Variant {
             Self {
                 title: "Slimmed & Margin",
                 scrollable: scrollable::State::new(),
-                button: button::State::new(),
+                scroll_to_top: button::State::new(),
+                scroll_to_bottom: button::State::new(),
                 scrollbar_width: Some(4),
                 scrollbar_margin: Some(3),
                 scroller_width: Some(4),
@@ -181,7 +207,8 @@ impl Variant {
             Self {
                 title: "Wide Scroller",
                 scrollable: scrollable::State::new(),
-                button: button::State::new(),
+                scroll_to_top: button::State::new(),
+                scroll_to_bottom: button::State::new(),
                 scrollbar_width: Some(4),
                 scrollbar_margin: None,
                 scroller_width: Some(10),
@@ -189,7 +216,8 @@ impl Variant {
             Self {
                 title: "Narrow Scroller",
                 scrollable: scrollable::State::new(),
-                button: button::State::new(),
+                scroll_to_top: button::State::new(),
+                scroll_to_bottom: button::State::new(),
                 scrollbar_width: Some(10),
                 scrollbar_margin: None,
                 scroller_width: Some(4),

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -1,8 +1,8 @@
 mod style;
 
 use iced::{
-    button, scrollable, Button, Column, Container, Element, Length, Radio, Row,
-    Rule, Sandbox, Scrollable, Settings, Space, Text,
+    button, scrollable, Button, Column, Container, Element, Length,
+    ProgressBar, Radio, Row, Rule, Sandbox, Scrollable, Settings, Space, Text,
 };
 
 pub fn main() -> iced::Result {
@@ -19,6 +19,7 @@ enum Message {
     ThemeChanged(style::Theme),
     ScrollToTop(usize),
     ScrollToBottom(usize),
+    Scrolled(usize, f32),
 }
 
 impl Sandbox for ScrollableDemo {
@@ -41,11 +42,20 @@ impl Sandbox for ScrollableDemo {
             Message::ScrollToTop(i) => {
                 if let Some(variant) = self.variants.get_mut(i) {
                     variant.scrollable.snap_to(0.0);
+
+                    variant.latest_offset = 0.0;
                 }
             }
             Message::ScrollToBottom(i) => {
                 if let Some(variant) = self.variants.get_mut(i) {
                     variant.scrollable.snap_to(1.0);
+
+                    variant.latest_offset = 1.0;
+                }
+            }
+            Message::Scrolled(i, offset) => {
+                if let Some(variant) = self.variants.get_mut(i) {
+                    variant.latest_offset = offset;
                 }
             }
         }
@@ -82,6 +92,9 @@ impl Sandbox for ScrollableDemo {
                             .spacing(10)
                             .width(Length::Fill)
                             .height(Length::Fill)
+                            .on_scroll(move |offset| {
+                                Message::Scrolled(i, offset)
+                            })
                             .style(*theme)
                             .push(Text::new(variant.title))
                             .push(
@@ -143,10 +156,20 @@ impl Sandbox for ScrollableDemo {
                             .on_press(Message::ScrollToTop(i)),
                         );
 
-                    Container::new(scrollable)
+                    Column::new()
                         .width(Length::Fill)
                         .height(Length::Fill)
-                        .style(*theme)
+                        .spacing(10)
+                        .push(
+                            Container::new(scrollable)
+                                .width(Length::Fill)
+                                .height(Length::Fill)
+                                .style(*theme),
+                        )
+                        .push(ProgressBar::new(
+                            0.0..=1.0,
+                            variant.latest_offset,
+                        ))
                         .into()
                 })
                 .collect(),
@@ -181,6 +204,7 @@ struct Variant {
     scrollbar_width: Option<u16>,
     scrollbar_margin: Option<u16>,
     scroller_width: Option<u16>,
+    latest_offset: f32,
 }
 
 impl Variant {
@@ -194,6 +218,7 @@ impl Variant {
                 scrollbar_width: None,
                 scrollbar_margin: None,
                 scroller_width: None,
+                latest_offset: 0.0,
             },
             Self {
                 title: "Slimmed & Margin",
@@ -203,6 +228,7 @@ impl Variant {
                 scrollbar_width: Some(4),
                 scrollbar_margin: Some(3),
                 scroller_width: Some(4),
+                latest_offset: 0.0,
             },
             Self {
                 title: "Wide Scroller",
@@ -212,6 +238,7 @@ impl Variant {
                 scrollbar_width: Some(4),
                 scrollbar_margin: None,
                 scroller_width: Some(10),
+                latest_offset: 0.0,
             },
             Self {
                 title: "Narrow Scroller",
@@ -221,6 +248,7 @@ impl Variant {
                 scrollbar_width: Some(10),
                 scrollbar_margin: None,
                 scroller_width: Some(4),
+                latest_offset: 0.0,
             },
         ]
     }

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -10,7 +10,7 @@ use crate::{
     Rectangle, Size, Vector, Widget,
 };
 
-use std::{f32, hash::Hash, u32};
+use std::{cell::RefCell, f32, hash::Hash, u32};
 
 /// A widget that can vertically display an infinite amount of content with a
 /// scrollbar.
@@ -24,6 +24,8 @@ pub struct Scrollable<'a, Message, Renderer: self::Renderer> {
     scroller_width: u16,
     content: Column<'a, Message, Renderer>,
     style: Renderer::Style,
+    on_scroll: Option<Box<dyn Fn(f32, f32) -> Message>>,
+    snap_to_bottom: bool,
 }
 
 impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
@@ -38,7 +40,34 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
             scroller_width: 10,
             content: Column::new(),
             style: Renderer::Style::default(),
+            on_scroll: None,
+            snap_to_bottom: false,
         }
+    }
+
+    /// Whether to set the [`Scrollable`] to snap to bottom when the user
+    /// scrolls to bottom or not. This will keep the scrollable at the bottom
+    /// even if new content is added to the scrollable.
+    ///
+    /// [`Scrollable`]: struct.Scrollable.html
+    pub fn snap_to_bottom(mut self, snap: bool) -> Self {
+        self.snap_to_bottom = snap;
+        self
+    }
+
+    /// Sets a function to call when the [`Scrollable`] is scrolled.
+    ///
+    /// The function takes two `f32` as arguments. First is the percentage of
+    /// where the scrollable is at right now. Second is the percentage of where
+    /// the scrollable was *before*. `0.0` means top and `1.0` means bottom.
+    ///
+    /// [`Scrollable`]: struct.Scrollable.html
+    pub fn on_scroll<F>(mut self, message_constructor: F) -> Self
+    where
+        F: 'static + Fn(f32, f32) -> Message,
+    {
+        self.on_scroll = Some(Box::new(message_constructor));
+        self
     }
 
     /// Sets the vertical spacing _between_ elements.
@@ -186,7 +215,7 @@ where
             .map(|scrollbar| scrollbar.is_mouse_over(cursor_position))
             .unwrap_or(false);
 
-        let event_status = {
+        let mut event_status = {
             let cursor_position = if is_mouse_over && !is_mouse_over_scrollbar {
                 Point::new(
                     cursor_position.x,
@@ -211,99 +240,78 @@ where
             )
         };
 
-        if let event::Status::Captured = event_status {
-            return event::Status::Captured;
-        }
+        if let event::Status::Ignored = event_status {
+            self.state.prev_offset = self.state.offset(bounds, content_bounds);
 
-        if is_mouse_over {
-            match event {
-                Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                    match delta {
-                        mouse::ScrollDelta::Lines { y, .. } => {
-                            // TODO: Configurable speed (?)
-                            self.state.scroll(y * 60.0, bounds, content_bounds);
-                        }
-                        mouse::ScrollDelta::Pixels { y, .. } => {
-                            self.state.scroll(y, bounds, content_bounds);
-                        }
-                    }
-
-                    return event::Status::Captured;
-                }
-                Event::Touch(event) => {
-                    match event {
-                        touch::Event::FingerPressed { .. } => {
-                            self.state.scroll_box_touched_at =
-                                Some(cursor_position);
-                        }
-                        touch::Event::FingerMoved { .. } => {
-                            if let Some(scroll_box_touched_at) =
-                                self.state.scroll_box_touched_at
-                            {
-                                let delta =
-                                    cursor_position.y - scroll_box_touched_at.y;
-
+            if is_mouse_over {
+                match event {
+                    Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                        match delta {
+                            mouse::ScrollDelta::Lines { y, .. } => {
+                                // TODO: Configurable speed (?)
                                 self.state.scroll(
-                                    delta,
+                                    y * 60.0,
                                     bounds,
                                     content_bounds,
                                 );
+                            }
+                            mouse::ScrollDelta::Pixels { y, .. } => {
+                                self.state.scroll(y, bounds, content_bounds);
+                            }
+                        }
 
+                        event_status = event::Status::Captured;
+                    }
+                    Event::Touch(event) => {
+                        match event {
+                            touch::Event::FingerPressed { .. } => {
                                 self.state.scroll_box_touched_at =
                                     Some(cursor_position);
                             }
+                            touch::Event::FingerMoved { .. } => {
+                                if let Some(scroll_box_touched_at) =
+                                    self.state.scroll_box_touched_at
+                                {
+                                    let delta = cursor_position.y
+                                        - scroll_box_touched_at.y;
+
+                                    self.state.scroll(
+                                        delta,
+                                        bounds,
+                                        content_bounds,
+                                    );
+
+                                    self.state.scroll_box_touched_at =
+                                        Some(cursor_position);
+                                }
+                            }
+                            touch::Event::FingerLifted { .. }
+                            | touch::Event::FingerLost { .. } => {
+                                self.state.scroll_box_touched_at = None;
+                            }
                         }
-                        touch::Event::FingerLifted { .. }
-                        | touch::Event::FingerLost { .. } => {
-                            self.state.scroll_box_touched_at = None;
-                        }
+
+                        event_status = event::Status::Captured;
                     }
-
-                    return event::Status::Captured;
+                    _ => {}
                 }
-                _ => {}
             }
-        }
 
-        if self.state.is_scroller_grabbed() {
-            match event {
-                Event::Mouse(mouse::Event::ButtonReleased(
-                    mouse::Button::Left,
-                ))
-                | Event::Touch(touch::Event::FingerLifted { .. })
-                | Event::Touch(touch::Event::FingerLost { .. }) => {
-                    self.state.scroller_grabbed_at = None;
+            if self.state.is_scroller_grabbed() {
+                match event {
+                    Event::Mouse(mouse::Event::ButtonReleased(
+                        mouse::Button::Left,
+                    ))
+                    | Event::Touch(touch::Event::FingerLifted { .. })
+                    | Event::Touch(touch::Event::FingerLost { .. }) => {
+                        self.state.scroller_grabbed_at = None;
 
-                    return event::Status::Captured;
-                }
-                Event::Mouse(mouse::Event::CursorMoved { .. })
-                | Event::Touch(touch::Event::FingerMoved { .. }) => {
-                    if let (Some(scrollbar), Some(scroller_grabbed_at)) =
-                        (scrollbar, self.state.scroller_grabbed_at)
-                    {
-                        self.state.scroll_to(
-                            scrollbar.scroll_percentage(
-                                scroller_grabbed_at,
-                                cursor_position,
-                            ),
-                            bounds,
-                            content_bounds,
-                        );
-
-                        return event::Status::Captured;
+                        event_status = event::Status::Captured;
                     }
-                }
-                _ => {}
-            }
-        } else if is_mouse_over_scrollbar {
-            match event {
-                Event::Mouse(mouse::Event::ButtonPressed(
-                    mouse::Button::Left,
-                ))
-                | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                    if let Some(scrollbar) = scrollbar {
-                        if let Some(scroller_grabbed_at) =
-                            scrollbar.grab_scroller(cursor_position)
+                    Event::Mouse(mouse::Event::CursorMoved { .. })
+                    | Event::Touch(touch::Event::FingerMoved { .. }) => {
+                        if let (Some(scrollbar), Some(scroller_grabbed_at)) =
+                            (scrollbar, self.state.scroller_grabbed_at)
                         {
                             self.state.scroll_to(
                                 scrollbar.scroll_percentage(
@@ -314,18 +322,71 @@ where
                                 content_bounds,
                             );
 
-                            self.state.scroller_grabbed_at =
-                                Some(scroller_grabbed_at);
-
-                            return event::Status::Captured;
+                            event_status = event::Status::Captured;
                         }
                     }
+                    _ => {}
                 }
-                _ => {}
+            } else if is_mouse_over_scrollbar {
+                match event {
+                    Event::Mouse(mouse::Event::ButtonPressed(
+                        mouse::Button::Left,
+                    ))
+                    | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                        if let Some(scrollbar) = scrollbar {
+                            if let Some(scroller_grabbed_at) =
+                                scrollbar.grab_scroller(cursor_position)
+                            {
+                                self.state.scroll_to(
+                                    scrollbar.scroll_percentage(
+                                        scroller_grabbed_at,
+                                        cursor_position,
+                                    ),
+                                    bounds,
+                                    content_bounds,
+                                );
+
+                                self.state.scroller_grabbed_at =
+                                    Some(scroller_grabbed_at);
+
+                                event_status = event::Status::Captured;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
 
-        event::Status::Ignored
+        if let event::Status::Captured = event_status {
+            if self.snap_to_bottom {
+                let new_offset = self.state.offset(bounds, content_bounds);
+
+                if new_offset < self.state.prev_offset {
+                    self.state.snap_to_bottom = false;
+                } else {
+                    let scroll_perc = new_offset as f32
+                        / (content_bounds.height - bounds.height);
+
+                    if scroll_perc >= 1.0 - f32::EPSILON {
+                        self.state.snap_to_bottom = true;
+                    }
+                }
+            }
+
+            if let Some(on_scroll) = &self.on_scroll {
+                messages.push(on_scroll(
+                    self.state.offset(bounds, content_bounds) as f32
+                        / (content_bounds.height - bounds.height),
+                    self.state.prev_offset as f32
+                        / (content_bounds.height - bounds.height),
+                ));
+            }
+
+            event::Status::Captured
+        } else {
+            event::Status::Ignored
+        }
     }
 
     fn draw(
@@ -339,6 +400,15 @@ where
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
         let content_bounds = content_layout.bounds();
+
+        if self.state.snap_to_bottom {
+            self.state.scroll_to(1.0, bounds, content_bounds);
+        }
+
+        if let Some(scroll_to) = self.state.scroll_to.borrow_mut().take() {
+            self.state.scroll_to(scroll_to, bounds, content_bounds);
+        }
+
         let offset = self.state.offset(bounds, content_bounds);
         let scrollbar = renderer.scrollbar(
             bounds,
@@ -418,11 +488,14 @@ where
 }
 
 /// The local state of a [`Scrollable`].
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct State {
     scroller_grabbed_at: Option<f32>,
     scroll_box_touched_at: Option<Point>,
-    offset: f32,
+    prev_offset: u32,
+    snap_to_bottom: bool,
+    offset: RefCell<f32>,
+    scroll_to: RefCell<Option<f32>>,
 }
 
 impl State {
@@ -443,7 +516,8 @@ impl State {
             return;
         }
 
-        self.offset = (self.offset - delta_y)
+        let offset_val = *self.offset.borrow();
+        *self.offset.borrow_mut() = (offset_val - delta_y)
             .max(0.0)
             .min((content_bounds.height - bounds.height) as f32);
     }
@@ -454,13 +528,30 @@ impl State {
     /// `0` represents scrollbar at the top, while `1` represents scrollbar at
     /// the bottom.
     pub fn scroll_to(
-        &mut self,
+        &self,
         percentage: f32,
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) {
-        self.offset =
+        *self.offset.borrow_mut() =
             ((content_bounds.height - bounds.height) * percentage).max(0.0);
+    }
+
+    /// Marks the scrollable to scroll to `perc` percentage (between 0.0 and 1.0)
+    /// in the next `draw` call.
+    ///
+    /// [`Scrollable`]: struct.Scrollable.html
+    /// [`State`]: struct.State.html
+    pub fn scroll_to_percentage(&mut self, perc: f32) {
+        *self.scroll_to.borrow_mut() = Some(perc.max(0.0).min(1.0));
+    }
+
+    /// Marks the scrollable to scroll to bottom in the next `draw` call.
+    ///
+    /// [`Scrollable`]: struct.Scrollable.html
+    /// [`State`]: struct.State.html
+    pub fn scroll_to_bottom(&mut self) {
+        self.scroll_to_percentage(1.0);
     }
 
     /// Returns the current scrolling offset of the [`State`], given the bounds
@@ -469,7 +560,7 @@ impl State {
         let hidden_content =
             (content_bounds.height - bounds.height).max(0.0).round() as u32;
 
-        self.offset.min(hidden_content as f32) as u32
+        self.offset.borrow().min(hidden_content as f32) as u32
     }
 
     /// Returns whether the scroller is currently grabbed or not.


### PR DESCRIPTION
This PR adds methods:
- `snap_to_bottom` and `on_scroll` to `Scrollable`
  - `snap_to_bottom` takes a bool and if true makes the `Scrollable` snap to bottom when the user scrolls to bottom. If the contents of the `Scrollable` change, it will automatically snap to bottom. Whenever the user scrolls up it will stop snapping to bottom. By default a `Scrollable` won't snap to bottom.
  - `on_scroll` takes a function whose arguments are two `f32`s and produces a `Message`. First argument is to pass the current `offset` of the `Scrollable` to provide the user with "where is this `Scrollable` at right now" and second argument is to pass the *previous* `offset` of the `Scrollable` to provide the user with "where was this `Scrollable` before this scroll event".
- `scroll_to_percentage` and `scroll_to_bottom` to `scrollable::State`
  - `scroll_to_percentage` takes a value between `0.0` and `1.0`. It marks the `Scrollable` to scroll to the specified percentage in the next `draw` call.
  - `scroll_to_bottom` is just a shorthand for `scroll_to_percentage(1.0)`.

This should fix #307 

I wonder what people think about this so please post your thoughts!