### PR TITLE
Update dependencies

### DIFF
--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 iced_winit = { path = "../../winit" }
 iced_wgpu = { path = "../../wgpu" }
-env_logger = "0.7"
+env_logger = "0.8"

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"
-directories = "3.0"
+directories-next = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window", "Storage"] }

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"
-directories = "2.0"
+directories = "3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window", "Storage"] }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -499,7 +499,7 @@ enum SaveError {
 impl SavedState {
     fn path() -> std::path::PathBuf {
         let mut path = if let Some(project_dirs) =
-            directories::ProjectDirs::from("rs", "Iced", "Todos")
+            directories_next::ProjectDirs::from("rs", "Iced", "Todos")
         {
             project_dirs.data_dir().into()
         } else {

--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["image", "debug"] }
-env_logger = "0.7"
+env_logger = "0.8"

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -19,7 +19,7 @@ glow = "0.6"
 glow_glyph = "0.4"
 glyph_brush = "0.7"
 euclid = "0.22"
-bytemuck = "1.2"
+bytemuck = "1.4"
 log = "0.4"
 
 [dependencies.iced_native]

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -15,8 +15,8 @@ image = []
 svg = []
 
 [dependencies]
-glow = "0.5"
-glow_glyph = "0.3"
+glow = "0.6"
+glow_glyph = "0.4"
 glyph_brush = "0.7"
 euclid = "0.22"
 bytemuck = "1.2"

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -18,7 +18,7 @@ svg = []
 glow = "0.5"
 glow_glyph = "0.3"
 glyph_brush = "0.7"
-euclid = "0.20"
+euclid = "0.22"
 bytemuck = "1.2"
 log = "0.4"
 

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.1"
 path = "../style"
 
 [dependencies.lyon]
-version = "0.15"
+version = "0.16"
 optional = true
 
 [dependencies.font-kit]

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -12,10 +12,13 @@ font-icons = []
 opengl = []
 
 [dependencies]
-bytemuck = "1.2"
 glam = "0.9"
 raw-window-handle = "0.3"
 thiserror = "1.0"
+
+[dependencies.bytemuck]
+version = "1.4"
+features = ["derive"]
 
 [dependencies.iced_native]
 version = "0.2"

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -12,7 +12,7 @@ font-icons = []
 opengl = []
 
 [dependencies]
-glam = "0.9"
+glam = "0.10"
 raw-window-handle = "0.3"
 thiserror = "1.0"
 

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.16"
 optional = true
 
 [dependencies.font-kit]
-version = "0.6"
+version = "0.8"
 optional = true
 
 [package.metadata.docs.rs]

--- a/graphics/src/triangle.rs
+++ b/graphics/src/triangle.rs
@@ -1,4 +1,5 @@
 //! Draw geometry using meshes of triangles.
+use bytemuck::{Pod, Zeroable};
 
 /// A set of [`Vertex2D`] and indices representing a list of triangles.
 ///
@@ -16,7 +17,7 @@ pub struct Mesh2D {
 }
 
 /// A two-dimensional vertex with some color in __linear__ RGBA.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Zeroable, Pod)]
 #[repr(C)]
 pub struct Vertex2D {
     /// The vertex position
@@ -24,9 +25,3 @@ pub struct Vertex2D {
     /// The vertex color in __linear__ RGBA.
     pub color: [f32; 4],
 }
-
-#[allow(unsafe_code)]
-unsafe impl bytemuck::Zeroable for Vertex2D {}
-
-#[allow(unsafe_code)]
-unsafe impl bytemuck::Pod for Vertex2D {}

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -16,12 +16,14 @@ default_system_font = ["iced_graphics/font-source"]
 wgpu = "0.6"
 wgpu_glyph = "0.10"
 glyph_brush = "0.7"
-zerocopy = "0.3"
-bytemuck = "1.2"
 raw-window-handle = "0.3"
 log = "0.4"
 guillotiere = "0.6"
 futures = "0.3"
+
+[dependencies.bytemuck]
+version = "1.4"
+features = ["derive"]
 
 [dependencies.iced_native]
 version = "0.2"

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -2,8 +2,6 @@ use crate::image::atlas::{self, Atlas};
 use iced_native::svg;
 use std::collections::{HashMap, HashSet};
 
-use zerocopy::AsBytes;
-
 pub enum Svg {
     Loaded(resvg::usvg::Tree),
     NotFound,
@@ -119,7 +117,7 @@ impl Cache {
                 let allocation = texture_atlas.upload(
                     width,
                     height,
-                    canvas.get_data().as_bytes(),
+                    bytemuck::cast_slice(canvas.get_data()),
                     device,
                     encoder,
                 )?;

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -2,9 +2,9 @@ use crate::Transformation;
 use iced_graphics::layer;
 use iced_native::Rectangle;
 
+use bytemuck::{Pod, Zeroable};
 use std::mem;
 use wgpu::util::DeviceExt;
-use zerocopy::AsBytes;
 
 #[derive(Debug)]
 pub struct Pipeline {
@@ -156,14 +156,14 @@ impl Pipeline {
         let vertices =
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::quad vertex buffer"),
-                contents: QUAD_VERTS.as_bytes(),
+                contents: bytemuck::cast_slice(&QUAD_VERTS),
                 usage: wgpu::BufferUsage::VERTEX,
             });
 
         let indices =
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::quad index buffer"),
-                contents: QUAD_INDICES.as_bytes(),
+                contents: bytemuck::cast_slice(&QUAD_INDICES),
                 usage: wgpu::BufferUsage::INDEX,
             });
 
@@ -207,7 +207,7 @@ impl Pipeline {
                 device,
             );
 
-            constants_buffer.copy_from_slice(uniforms.as_bytes());
+            constants_buffer.copy_from_slice(bytemuck::bytes_of(&uniforms));
         }
 
         let mut i = 0;
@@ -271,7 +271,7 @@ impl Pipeline {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, AsBytes)]
+#[derive(Clone, Copy, Zeroable, Pod)]
 pub struct Vertex {
     _position: [f32; 2],
 }
@@ -296,7 +296,7 @@ const QUAD_VERTS: [Vertex; 4] = [
 const MAX_INSTANCES: usize = 100_000;
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, AsBytes)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 struct Uniforms {
     transform: [f32; 16],
     scale: f32,

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -1,8 +1,9 @@
 //! Draw meshes of triangles.
 use crate::{settings, Transformation};
 use iced_graphics::layer;
+
+use bytemuck::{Pod, Zeroable};
 use std::mem;
-use zerocopy::AsBytes;
 
 pub use iced_graphics::triangle::{Mesh2D, Vertex2D};
 
@@ -322,7 +323,7 @@ impl Pipeline {
             }
         }
 
-        let uniforms = uniforms.as_bytes();
+        let uniforms = bytemuck::cast_slice(&uniforms);
 
         if let Some(uniforms_size) =
             wgpu::BufferSize::new(uniforms.len() as u64)
@@ -409,7 +410,7 @@ impl Pipeline {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, AsBytes)]
+#[derive(Debug, Clone, Copy, Zeroable, Pod)]
 struct Uniforms {
     transform: [f32; 16],
     // We need to align this to 256 bytes to please `wgpu`...


### PR DESCRIPTION
This PR updates a bunch of outdated dependencies in the workspace.

After this patch, there are 3 outdated dependencies left:

- `tokio`, which should be up-to-date after #595 is merged.
- `font-kit`, which has only been updated to `0.8`. Updating to `0.10` is blocked by https://github.com/manuel-rhdt/harfbuzz_rs/issues/27.
- `resvg`, which now depends on Skia (see #573). We should wait until [`tiny-skia`](https://github.com/RazrFalcon/tiny-skia) matures!