### PR TITLE
Event capturing

### DIFF
--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -69,7 +69,8 @@ impl Sandbox for Example {
 
 mod bezier {
     use iced::{
-        canvas::{self, Canvas, Cursor, Event, Frame, Geometry, Path, Stroke},
+        canvas::event::{self, Event},
+        canvas::{self, Canvas, Cursor, Frame, Geometry, Path, Stroke},
         mouse, Element, Length, Point, Rectangle,
     };
 
@@ -109,41 +110,51 @@ mod bezier {
             event: Event,
             bounds: Rectangle,
             cursor: Cursor,
-        ) -> Option<Curve> {
-            let cursor_position = cursor.position_in(&bounds)?;
+        ) -> (event::Status, Option<Curve>) {
+            let cursor_position =
+                if let Some(position) = cursor.position_in(&bounds) {
+                    position
+                } else {
+                    return (event::Status::Ignored, None);
+                };
 
             match event {
-                Event::Mouse(mouse_event) => match mouse_event {
-                    mouse::Event::ButtonPressed(mouse::Button::Left) => {
-                        match self.state.pending {
-                            None => {
-                                self.state.pending = Some(Pending::One {
-                                    from: cursor_position,
-                                });
-                                None
-                            }
-                            Some(Pending::One { from }) => {
-                                self.state.pending = Some(Pending::Two {
-                                    from,
-                                    to: cursor_position,
-                                });
+                Event::Mouse(mouse_event) => {
+                    let message = match mouse_event {
+                        mouse::Event::ButtonPressed(mouse::Button::Left) => {
+                            match self.state.pending {
+                                None => {
+                                    self.state.pending = Some(Pending::One {
+                                        from: cursor_position,
+                                    });
 
-                                None
-                            }
-                            Some(Pending::Two { from, to }) => {
-                                self.state.pending = None;
+                                    None
+                                }
+                                Some(Pending::One { from }) => {
+                                    self.state.pending = Some(Pending::Two {
+                                        from,
+                                        to: cursor_position,
+                                    });
 
-                                Some(Curve {
-                                    from,
-                                    to,
-                                    control: cursor_position,
-                                })
+                                    None
+                                }
+                                Some(Pending::Two { from, to }) => {
+                                    self.state.pending = None;
+
+                                    Some(Curve {
+                                        from,
+                                        to,
+                                        control: cursor_position,
+                                    })
+                                }
                             }
                         }
-                    }
-                    _ => None,
-                },
-                _ => None,
+                        _ => None,
+                    };
+
+                    (event::Status::Captured, message)
+                }
+                _ => (event::Status::Ignored, None),
             }
         }
 

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -3,7 +3,7 @@ use iced::{
     Button, Column, Command, Container, Element, HorizontalAlignment, Length,
     PaneGrid, Scrollable, Settings, Subscription, Text,
 };
-use iced_native::{subscription, Event};
+use iced_native::{event, subscription, Event};
 
 pub fn main() -> iced::Result {
     Example::run(Settings::default())
@@ -119,12 +119,18 @@ impl Application for Example {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        subscription::events_with(|event| match event {
-            Event::Keyboard(keyboard::Event::KeyPressed {
-                modifiers,
-                key_code,
-            }) if modifiers.is_command_pressed() => handle_hotkey(key_code),
-            _ => None,
+        subscription::events_with(|event, status| {
+            if let event::Status::Captured = status {
+                return None;
+            }
+
+            match event {
+                Event::Keyboard(keyboard::Event::KeyPressed {
+                    modifiers,
+                    key_code,
+                }) if modifiers.is_command_pressed() => handle_hotkey(key_code),
+                _ => None,
+            }
         })
     }
 

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -277,7 +277,7 @@ async fn run_instance<A, E, C>(
                     state.scale_factor(),
                     state.modifiers(),
                 ) {
-                    let _ = user_interface.update(
+                    let event_status = user_interface.update(
                         event.clone(),
                         state.cursor_position(),
                         clipboard.as_ref().map(|c| c as _),
@@ -285,7 +285,7 @@ async fn run_instance<A, E, C>(
                         &mut messages,
                     );
 
-                    runtime.broadcast(event);
+                    runtime.broadcast((event, event_status));
 
                     is_clean = false;
                 }

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -16,11 +16,11 @@ use iced_native::{
 use std::hash::Hash;
 use std::marker::PhantomData;
 
+pub mod event;
 pub mod path;
 
 mod cache;
 mod cursor;
-mod event;
 mod fill;
 mod frame;
 mod geometry;
@@ -184,11 +184,14 @@ where
         let cursor = Cursor::from_window_position(cursor_position);
 
         if let Some(canvas_event) = canvas_event {
-            if let Some(message) =
-                self.program.update(canvas_event, bounds, cursor)
-            {
+            let (event_status, message) =
+                self.program.update(canvas_event, bounds, cursor);
+
+            if let Some(message) = message {
                 messages.push(message);
             }
+
+            return event_status;
         }
 
         event::Status::Ignored

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -7,9 +7,11 @@
 //! [`Canvas`]: struct.Canvas.html
 //! [`Frame`]: struct.Frame.html
 use crate::{Backend, Defaults, Primitive, Renderer};
+use iced_native::layout;
+use iced_native::mouse;
 use iced_native::{
-    layout, mouse, Clipboard, Element, Hasher, Layout, Length, Point,
-    Rectangle, Size, Vector, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
+    Widget,
 };
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -166,7 +168,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer<B>,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         let bounds = layout.bounds();
 
         let canvas_event = match event {
@@ -188,6 +190,8 @@ where
                 messages.push(message);
             }
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/graphics/src/widget/canvas/event.rs
+++ b/graphics/src/widget/canvas/event.rs
@@ -1,6 +1,8 @@
 use iced_native::keyboard;
 use iced_native::mouse;
 
+pub use iced_native::event::Status;
+
 /// A [`Canvas`] event.
 ///
 /// [`Canvas`]: struct.Event.html

--- a/graphics/src/widget/canvas/event.rs
+++ b/graphics/src/widget/canvas/event.rs
@@ -1,3 +1,4 @@
+//! Handle events of a canvas.
 use iced_native::keyboard;
 use iced_native::mouse;
 

--- a/graphics/src/widget/canvas/program.rs
+++ b/graphics/src/widget/canvas/program.rs
@@ -1,4 +1,5 @@
-use crate::canvas::{Cursor, Event, Geometry};
+use crate::canvas::event::{self, Event};
+use crate::canvas::{Cursor, Geometry};
 use iced_native::{mouse, Rectangle};
 
 /// The state and logic of a [`Canvas`].
@@ -27,8 +28,8 @@ pub trait Program<Message> {
         _event: Event,
         _bounds: Rectangle,
         _cursor: Cursor,
-    ) -> Option<Message> {
-        None
+    ) -> (event::Status, Option<Message>) {
+        (event::Status::Ignored, None)
     }
 
     /// Draws the state of the [`Program`], producing a bunch of [`Geometry`].
@@ -67,7 +68,7 @@ where
         event: Event,
         bounds: Rectangle,
         cursor: Cursor,
-    ) -> Option<Message> {
+    ) -> (event::Status, Option<Message>) {
         T::update(self, event, bounds, cursor)
     }
 

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -1,7 +1,8 @@
+use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
 use crate::{
-    Clipboard, Color, Event, Hasher, Layout, Length, Point, Rectangle, Widget,
+    Clipboard, Color, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 
 /// A generic [`Widget`].
@@ -240,7 +241,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.widget.on_event(
             event,
             layout,
@@ -248,7 +249,7 @@ where
             messages,
             renderer,
             clipboard,
-        );
+        )
     }
 
     /// Draws the [`Element`] and its children using the given [`Layout`].
@@ -335,10 +336,10 @@ where
         messages: &mut Vec<B>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         let mut original_messages = Vec::new();
 
-        self.widget.on_event(
+        let status = self.widget.on_event(
             event,
             layout,
             cursor_position,
@@ -350,6 +351,8 @@ where
         original_messages
             .drain(..)
             .for_each(|message| messages.push((self.mapper)(message)));
+
+        status
     }
 
     fn draw(
@@ -423,7 +426,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.element.widget.on_event(
             event,
             layout,

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -1,3 +1,4 @@
+//! Handle events of a user interface.
 use crate::{keyboard, mouse, window};
 
 /// A user interface event.
@@ -6,7 +7,7 @@ use crate::{keyboard, mouse, window};
 /// additional events, feel free to [open an issue] and share your use case!_
 ///
 /// [open an issue]: https://github.com/hecrj/iced/issues
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     /// A keyboard event
     Keyboard(keyboard::Event),
@@ -16,4 +17,24 @@ pub enum Event {
 
     /// A window event
     Window(window::Event),
+}
+
+/// The status of an [`Event`] after being processed by a [`UserInterface`].
+///
+/// [`Event`]: enum.Event.html
+/// [`UserInterface`]: ../struct.UserInterface.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// The [`Event`] was _NOT_ handled by any widget in the [`UserInterface`].
+    ///
+    /// [`Event`]: enum.Event.html
+    /// [`UserInterface`]: ../struct.UserInterface.html
+    Ignored,
+
+    /// The [`Event`] was handled and processed by a widget in the
+    /// [`UserInterface`].
+    ///
+    /// [`Event`]: enum.Event.html
+    /// [`UserInterface`]: ../struct.UserInterface.html
+    Captured,
 }

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -19,22 +19,19 @@ pub enum Event {
     Window(window::Event),
 }
 
-/// The status of an [`Event`] after being processed by a [`UserInterface`].
+/// The status of an [`Event`] after being processed.
 ///
 /// [`Event`]: enum.Event.html
 /// [`UserInterface`]: ../struct.UserInterface.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
-    /// The [`Event`] was _NOT_ handled by any widget in the [`UserInterface`].
+    /// The [`Event`] was _NOT_ handled by any widget.
     ///
     /// [`Event`]: enum.Event.html
-    /// [`UserInterface`]: ../struct.UserInterface.html
     Ignored,
 
-    /// The [`Event`] was handled and processed by a widget in the
-    /// [`UserInterface`].
+    /// The [`Event`] was handled and processed by a widget.
     ///
     /// [`Event`]: enum.Event.html
-    /// [`UserInterface`]: ../struct.UserInterface.html
     Captured,
 }

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -25,7 +25,7 @@ pub enum Event {
 /// [`UserInterface`]: ../struct.UserInterface.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
-    /// The [`Event`] was _NOT_ handled by any widget.
+    /// The [`Event`] was **NOT** handled by any widget.
     ///
     /// [`Event`]: enum.Event.html
     Ignored,

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -35,3 +35,24 @@ pub enum Status {
     /// [`Event`]: enum.Event.html
     Captured,
 }
+
+impl Status {
+    /// Merges two [`Status`] into one.
+    ///
+    /// `Captured` takes precedence over `Ignored`:
+    ///
+    /// ```
+    /// use iced_native::event::Status;
+    ///
+    /// assert_eq!(Status::Ignored.merge(Status::Ignored), Status::Ignored);
+    /// assert_eq!(Status::Ignored.merge(Status::Captured), Status::Captured);
+    /// assert_eq!(Status::Captured.merge(Status::Ignored), Status::Captured);
+    /// assert_eq!(Status::Captured.merge(Status::Captured), Status::Captured);
+    /// ```
+    pub fn merge(self, b: Self) -> Self {
+        match self {
+            Status::Ignored => b,
+            Status::Captured => Status::Captured,
+        }
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -35,6 +35,7 @@
 #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
+pub mod event;
 pub mod keyboard;
 pub mod layout;
 pub mod mouse;
@@ -47,7 +48,6 @@ pub mod window;
 
 mod clipboard;
 mod element;
-mod event;
 mod hasher;
 mod runtime;
 mod user_interface;

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -6,7 +6,9 @@ pub mod menu;
 pub use element::Element;
 pub use menu::Menu;
 
-use crate::{layout, Clipboard, Event, Hasher, Layout, Point, Size};
+use crate::event::{self, Event};
+use crate::layout;
+use crate::{Clipboard, Hasher, Layout, Point, Size};
 
 /// An interactive component that can be displayed on top of other widgets.
 pub trait Overlay<Message, Renderer>
@@ -79,6 +81,7 @@ where
         _messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
+        event::Status::Ignored
     }
 }

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -1,6 +1,8 @@
 pub use crate::Overlay;
 
-use crate::{layout, Clipboard, Event, Hasher, Layout, Point, Size, Vector};
+use crate::event::{self, Event};
+use crate::layout;
+use crate::{Clipboard, Hasher, Layout, Point, Size, Vector};
 
 /// A generic [`Overlay`].
 ///
@@ -67,7 +69,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.overlay.on_event(
             event,
             layout,
@@ -136,10 +138,10 @@ where
         messages: &mut Vec<B>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         let mut original_messages = Vec::new();
 
-        self.content.on_event(
+        let event_status = self.content.on_event(
             event,
             layout,
             cursor_position,
@@ -151,6 +153,8 @@ where
         original_messages
             .drain(..)
             .for_each(|message| messages.push((self.mapper)(message)));
+
+        event_status
     }
 
     fn draw(

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -1,8 +1,14 @@
 //! Build and show dropdown menus.
+use crate::container;
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::overlay;
+use crate::scrollable;
+use crate::text;
 use crate::{
-    container, layout, mouse, overlay, scrollable, text, Clipboard, Container,
-    Element, Event, Hasher, Layout, Length, Point, Rectangle, Scrollable, Size,
-    Vector, Widget,
+    Clipboard, Container, Element, Hasher, Layout, Length, Point, Rectangle,
+    Scrollable, Size, Vector, Widget,
 };
 
 /// A list of selectable options.
@@ -236,7 +242,7 @@ where
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
     ) {
-        self.container.on_event(
+        let _ = self.container.on_event(
             event.clone(),
             layout,
             cursor_position,
@@ -336,7 +342,7 @@ where
         _messages: &mut Vec<Message>,
         renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let bounds = layout.bounds();
@@ -364,6 +370,8 @@ where
             }
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -241,15 +241,15 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
-        let _ = self.container.on_event(
+    ) -> event::Status {
+        self.container.on_event(
             event.clone(),
             layout,
             cursor_position,
             messages,
             renderer,
             clipboard,
-        );
+        )
     }
 
     fn draw(

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -120,15 +120,19 @@ where
         );
 
         debug.event_processing_started();
-        let mut messages = user_interface.update(
-            &self.queued_events,
-            cursor_position,
-            clipboard,
-            renderer,
-        );
-        messages.extend(self.queued_messages.drain(..));
+        let mut messages = Vec::new();
 
-        self.queued_events.clear();
+        for event in self.queued_events.drain(..) {
+            let _ = user_interface.update(
+                event,
+                cursor_position,
+                clipboard,
+                renderer,
+                &mut messages,
+            );
+        }
+
+        messages.extend(self.queued_messages.drain(..));
         debug.event_processing_finished();
 
         if messages.is_empty() {

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -122,17 +122,16 @@ where
         debug.event_processing_started();
         let mut messages = Vec::new();
 
-        for event in self.queued_events.drain(..) {
-            let _ = user_interface.update(
-                event,
-                cursor_position,
-                clipboard,
-                renderer,
-                &mut messages,
-            );
-        }
+        let _ = user_interface.update(
+            &self.queued_events,
+            cursor_position,
+            clipboard,
+            renderer,
+            &mut messages,
+        );
 
         messages.extend(self.queued_messages.drain(..));
+        self.queued_events.clear();
         debug.event_processing_finished();
 
         if messages.is_empty() {

--- a/native/src/runtime.rs
+++ b/native/src/runtime.rs
@@ -1,5 +1,6 @@
 //! Run commands and subscriptions.
-use crate::{Event, Hasher};
+use crate::event::{self, Event};
+use crate::Hasher;
 
 /// A native runtime with a generic executor and receiver of results.
 ///
@@ -8,5 +9,10 @@ use crate::{Event, Hasher};
 ///
 /// [`Command`]: ../struct.Command.html
 /// [`Subscription`]: ../struct.Subscription.html
-pub type Runtime<Executor, Receiver, Message> =
-    iced_futures::Runtime<Hasher, Event, Executor, Receiver, Message>;
+pub type Runtime<Executor, Receiver, Message> = iced_futures::Runtime<
+    Hasher,
+    (Event, event::Status),
+    Executor,
+    Receiver,
+    Message,
+>;

--- a/native/src/subscription/events.rs
+++ b/native/src/subscription/events.rs
@@ -1,16 +1,15 @@
-use crate::{
-    subscription::{EventStream, Recipe},
-    Event, Hasher,
-};
+use crate::event::{self, Event};
+use crate::subscription::{EventStream, Recipe};
+use crate::Hasher;
 use iced_futures::futures::future;
 use iced_futures::futures::StreamExt;
 use iced_futures::BoxStream;
 
 pub struct Events<Message> {
-    pub(super) f: fn(Event) -> Option<Message>,
+    pub(super) f: fn(Event, event::Status) -> Option<Message>,
 }
 
-impl<Message> Recipe<Hasher, Event> for Events<Message>
+impl<Message> Recipe<Hasher, (Event, event::Status)> for Events<Message>
 where
     Message: 'static + Send,
 {
@@ -29,7 +28,9 @@ where
         event_stream: EventStream,
     ) -> BoxStream<Self::Output> {
         event_stream
-            .filter_map(move |event| future::ready((self.f)(event)))
+            .filter_map(move |(event, status)| {
+                future::ready((self.f)(event, status))
+            })
             .boxed()
     }
 }

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -242,7 +242,7 @@ where
         };
 
         for event in events {
-            self.root.widget.on_event(
+            let _ = self.root.widget.on_event(
                 event.clone(),
                 Layout::new(&self.base.layout),
                 base_cursor,

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -216,7 +216,7 @@ where
             );
 
             for event in events {
-                overlay.on_event(
+                let _ = overlay.on_event(
                     event.clone(),
                     Layout::new(&layer.layout),
                     cursor_position,

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -73,9 +73,10 @@ pub use text::Text;
 #[doc(no_inline)]
 pub use text_input::TextInput;
 
-use crate::{
-    layout, overlay, Clipboard, Event, Hasher, Layout, Length, Point, Rectangle,
-};
+use crate::event::{self, Event};
+use crate::layout;
+use crate::overlay;
+use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle};
 
 /// A component that displays information and allows interaction.
 ///
@@ -182,7 +183,8 @@ where
         _messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
+        event::Status::Ignored
     }
 
     /// Returns the overlay of the [`Element`], if there is any.

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -4,9 +4,11 @@
 //!
 //! [`Button`]: struct.Button.html
 //! [`State`]: struct.State.html
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
 use crate::{
-    layout, mouse, Clipboard, Element, Event, Hasher, Layout, Length, Point,
-    Rectangle, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 use std::hash::Hash;
 
@@ -184,7 +186,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if self.on_press.is_some() {
@@ -209,6 +211,8 @@ where
             }
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -192,20 +192,25 @@ where
                 if self.on_press.is_some() {
                     let bounds = layout.bounds();
 
-                    self.state.is_pressed = bounds.contains(cursor_position);
+                    if bounds.contains(cursor_position) {
+                        self.state.is_pressed = true;
+
+                        return event::Status::Captured;
+                    }
                 }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if let Some(on_press) = self.on_press.clone() {
                     let bounds = layout.bounds();
 
-                    let is_clicked = self.state.is_pressed
-                        && bounds.contains(cursor_position);
+                    if self.state.is_pressed {
+                        self.state.is_pressed = false;
 
-                    self.state.is_pressed = false;
+                        if bounds.contains(cursor_position) {
+                            messages.push(on_press);
+                        }
 
-                    if is_clicked {
-                        messages.push(on_press);
+                        return event::Status::Captured;
                     }
                 }
             }

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -172,6 +172,8 @@ where
 
                 if mouse_over {
                     messages.push((self.on_toggle)(!self.is_checked));
+
+                    return event::Status::Captured;
                 }
             }
             _ => {}

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -1,10 +1,14 @@
 //! Show toggle controls using checkboxes.
 use std::hash::Hash;
 
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::row;
+use crate::text;
 use crate::{
-    layout, mouse, row, text, Align, Clipboard, Element, Event, Hasher,
-    HorizontalAlignment, Layout, Length, Point, Rectangle, Row, Text,
-    VerticalAlignment, Widget,
+    Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
+    Point, Rectangle, Row, Text, VerticalAlignment, Widget,
 };
 
 /// A box that can be checked.
@@ -161,7 +165,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let mouse_over = layout.bounds().contains(cursor_position);
@@ -172,6 +176,8 @@ where
             }
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -1,11 +1,11 @@
 //! Distribute content vertically.
 use std::hash::Hash;
 
+use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
 use crate::{
-    Align, Clipboard, Element, Event, Hasher, Layout, Length, Point, Rectangle,
-    Widget,
+    Align, Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 
 use std::u32;
@@ -162,19 +162,21 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.children.iter_mut().zip(layout.children()).for_each(
             |(child, layout)| {
-                child.widget.on_event(
+                let _ = child.widget.on_event(
                     event.clone(),
                     layout,
                     cursor_position,
                     messages,
                     renderer,
                     clipboard,
-                )
+                );
             },
         );
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -163,20 +163,20 @@ where
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
-        self.children.iter_mut().zip(layout.children()).for_each(
-            |(child, layout)| {
-                let _ = child.widget.on_event(
+        self.children
+            .iter_mut()
+            .zip(layout.children())
+            .map(|(child, layout)| {
+                child.widget.on_event(
                     event.clone(),
                     layout,
                     cursor_position,
                     messages,
                     renderer,
                     clipboard,
-                );
-            },
-        );
-
-        event::Status::Ignored
+                )
+            })
+            .fold(event::Status::Ignored, event::Status::merge)
     }
 
     fn draw(

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -1,9 +1,11 @@
 //! Decorate content and apply alignment.
 use std::hash::Hash;
 
+use crate::event::{self, Event};
+use crate::layout;
+use crate::overlay;
 use crate::{
-    layout, overlay, Align, Clipboard, Element, Event, Hasher, Layout, Length,
-    Point, Rectangle, Widget,
+    Align, Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 
 use std::u32;
@@ -174,7 +176,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.content.widget.on_event(
             event,
             layout.children().next().unwrap(),

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -28,9 +28,16 @@ pub use split::Split;
 pub use state::{Focus, State};
 pub use title_bar::TitleBar;
 
+use crate::container;
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::overlay;
+use crate::row;
+use crate::text;
 use crate::{
-    container, layout, mouse, overlay, row, text, Clipboard, Element, Event,
-    Hasher, Layout, Length, Point, Rectangle, Size, Vector, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
+    Widget,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -386,7 +393,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse_event) => match mouse_event {
                 mouse::Event::ButtonPressed(mouse::Button::Left) => {
@@ -484,6 +491,8 @@ where
                 );
             }
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -172,7 +172,7 @@ where
             layout
         };
 
-        self.body.on_event(
+        let _ = self.body.on_event(
             event,
             body_layout,
             cursor_position,

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -1,8 +1,7 @@
+use crate::event::{self, Event};
 use crate::layout;
 use crate::pane_grid;
-use crate::{
-    Clipboard, Element, Event, Hasher, Layout, Point, Rectangle, Size,
-};
+use crate::{Clipboard, Element, Hasher, Layout, Point, Rectangle, Size};
 
 /// The title bar of a [`Pane`].
 ///
@@ -245,7 +244,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         if let Some(controls) = &mut self.controls {
             let mut children = layout.children();
             let padded = children.next().unwrap();
@@ -254,14 +253,16 @@ where
             let _ = children.next();
             let controls_layout = children.next().unwrap();
 
-            let _ = controls.on_event(
+            controls.on_event(
                 event,
                 controls_layout,
                 cursor_position,
                 messages,
                 renderer,
                 clipboard,
-            );
+            )
+        } else {
+            event::Status::Ignored
         }
     }
 }

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -254,7 +254,7 @@ where
             let _ = children.next();
             let controls_layout = children.next().unwrap();
 
-            controls.on_event(
+            let _ = controls.on_event(
                 event,
                 controls_layout,
                 cursor_position,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -1,9 +1,13 @@
 //! Display a dropdown list of selectable values.
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::overlay;
+use crate::overlay::menu::{self, Menu};
+use crate::scrollable;
+use crate::text;
 use crate::{
-    layout, mouse, overlay,
-    overlay::menu::{self, Menu},
-    scrollable, text, Clipboard, Element, Event, Hasher, Layout, Length, Point,
-    Rectangle, Size, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
 use std::borrow::Cow;
 
@@ -223,7 +227,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if *self.is_open {
@@ -248,6 +252,8 @@ where
             }
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -175,6 +175,8 @@ where
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if layout.bounds().contains(cursor_position) {
                     messages.push(self.on_click.clone());
+
+                    return event::Status::Captured;
                 }
             }
             _ => {}

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -1,8 +1,12 @@
 //! Create choices using radio buttons.
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::row;
+use crate::text;
 use crate::{
-    layout, mouse, row, text, Align, Clipboard, Element, Event, Hasher,
-    HorizontalAlignment, Layout, Length, Point, Rectangle, Row, Text,
-    VerticalAlignment, Widget,
+    Align, Clipboard, Element, Hasher, HorizontalAlignment, Layout, Length,
+    Point, Rectangle, Row, Text, VerticalAlignment, Widget,
 };
 
 use std::hash::Hash;
@@ -166,7 +170,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if layout.bounds().contains(cursor_position) {
@@ -175,6 +179,8 @@ where
             }
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -163,20 +163,20 @@ where
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
     ) -> event::Status {
-        self.children.iter_mut().zip(layout.children()).for_each(
-            |(child, layout)| {
-                let _ = child.widget.on_event(
+        self.children
+            .iter_mut()
+            .zip(layout.children())
+            .map(|(child, layout)| {
+                child.widget.on_event(
                     event.clone(),
                     layout,
                     cursor_position,
                     messages,
                     renderer,
                     clipboard,
-                );
-            },
-        );
-
-        event::Status::Ignored
+                )
+            })
+            .fold(event::Status::Ignored, event::Status::merge)
     }
 
     fn draw(

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -1,9 +1,9 @@
 //! Distribute content horizontally.
+use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
 use crate::{
-    Align, Clipboard, Element, Event, Hasher, Layout, Length, Point, Rectangle,
-    Widget,
+    Align, Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,
 };
 
 use std::hash::Hash;
@@ -162,19 +162,21 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         self.children.iter_mut().zip(layout.children()).for_each(
             |(child, layout)| {
-                child.widget.on_event(
+                let _ = child.widget.on_event(
                     event.clone(),
                     layout,
                     cursor_position,
                     messages,
                     renderer,
                     clipboard,
-                )
+                );
             },
         );
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -1,7 +1,12 @@
 //! Navigate an endless amount of content with a scrollbar.
+use crate::column;
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
+use crate::overlay;
 use crate::{
-    column, layout, mouse, overlay, Align, Clipboard, Column, Element, Event,
-    Hasher, Layout, Length, Point, Rectangle, Size, Vector, Widget,
+    Align, Clipboard, Column, Element, Hasher, Layout, Length, Point,
+    Rectangle, Size, Vector, Widget,
 };
 
 use std::{f32, hash::Hash, u32};
@@ -184,7 +189,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         let bounds = layout.bounds();
         let is_mouse_over = bounds.contains(cursor_position);
 

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -4,9 +4,11 @@
 //!
 //! [`Slider`]: struct.Slider.html
 //! [`State`]: struct.State.html
+use crate::event::{self, Event};
+use crate::layout;
+use crate::mouse;
 use crate::{
-    layout, mouse, Clipboard, Element, Event, Hasher, Layout, Length, Point,
-    Rectangle, Size, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
 
 use std::{hash::Hash, ops::RangeInclusive};
@@ -202,7 +204,7 @@ where
         messages: &mut Vec<Message>,
         _renderer: &Renderer,
         _clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         let mut change = || {
             let bounds = layout.bounds();
             if cursor_position.x <= bounds.x {
@@ -251,6 +253,8 @@ where
             },
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -234,6 +234,8 @@ where
                     if layout.bounds().contains(cursor_position) {
                         change();
                         self.state.is_dragging = true;
+
+                        return event::Status::Captured;
                     }
                 }
                 mouse::Event::ButtonReleased(mouse::Button::Left) => {
@@ -242,11 +244,15 @@ where
                             messages.push(on_release);
                         }
                         self.state.is_dragging = false;
+
+                        return event::Status::Captured;
                     }
                 }
                 mouse::Event::CursorMoved { .. } => {
                     if self.state.is_dragging {
                         change();
+
+                        return event::Status::Captured;
                     }
                 }
                 _ => {}

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -14,11 +14,13 @@ pub use value::Value;
 
 use editor::Editor;
 
+use crate::event::{self, Event};
+use crate::keyboard;
+use crate::layout;
+use crate::mouse::{self, click};
+use crate::text;
 use crate::{
-    keyboard, layout,
-    mouse::{self, click},
-    text, Clipboard, Element, Event, Hasher, Layout, Length, Point, Rectangle,
-    Size, Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget,
 };
 
 use std::u32;
@@ -218,7 +220,7 @@ where
         messages: &mut Vec<Message>,
         renderer: &Renderer,
         clipboard: Option<&dyn Clipboard>,
-    ) {
+    ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let is_clicked = layout.bounds().contains(cursor_position);
@@ -489,6 +491,8 @@ where
             },
             _ => {}
         }
+
+        event::Status::Ignored
     }
 
     fn draw(

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -225,6 +225,9 @@ where
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let is_clicked = layout.bounds().contains(cursor_position);
 
+                self.state.is_dragging = is_clicked;
+                self.state.is_focused = is_clicked;
+
                 if is_clicked {
                     let text_layout = layout.children().next().unwrap();
                     let target = cursor_position.x - text_layout.bounds().x;
@@ -282,10 +285,9 @@ where
                     }
 
                     self.state.last_click = Some(click);
-                }
 
-                self.state.is_dragging = is_clicked;
-                self.state.is_focused = is_clicked;
+                    return event::Status::Captured;
+                }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 self.state.is_dragging = false;
@@ -316,6 +318,8 @@ where
                             position,
                         );
                     }
+
+                    return event::Status::Captured;
                 }
             }
             Event::Keyboard(keyboard::Event::CharacterReceived(c))
@@ -330,165 +334,199 @@ where
 
                 let message = (self.on_change)(editor.contents());
                 messages.push(message);
+
+                return event::Status::Captured;
             }
             Event::Keyboard(keyboard::Event::KeyPressed {
                 key_code,
                 modifiers,
-            }) if self.state.is_focused => match key_code {
-                keyboard::KeyCode::Enter => {
-                    if let Some(on_submit) = self.on_submit.clone() {
-                        messages.push(on_submit);
-                    }
-                }
-                keyboard::KeyCode::Backspace => {
-                    if platform::is_jump_modifier_pressed(modifiers)
-                        && self.state.cursor.selection(&self.value).is_none()
-                    {
-                        if self.is_secure {
-                            let cursor_pos = self.state.cursor.end(&self.value);
-                            self.state.cursor.select_range(0, cursor_pos);
-                        } else {
-                            self.state.cursor.select_left_by_words(&self.value);
+            }) if self.state.is_focused => {
+                match key_code {
+                    keyboard::KeyCode::Enter => {
+                        if let Some(on_submit) = self.on_submit.clone() {
+                            messages.push(on_submit);
                         }
                     }
-
-                    let mut editor =
-                        Editor::new(&mut self.value, &mut self.state.cursor);
-
-                    editor.backspace();
-
-                    let message = (self.on_change)(editor.contents());
-                    messages.push(message);
-                }
-                keyboard::KeyCode::Delete => {
-                    if platform::is_jump_modifier_pressed(modifiers)
-                        && self.state.cursor.selection(&self.value).is_none()
-                    {
-                        if self.is_secure {
-                            let cursor_pos = self.state.cursor.end(&self.value);
-                            self.state
+                    keyboard::KeyCode::Backspace => {
+                        if platform::is_jump_modifier_pressed(modifiers)
+                            && self
+                                .state
                                 .cursor
-                                .select_range(cursor_pos, self.value.len());
-                        } else {
-                            self.state
-                                .cursor
-                                .select_right_by_words(&self.value);
+                                .selection(&self.value)
+                                .is_none()
+                        {
+                            if self.is_secure {
+                                let cursor_pos =
+                                    self.state.cursor.end(&self.value);
+                                self.state.cursor.select_range(0, cursor_pos);
+                            } else {
+                                self.state
+                                    .cursor
+                                    .select_left_by_words(&self.value);
+                            }
                         }
-                    }
 
-                    let mut editor =
-                        Editor::new(&mut self.value, &mut self.state.cursor);
-
-                    editor.delete();
-
-                    let message = (self.on_change)(editor.contents());
-                    messages.push(message);
-                }
-                keyboard::KeyCode::Left => {
-                    if platform::is_jump_modifier_pressed(modifiers)
-                        && !self.is_secure
-                    {
-                        if modifiers.shift {
-                            self.state.cursor.select_left_by_words(&self.value);
-                        } else {
-                            self.state.cursor.move_left_by_words(&self.value);
-                        }
-                    } else if modifiers.shift {
-                        self.state.cursor.select_left(&self.value)
-                    } else {
-                        self.state.cursor.move_left(&self.value);
-                    }
-                }
-                keyboard::KeyCode::Right => {
-                    if platform::is_jump_modifier_pressed(modifiers)
-                        && !self.is_secure
-                    {
-                        if modifiers.shift {
-                            self.state
-                                .cursor
-                                .select_right_by_words(&self.value);
-                        } else {
-                            self.state.cursor.move_right_by_words(&self.value);
-                        }
-                    } else if modifiers.shift {
-                        self.state.cursor.select_right(&self.value)
-                    } else {
-                        self.state.cursor.move_right(&self.value);
-                    }
-                }
-                keyboard::KeyCode::Home => {
-                    if modifiers.shift {
-                        self.state.cursor.select_range(
-                            self.state.cursor.start(&self.value),
-                            0,
+                        let mut editor = Editor::new(
+                            &mut self.value,
+                            &mut self.state.cursor,
                         );
-                    } else {
-                        self.state.cursor.move_to(0);
+
+                        editor.backspace();
+
+                        let message = (self.on_change)(editor.contents());
+                        messages.push(message);
                     }
-                }
-                keyboard::KeyCode::End => {
-                    if modifiers.shift {
-                        self.state.cursor.select_range(
-                            self.state.cursor.start(&self.value),
-                            self.value.len(),
+                    keyboard::KeyCode::Delete => {
+                        if platform::is_jump_modifier_pressed(modifiers)
+                            && self
+                                .state
+                                .cursor
+                                .selection(&self.value)
+                                .is_none()
+                        {
+                            if self.is_secure {
+                                let cursor_pos =
+                                    self.state.cursor.end(&self.value);
+                                self.state
+                                    .cursor
+                                    .select_range(cursor_pos, self.value.len());
+                            } else {
+                                self.state
+                                    .cursor
+                                    .select_right_by_words(&self.value);
+                            }
+                        }
+
+                        let mut editor = Editor::new(
+                            &mut self.value,
+                            &mut self.state.cursor,
                         );
-                    } else {
-                        self.state.cursor.move_to(self.value.len());
+
+                        editor.delete();
+
+                        let message = (self.on_change)(editor.contents());
+                        messages.push(message);
                     }
-                }
-                keyboard::KeyCode::V => {
-                    if platform::is_copy_paste_modifier_pressed(modifiers) {
-                        if let Some(clipboard) = clipboard {
-                            let content = match self.state.is_pasting.take() {
-                                Some(content) => content,
-                                None => {
-                                    let content: String = clipboard
-                                        .content()
-                                        .unwrap_or(String::new())
-                                        .chars()
-                                        .filter(|c| !c.is_control())
-                                        .collect();
-
-                                    Value::new(&content)
-                                }
-                            };
-
-                            let mut editor = Editor::new(
-                                &mut self.value,
-                                &mut self.state.cursor,
+                    keyboard::KeyCode::Left => {
+                        if platform::is_jump_modifier_pressed(modifiers)
+                            && !self.is_secure
+                        {
+                            if modifiers.shift {
+                                self.state
+                                    .cursor
+                                    .select_left_by_words(&self.value);
+                            } else {
+                                self.state
+                                    .cursor
+                                    .move_left_by_words(&self.value);
+                            }
+                        } else if modifiers.shift {
+                            self.state.cursor.select_left(&self.value)
+                        } else {
+                            self.state.cursor.move_left(&self.value);
+                        }
+                    }
+                    keyboard::KeyCode::Right => {
+                        if platform::is_jump_modifier_pressed(modifiers)
+                            && !self.is_secure
+                        {
+                            if modifiers.shift {
+                                self.state
+                                    .cursor
+                                    .select_right_by_words(&self.value);
+                            } else {
+                                self.state
+                                    .cursor
+                                    .move_right_by_words(&self.value);
+                            }
+                        } else if modifiers.shift {
+                            self.state.cursor.select_right(&self.value)
+                        } else {
+                            self.state.cursor.move_right(&self.value);
+                        }
+                    }
+                    keyboard::KeyCode::Home => {
+                        if modifiers.shift {
+                            self.state.cursor.select_range(
+                                self.state.cursor.start(&self.value),
+                                0,
                             );
-
-                            editor.paste(content.clone());
-
-                            let message = (self.on_change)(editor.contents());
-                            messages.push(message);
-
-                            self.state.is_pasting = Some(content);
+                        } else {
+                            self.state.cursor.move_to(0);
                         }
-                    } else {
+                    }
+                    keyboard::KeyCode::End => {
+                        if modifiers.shift {
+                            self.state.cursor.select_range(
+                                self.state.cursor.start(&self.value),
+                                self.value.len(),
+                            );
+                        } else {
+                            self.state.cursor.move_to(self.value.len());
+                        }
+                    }
+                    keyboard::KeyCode::V => {
+                        if platform::is_copy_paste_modifier_pressed(modifiers) {
+                            if let Some(clipboard) = clipboard {
+                                let content = match self.state.is_pasting.take()
+                                {
+                                    Some(content) => content,
+                                    None => {
+                                        let content: String = clipboard
+                                            .content()
+                                            .unwrap_or(String::new())
+                                            .chars()
+                                            .filter(|c| !c.is_control())
+                                            .collect();
+
+                                        Value::new(&content)
+                                    }
+                                };
+
+                                let mut editor = Editor::new(
+                                    &mut self.value,
+                                    &mut self.state.cursor,
+                                );
+
+                                editor.paste(content.clone());
+
+                                let message =
+                                    (self.on_change)(editor.contents());
+                                messages.push(message);
+
+                                self.state.is_pasting = Some(content);
+                            }
+                        } else {
+                            self.state.is_pasting = None;
+                        }
+                    }
+                    keyboard::KeyCode::A => {
+                        if platform::is_copy_paste_modifier_pressed(modifiers) {
+                            self.state.cursor.select_all(&self.value);
+                        }
+                    }
+                    keyboard::KeyCode::Escape => {
+                        self.state.is_focused = false;
+                        self.state.is_dragging = false;
                         self.state.is_pasting = None;
                     }
+                    _ => {}
                 }
-                keyboard::KeyCode::A => {
-                    if platform::is_copy_paste_modifier_pressed(modifiers) {
-                        self.state.cursor.select_all(&self.value);
-                    }
-                }
-                keyboard::KeyCode::Escape => {
-                    self.state.is_focused = false;
-                    self.state.is_dragging = false;
-                    self.state.is_pasting = None;
-                }
-                _ => {}
-            },
+
+                return event::Status::Captured;
+            }
             Event::Keyboard(keyboard::Event::KeyReleased {
                 key_code, ..
-            }) => match key_code {
-                keyboard::KeyCode::V => {
-                    self.state.is_pasting = None;
+            }) if self.state.is_focused => {
+                match key_code {
+                    keyboard::KeyCode::V => {
+                        self.state.is_pasting = None;
+                    }
+                    _ => {}
                 }
-                _ => {}
-            },
+
+                return event::Status::Captured;
+            }
             _ => {}
         }
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -359,7 +359,7 @@ async fn run_instance<A, E, C>(
                     state.scale_factor(),
                     state.modifiers(),
                 ) {
-                    let _ = user_interface.update(
+                    let event_status = user_interface.update(
                         event.clone(),
                         state.cursor_position(),
                         clipboard.as_ref().map(|c| c as _),
@@ -367,7 +367,7 @@ async fn run_instance<A, E, C>(
                         &mut messages,
                     );
 
-                    runtime.broadcast(event);
+                    runtime.broadcast((event, event_status));
 
                     is_clean = false;
                 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -241,21 +241,32 @@ async fn run_instance<A, E, C>(
         user_interface.draw(&mut renderer, state.cursor_position());
     let mut mouse_interaction = mouse::Interaction::default();
 
+    let mut events = Vec::new();
     let mut messages = Vec::new();
-    let mut is_clean = true;
 
     debug.startup_finished();
 
     while let Some(event) = receiver.next().await {
         match event {
-            event::Event::NewEvents(_) => {
-                debug.event_processing_started();
-            }
             event::Event::MainEventsCleared => {
+                if events.is_empty() && messages.is_empty() {
+                    continue;
+                }
+
+                debug.event_processing_started();
+
+                let statuses = user_interface.update(
+                    &events,
+                    state.cursor_position(),
+                    clipboard.as_ref().map(|c| c as _),
+                    &mut renderer,
+                    &mut messages,
+                );
+
                 debug.event_processing_finished();
 
-                if is_clean && messages.is_empty() {
-                    continue;
+                for event in events.drain(..).zip(statuses.into_iter()) {
+                    runtime.broadcast(event);
                 }
 
                 if !messages.is_empty() {
@@ -288,7 +299,6 @@ async fn run_instance<A, E, C>(
                 debug.draw_finished();
 
                 window.request_redraw();
-                is_clean = true;
             }
             event::Event::UserEvent(message) => {
                 messages.push(message);
@@ -359,17 +369,7 @@ async fn run_instance<A, E, C>(
                     state.scale_factor(),
                     state.modifiers(),
                 ) {
-                    let event_status = user_interface.update(
-                        event.clone(),
-                        state.cursor_position(),
-                        clipboard.as_ref().map(|c| c as _),
-                        &mut renderer,
-                        &mut messages,
-                    );
-
-                    runtime.broadcast((event, event_status));
-
-                    is_clean = false;
+                    events.push(event);
                 }
             }
             _ => {}


### PR DESCRIPTION
This PR allows widgets to inform the runtime about whether they have handled an event or not.

Specifically, a new `event::Status` enum has been introduced. It has two variants: `Ignored` and `Captured`, and `Widget::on_event` now must return one of them:

- `Captured` if the event was handled by the implementor.
- `Ignored` otherwise.

As a consequence, `UserInterface::update` has been changed to return an `event::Status` for every processed `Event`. This should help users that are integrating `iced` with their own custom event loop to implement proper event propagation (see #408 and #455). 

Furthermore, `subscription::Recipe` in `iced_native` now takes a stream of `(Event, event::Status)` as input, effectively allowing subscriptions to discard events that have already been processed by a widget. This is specially useful for implementing global hotkeys (e.g. if a `TextInput` is focused, hotkeys will not trigger when typing on it).

Fixes #408.
Closes #455.