### PR TITLE
Fix backwards `Frame::rotate` in `canvas`

### DIFF
--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -276,7 +276,7 @@ impl Frame {
             .transforms
             .current
             .raw
-            .pre_rotate(lyon::math::Angle::radians(-angle));
+            .pre_rotate(lyon::math::Angle::radians(angle));
         self.transforms.current.is_identity = false;
     }
 


### PR DESCRIPTION
Fixes #626.

The angle direction has been fixed upstream in `euclid` (see https://github.com/servo/euclid/pull/413).