### PR TITLE
Disable dragging in `TextInput` after double click

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -278,7 +278,6 @@ where
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let is_clicked = layout.bounds().contains(cursor_position);
 
-                self.state.is_dragging = is_clicked;
                 self.state.is_focused = is_clicked;
 
                 if is_clicked {
@@ -312,6 +311,8 @@ where
                             } else {
                                 self.state.cursor.move_to(0);
                             }
+
+                            self.state.is_dragging = true;
                         }
                         click::Kind::Double => {
                             if self.is_secure {
@@ -331,9 +332,12 @@ where
                                     self.value.next_end_of_word(position),
                                 );
                             }
+
+                            self.state.is_dragging = false;
                         }
                         click::Kind::Triple => {
                             self.state.cursor.select_all(&self.value);
+                            self.state.is_dragging = false;
                         }
                     }
 


### PR DESCRIPTION
Fixes #616.

When using a trackpad, mouse move events may happen between the press/release events. This was incorrectly triggering selection dragging in the `TextInput` widget.

Eventually, we should implement proper word-aware selection dragging.