### PR TITLE
Use intra-doc links

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -43,8 +43,6 @@ impl Color {
     ///
     /// In debug mode, it will panic if the values are not in the correct
     /// range: 0.0 - 1.0
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
         debug_assert!(
             (0.0..=1.0).contains(&r),
@@ -67,29 +65,21 @@ impl Color {
     }
 
     /// Creates a [`Color`] from its RGB components.
-    ///
-    /// [`Color`]: struct.Color.html
     pub const fn from_rgb(r: f32, g: f32, b: f32) -> Color {
         Color::from_rgba(r, g, b, 1.0f32)
     }
 
     /// Creates a [`Color`] from its RGBA components.
-    ///
-    /// [`Color`]: struct.Color.html
     pub const fn from_rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
         Color { r, g, b, a }
     }
 
     /// Creates a [`Color`] from its RGB8 components.
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn from_rgb8(r: u8, g: u8, b: u8) -> Color {
         Color::from_rgba8(r, g, b, 1.0)
     }
 
     /// Creates a [`Color`] from its RGB8 components and an alpha value.
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn from_rgba8(r: u8, g: u8, b: u8, a: f32) -> Color {
         Color {
             r: f32::from(r) / 255.0,
@@ -100,8 +90,6 @@ impl Color {
     }
 
     /// Converts the [`Color`] into its linear values.
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn into_linear(self) -> [f32; 4] {
         // As described in:
         // https://en.wikipedia.org/wiki/SRGB#The_reverse_transformation
@@ -122,8 +110,6 @@ impl Color {
     }
 
     /// Inverts the [`Color`] in-place.
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn invert(&mut self) {
         self.r = 1.0f32 - self.r;
         self.b = 1.0f32 - self.g;
@@ -131,8 +117,6 @@ impl Color {
     }
 
     /// Returns the inverted [`Color`].
-    ///
-    /// [`Color`]: struct.Color.html
     pub fn inverse(self) -> Color {
         Color::new(1.0f32 - self.r, 1.0f32 - self.g, 1.0f32 - self.b, self.a)
     }
@@ -152,8 +136,6 @@ impl From<[f32; 4]> for Color {
 
 #[cfg(feature = "palette")]
 /// Converts from palette's `Srgba` type to a [`Color`].
-///
-/// [`Color`]: struct.Color.html
 impl From<Srgba> for Color {
     fn from(srgba: Srgba) -> Self {
         Color::new(srgba.red, srgba.green, srgba.blue, srgba.alpha)
@@ -162,8 +144,6 @@ impl From<Srgba> for Color {
 
 #[cfg(feature = "palette")]
 /// Converts from [`Color`] to palette's `Srgba` type.
-///
-/// [`Color`]: struct.Color.html
 impl From<Color> for Srgba {
     fn from(c: Color) -> Self {
         Srgba::new(c.r, c.g, c.b, c.a)
@@ -172,8 +152,6 @@ impl From<Color> for Srgba {
 
 #[cfg(feature = "palette")]
 /// Converts from palette's `Srgb` type to a [`Color`].
-///
-/// [`Color`]: struct.Color.html
 impl From<Srgb> for Color {
     fn from(srgb: Srgb) -> Self {
         Color::new(srgb.red, srgb.green, srgb.blue, 1.0)
@@ -182,9 +160,6 @@ impl From<Srgb> for Color {
 
 #[cfg(feature = "palette")]
 /// Converts from [`Color`] to palette's `Srgb` type.
-///
-/// [`Color`]: struct.Color.html
-/// [`Srgb`]: ../palette/rgb/type.Srgb.html
 impl From<Color> for Srgb {
     fn from(c: Color) -> Self {
         Srgb::new(c.r, c.g, c.b)

--- a/core/src/keyboard.rs
+++ b/core/src/keyboard.rs
@@ -1,8 +1,8 @@
 //! Reuse basic keyboard types.
 mod event;
 mod key_code;
-mod modifiers_state;
+mod modifiers;
 
 pub use event::Event;
 pub use key_code::KeyCode;
-pub use modifiers_state::ModifiersState;
+pub use modifiers::Modifiers;

--- a/core/src/keyboard/event.rs
+++ b/core/src/keyboard/event.rs
@@ -1,4 +1,4 @@
-use super::{KeyCode, ModifiersState};
+use super::{KeyCode, Modifiers};
 
 /// A keyboard event.
 ///
@@ -14,7 +14,7 @@ pub enum Event {
         key_code: KeyCode,
 
         /// The state of the modifier keys
-        modifiers: ModifiersState,
+        modifiers: Modifiers,
     },
 
     /// A keyboard key was released.
@@ -23,12 +23,12 @@ pub enum Event {
         key_code: KeyCode,
 
         /// The state of the modifier keys
-        modifiers: ModifiersState,
+        modifiers: Modifiers,
     },
 
     /// A unicode character was received.
     CharacterReceived(char),
 
     /// The keyboard modifiers have changed.
-    ModifiersChanged(ModifiersState),
+    ModifiersChanged(Modifiers),
 }

--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -1,6 +1,6 @@
 /// The current state of the keyboard modifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ModifiersState {
+pub struct Modifiers {
     /// Whether a shift key is pressed
     pub shift: bool,
 
@@ -14,17 +14,14 @@ pub struct ModifiersState {
     pub logo: bool,
 }
 
-impl ModifiersState {
-    /// Returns true if the current [`ModifiersState`] has a "command key"
-    /// pressed.
+impl Modifiers {
+    /// Returns true if a "command key" is pressed in the [`Modifiers`].
     ///
     /// The "command key" is the main modifier key used to issue commands in the
     /// current platform. Specifically:
     ///
     /// - It is the `logo` or command key (⌘) on macOS
     /// - It is the `control` key on other platforms
-    ///
-    /// [`ModifiersState`]: struct.ModifiersState.html
     pub fn is_command_pressed(self) -> bool {
         #[cfg(target_os = "macos")]
         let is_pressed = self.logo;
@@ -35,11 +32,9 @@ impl ModifiersState {
         is_pressed
     }
 
-    /// Returns true if the current [`ModifiersState`] has at least the same
-    /// modifiers enabled as the given value, and false otherwise.
-    ///
-    /// [`ModifiersState`]: struct.ModifiersState.html
-    pub fn matches(&self, modifiers: ModifiersState) -> bool {
+    /// Returns true if the current [`Modifiers`] have at least the same
+    /// keys pressed as the provided ones, and false otherwise.
+    pub fn matches(&self, modifiers: Self) -> bool {
         let shift = !modifiers.shift || self.shift;
         let control = !modifiers.control || self.control;
         let alt = !modifiers.alt || self.alt;

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -26,8 +26,6 @@ impl Length {
     /// The _fill factor_ is a relative unit describing how much of the
     /// remaining space should be filled when compared to other elements. It
     /// is only meant to be used by layout engines.
-    ///
-    /// [`Length`]: enum.Length.html
     pub fn fill_factor(&self) -> u16 {
         match self {
             Length::Fill => 1,

--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -12,20 +12,14 @@ pub struct Point {
 
 impl Point {
     /// The origin (i.e. a [`Point`] at (0, 0)).
-    ///
-    /// [`Point`]: struct.Point.html
     pub const ORIGIN: Point = Point::new(0.0, 0.0);
 
     /// Creates a new [`Point`] with the given coordinates.
-    ///
-    /// [`Point`]: struct.Point.html
     pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 
     /// Computes the distance to another [`Point`].
-    ///
-    /// [`Point`]: struct.Point.html
     pub fn distance(&self, to: Point) -> f32 {
         let a = self.x - to.x;
         let b = self.y - to.y;

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -19,10 +19,6 @@ pub struct Rectangle<T = f32> {
 impl Rectangle<f32> {
     /// Creates a new [`Rectangle`] with its top-left corner in the given
     /// [`Point`] and with the provided [`Size`].
-    ///
-    /// [`Rectangle`]: struct.Rectangle.html
-    /// [`Point`]: struct.Point.html
-    /// [`Size`]: struct.Size.html
     pub fn new(top_left: Point, size: Size) -> Self {
         Self {
             x: top_left.x,
@@ -34,9 +30,6 @@ impl Rectangle<f32> {
 
     /// Creates a new [`Rectangle`] with its top-left corner at the origin
     /// and with the provided [`Size`].
-    ///
-    /// [`Rectangle`]: struct.Rectangle.html
-    /// [`Size`]: struct.Size.html
     pub fn with_size(size: Size) -> Self {
         Self {
             x: 0.0,
@@ -47,50 +40,33 @@ impl Rectangle<f32> {
     }
 
     /// Returns the [`Point`] at the center of the [`Rectangle`].
-    ///
-    /// [`Point`]: struct.Point.html
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn center(&self) -> Point {
         Point::new(self.center_x(), self.center_y())
     }
 
     /// Returns the X coordinate of the [`Point`] at the center of the
     /// [`Rectangle`].
-    ///
-    /// [`Point`]: struct.Point.html
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn center_x(&self) -> f32 {
         self.x + self.width / 2.0
     }
 
     /// Returns the Y coordinate of the [`Point`] at the center of the
     /// [`Rectangle`].
-    ///
-    /// [`Point`]: struct.Point.html
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn center_y(&self) -> f32 {
         self.y + self.height / 2.0
     }
 
     /// Returns the position of the top left corner of the [`Rectangle`].
-    ///
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn position(&self) -> Point {
         Point::new(self.x, self.y)
     }
 
     /// Returns the [`Size`] of the [`Rectangle`].
-    ///
-    /// [`Size`]: struct.Size.html
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn size(&self) -> Size {
         Size::new(self.width, self.height)
     }
 
     /// Returns true if the given [`Point`] is contained in the [`Rectangle`].
-    ///
-    /// [`Point`]: struct.Point.html
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn contains(&self, point: Point) -> bool {
         self.x <= point.x
             && point.x <= self.x + self.width
@@ -99,8 +75,6 @@ impl Rectangle<f32> {
     }
 
     /// Computes the intersection with the given [`Rectangle`].
-    ///
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn intersection(
         &self,
         other: &Rectangle<f32>,
@@ -127,8 +101,6 @@ impl Rectangle<f32> {
     }
 
     /// Snaps the [`Rectangle`] to __unsigned__ integer coordinates.
-    ///
-    /// [`Rectangle`]: struct.Rectangle.html
     pub fn snap(self) -> Rectangle<u32> {
         Rectangle {
             x: self.x as u32,

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -12,8 +12,6 @@ pub struct Size<T = f32> {
 
 impl<T> Size<T> {
     /// Creates a new  [`Size`] with the given width and height.
-    ///
-    /// [`Size`]: struct.Size.html
     pub const fn new(width: T, height: T) -> Self {
         Size { width, height }
     }
@@ -21,23 +19,15 @@ impl<T> Size<T> {
 
 impl Size {
     /// A [`Size`] with zero width and height.
-    ///
-    /// [`Size`]: struct.Size.html
     pub const ZERO: Size = Size::new(0., 0.);
 
     /// A [`Size`] with a width and height of 1 unit.
-    ///
-    /// [`Size`]: struct.Size.html
     pub const UNIT: Size = Size::new(1., 1.);
 
     /// A [`Size`] with infinite width and height.
-    ///
-    /// [`Size`]: struct.Size.html
     pub const INFINITY: Size = Size::new(f32::INFINITY, f32::INFINITY);
 
     /// Increments the [`Size`] to account for the given padding.
-    ///
-    /// [`Size`]: struct.Size.html
     pub fn pad(&self, padding: f32) -> Self {
         Size {
             width: self.width + padding * 2.0,

--- a/core/src/vector.rs
+++ b/core/src/vector.rs
@@ -2,20 +2,14 @@
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Vector<T = f32> {
     /// The X component of the [`Vector`]
-    ///
-    /// [`Vector`]: struct.Vector.html
     pub x: T,
 
     /// The Y component of the [`Vector`]
-    ///
-    /// [`Vector`]: struct.Vector.html
     pub y: T,
 }
 
 impl<T> Vector<T> {
     /// Creates a new [`Vector`] with the given components.
-    ///
-    /// [`Vector`]: struct.Vector.html
     pub const fn new(x: T, y: T) -> Self {
         Self { x, y }
     }

--- a/futures/src/command.rs
+++ b/futures/src/command.rs
@@ -5,9 +5,6 @@ use futures::future::{Future, FutureExt};
 ///
 /// You should be able to turn a future easily into a [`Command`], either by
 /// using the `From` trait or [`Command::perform`].
-///
-/// [`Command`]: struct.Command.html
-/// [`Command::perform`]: #method.perform
 pub struct Command<T> {
     futures: Vec<BoxFuture<T>>,
 }
@@ -16,8 +13,6 @@ impl<T> Command<T> {
     /// Creates an empty [`Command`].
     ///
     /// In other words, a [`Command`] that does nothing.
-    ///
-    /// [`Command`]: struct.Command.html
     pub fn none() -> Self {
         Self {
             futures: Vec::new(),
@@ -25,8 +20,6 @@ impl<T> Command<T> {
     }
 
     /// Creates a [`Command`] that performs the action of the given future.
-    ///
-    /// [`Command`]: struct.Command.html
     #[cfg(not(target_arch = "wasm32"))]
     pub fn perform<A>(
         future: impl Future<Output = T> + 'static + Send,
@@ -38,8 +31,6 @@ impl<T> Command<T> {
     }
 
     /// Creates a [`Command`] that performs the action of the given future.
-    ///
-    /// [`Command`]: struct.Command.html
     #[cfg(target_arch = "wasm32")]
     pub fn perform<A>(
         future: impl Future<Output = T> + 'static,
@@ -51,8 +42,6 @@ impl<T> Command<T> {
     }
 
     /// Applies a transformation to the result of a [`Command`].
-    ///
-    /// [`Command`]: struct.Command.html
     #[cfg(not(target_arch = "wasm32"))]
     pub fn map<A>(
         mut self,
@@ -78,8 +67,6 @@ impl<T> Command<T> {
     }
 
     /// Applies a transformation to the result of a [`Command`].
-    ///
-    /// [`Command`]: struct.Command.html
     #[cfg(target_arch = "wasm32")]
     pub fn map<A>(mut self, f: impl Fn(T) -> A + 'static) -> Command<A>
     where
@@ -105,8 +92,6 @@ impl<T> Command<T> {
     /// commands.
     ///
     /// Once this command is run, all the commands will be executed at once.
-    ///
-    /// [`Command`]: struct.Command.html
     pub fn batch(commands: impl IntoIterator<Item = Command<T>>) -> Self {
         Self {
             futures: commands
@@ -117,8 +102,6 @@ impl<T> Command<T> {
     }
 
     /// Converts a [`Command`] into its underlying list of futures.
-    ///
-    /// [`Command`]: struct.Command.html
     pub fn futures(self) -> Vec<BoxFuture<T>> {
         self.futures
     }

--- a/futures/src/executor.rs
+++ b/futures/src/executor.rs
@@ -38,21 +38,15 @@ use futures::Future;
 /// A type that can run futures.
 pub trait Executor: Sized {
     /// Creates a new [`Executor`].
-    ///
-    /// [`Executor`]: trait.Executor.html
     fn new() -> Result<Self, futures::io::Error>
     where
         Self: Sized;
 
     /// Spawns a future in the [`Executor`].
-    ///
-    /// [`Executor`]: trait.Executor.html
     #[cfg(not(target_arch = "wasm32"))]
     fn spawn(&self, future: impl Future<Output = ()> + Send + 'static);
 
     /// Spawns a local future in the [`Executor`].
-    ///
-    /// [`Executor`]: trait.Executor.html
     #[cfg(target_arch = "wasm32")]
     fn spawn(&self, future: impl Future<Output = ()> + 'static);
 
@@ -62,8 +56,6 @@ pub trait Executor: Sized {
     /// before creating futures. This method can be leveraged to set up this
     /// global state, call a function, restore the state, and obtain the result
     /// of the call.
-    ///
-    /// [`Executor`]: trait.Executor.html
     fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
         f()
     }

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -8,11 +8,6 @@ use std::marker::PhantomData;
 ///
 /// If you have an [`Executor`], a [`Runtime`] can be leveraged to run any
 /// [`Command`] or [`Subscription`] and get notified of the results!
-///
-/// [`Runtime`]: struct.Runtime.html
-/// [`Executor`]: executor/trait.Executor.html
-/// [`Command`]: struct.Command.html
-/// [`Subscription`]: subscription/struct.Subscription.html
 #[derive(Debug)]
 pub struct Runtime<Hasher, Event, Executor, Sender, Message> {
     executor: Executor,
@@ -36,8 +31,6 @@ where
     /// You need to provide:
     /// - an [`Executor`] to spawn futures
     /// - a `Sender` implementing `Sink` to receive the results
-    ///
-    /// [`Runtime`]: struct.Runtime.html
     pub fn new(executor: Executor, sender: Sender) -> Self {
         Self {
             executor,
@@ -50,10 +43,6 @@ where
     /// Runs the given closure inside the [`Executor`] of the [`Runtime`].
     ///
     /// See [`Executor::enter`] to learn more.
-    ///
-    /// [`Executor`]: executor/trait.Executor.html
-    /// [`Runtime`]: struct.Runtime.html
-    /// [`Executor::enter`]: executor/trait.Executor.html#method.enter
     pub fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
         self.executor.enter(f)
     }
@@ -62,9 +51,6 @@ where
     ///
     /// The resulting `Message` will be forwarded to the `Sender` of the
     /// [`Runtime`].
-    ///
-    /// [`Command`]: struct.Command.html
-    /// [`Runtime`]: struct.Runtime.html
     pub fn spawn(&mut self, command: Command<Message>) {
         use futures::{FutureExt, SinkExt};
 
@@ -88,9 +74,7 @@ where
     /// It will spawn new streams or close old ones as necessary! See
     /// [`Tracker::update`] to learn more about this!
     ///
-    /// [`Subscription`]: subscription/struct.Subscription.html
-    /// [`Runtime`]: struct.Runtime.html
-    /// [`Tracker::update`]: subscription/struct.Tracker.html#method.update
+    /// [`Tracker::update`]: subscription::Tracker::update
     pub fn track(
         &mut self,
         subscription: Subscription<Hasher, Event, Message>,
@@ -115,9 +99,7 @@ where
     ///
     /// See [`Tracker::broadcast`] to learn more.
     ///
-    /// [`Runtime`]: struct.Runtime.html
-    /// [`Tracker::broadcast`]:
-    /// subscription/struct.Tracker.html#method.broadcast
+    /// [`Tracker::broadcast`]: subscription::Tracker::broadcast
     pub fn broadcast(&mut self, event: Event) {
         self.subscriptions.broadcast(event);
     }

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -19,8 +19,7 @@ use crate::BoxStream;
 /// This type is normally aliased by runtimes with a specific `Event` and/or
 /// `Hasher`.
 ///
-/// [`Command`]: ../struct.Command.html
-/// [`Subscription`]: struct.Subscription.html
+/// [`Command`]: crate::Command
 pub struct Subscription<Hasher, Event, Output> {
     recipes: Vec<Box<dyn Recipe<Hasher, Event, Output = Output>>>,
 }
@@ -30,8 +29,6 @@ where
     H: std::hash::Hasher,
 {
     /// Returns an empty [`Subscription`] that will not produce any output.
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     pub fn none() -> Self {
         Self {
             recipes: Vec::new(),
@@ -39,9 +36,6 @@ where
     }
 
     /// Creates a [`Subscription`] from a [`Recipe`] describing it.
-    ///
-    /// [`Subscription`]: struct.Subscription.html
-    /// [`Recipe`]: trait.Recipe.html
     pub fn from_recipe(
         recipe: impl Recipe<H, E, Output = O> + 'static,
     ) -> Self {
@@ -52,8 +46,6 @@ where
 
     /// Batches all the provided subscriptions and returns the resulting
     /// [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     pub fn batch(
         subscriptions: impl IntoIterator<Item = Subscription<H, E, O>>,
     ) -> Self {
@@ -66,8 +58,6 @@ where
     }
 
     /// Returns the different recipes of the [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     pub fn recipes(self) -> Vec<Box<dyn Recipe<H, E, Output = O>>> {
         self.recipes
     }
@@ -75,8 +65,6 @@ where
     /// Adds a value to the [`Subscription`] context.
     ///
     /// The value will be part of the identity of a [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     pub fn with<T>(mut self, value: T) -> Subscription<H, E, (T, O)>
     where
         H: 'static,
@@ -97,8 +85,6 @@ where
     }
 
     /// Transforms the [`Subscription`] output with the given function.
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     pub fn map<A>(mut self, f: fn(O) -> A) -> Subscription<H, E, A>
     where
         H: 'static,
@@ -131,9 +117,6 @@ impl<I, O, H> std::fmt::Debug for Subscription<I, O, H> {
 /// by runtimes to run and identify subscriptions. You can use it to create your
 /// own!
 ///
-/// [`Subscription`]: struct.Subscription.html
-/// [`Recipe`]: trait.Recipe.html
-///
 /// # Examples
 /// The repository has a couple of [examples] that use a custom [`Recipe`]:
 ///
@@ -148,17 +131,11 @@ impl<I, O, H> std::fmt::Debug for Subscription<I, O, H> {
 pub trait Recipe<Hasher: std::hash::Hasher, Event> {
     /// The events that will be produced by a [`Subscription`] with this
     /// [`Recipe`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
-    /// [`Recipe`]: trait.Recipe.html
     type Output;
 
     /// Hashes the [`Recipe`].
     ///
     /// This is used by runtimes to uniquely identify a [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
-    /// [`Recipe`]: trait.Recipe.html
     fn hash(&self, state: &mut Hasher);
 
     /// Executes the [`Recipe`] and produces the stream of events of its
@@ -166,9 +143,6 @@ pub trait Recipe<Hasher: std::hash::Hasher, Event> {
     ///
     /// It receives some stream of generic events, which is normally defined by
     /// shells.
-    ///
-    /// [`Subscription`]: struct.Subscription.html
-    /// [`Recipe`]: trait.Recipe.html
     fn stream(
         self: Box<Self>,
         input: BoxStream<Event>,

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -26,8 +26,6 @@ where
     Event: 'static + Send + Clone,
 {
     /// Creates a new empty [`Tracker`].
-    ///
-    /// [`Tracker`]: struct.Tracker.html
     pub fn new() -> Self {
         Self {
             subscriptions: HashMap::new(),
@@ -52,9 +50,7 @@ where
     /// It returns a list of futures that need to be spawned to materialize
     /// the [`Tracker`] changes.
     ///
-    /// [`Tracker`]: struct.Tracker.html
-    /// [`Subscription`]: struct.Subscription.html
-    /// [`Recipe`]: trait.Recipe.html
+    /// [`Recipe`]: crate::subscription::Recipe
     pub fn update<Message, Receiver>(
         &mut self,
         subscription: Subscription<Hasher, Event, Message>,
@@ -132,7 +128,7 @@ where
     /// This method publishes the given event to all the subscription streams
     /// currently open.
     ///
-    /// [`Recipe::stream`]: trait.Recipe.html#tymethod.stream
+    /// [`Recipe::stream`]: crate::subscription::Recipe::stream
     pub fn broadcast(&mut self, event: Event) {
         self.subscriptions
             .values_mut()

--- a/futures/src/time.rs
+++ b/futures/src/time.rs
@@ -5,8 +5,6 @@ use crate::subscription::{self, Subscription};
 ///
 /// The first message is produced after a `duration`, and then continues to
 /// produce more messages every `duration` after that.
-///
-/// [`Subscription`]: ../subscription/struct.Subscription.html
 pub fn every<H: std::hash::Hasher, E>(
     duration: std::time::Duration,
 ) -> Subscription<H, E, std::time::Instant> {

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -23,8 +23,6 @@ pub struct Backend {
 
 impl Backend {
     /// Creates a new [`Backend`].
-    ///
-    /// [`Backend`]: struct.Backend.html
     pub fn new(gl: &glow::Context, settings: Settings) -> Self {
         let text_pipeline = text::Pipeline::new(gl, settings.default_font);
         let quad_pipeline = quad::Pipeline::new(gl);

--- a/glow/src/settings.rs
+++ b/glow/src/settings.rs
@@ -1,9 +1,9 @@
 //! Configure a renderer.
 pub use iced_graphics::Antialiasing;
 
-/// The settings of a [`Renderer`].
+/// The settings of a [`Backend`].
 ///
-/// [`Renderer`]: ../struct.Renderer.html
+/// [`Backend`]: crate::Backend
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings {
     /// The bytes of the font that will be used by default.

--- a/glow/src/widget/button.rs
+++ b/glow/src/widget/button.rs
@@ -1,9 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-//!
-//! [`Button`]: type.Button.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::button::{Style, StyleSheet};

--- a/glow/src/widget/canvas.rs
+++ b/glow/src/widget/canvas.rs
@@ -3,7 +3,4 @@
 //! A [`Canvas`] widget can be used to draw different kinds of 2D shapes in a
 //! [`Frame`]. It can be used for animation, data visualization, game graphics,
 //! and more!
-//!
-//! [`Canvas`]: struct.Canvas.html
-//! [`Frame`]: struct.Frame.html
 pub use iced_graphics::canvas::*;

--- a/glow/src/widget/pane_grid.rs
+++ b/glow/src/widget/pane_grid.rs
@@ -7,7 +7,6 @@
 //! drag and drop, and hotkey support.
 //!
 //! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
-//! [`PaneGrid`]: type.PaneGrid.html
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
@@ -24,13 +23,9 @@ pub use iced_native::pane_grid::{
 pub type PaneGrid<'a, Message> = iced_native::PaneGrid<'a, Message, Renderer>;
 
 /// The content of a [`Pane`].
-///
-/// [`Pane`]: struct.Pane.html
 pub type Content<'a, Message> =
     iced_native::pane_grid::Content<'a, Message, Renderer>;
 
 /// The title bar of a [`Pane`].
-///
-/// [`Pane`]: struct.Pane.html
 pub type TitleBar<'a, Message> =
     iced_native::pane_grid::TitleBar<'a, Message, Renderer>;

--- a/glow/src/widget/progress_bar.rs
+++ b/glow/src/widget/progress_bar.rs
@@ -2,8 +2,6 @@
 //!
 //! A [`ProgressBar`] has a range of possible values and a current value,
 //! as well as a length, height and style.
-//!
-//! [`ProgressBar`]: type.ProgressBar.html
 use crate::Renderer;
 
 pub use iced_graphics::progress_bar::{Style, StyleSheet};

--- a/glow/src/widget/slider.rs
+++ b/glow/src/widget/slider.rs
@@ -1,9 +1,6 @@
 //! Display an interactive selector of a single value from a range of values.
 //!
 //! A [`Slider`] has some local [`State`].
-//!
-//! [`Slider`]: struct.Slider.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::slider::{Handle, HandleShape, Style, StyleSheet};

--- a/glow/src/widget/text_input.rs
+++ b/glow/src/widget/text_input.rs
@@ -1,9 +1,6 @@
 //! Display fields that can be filled with text.
 //!
 //! A [`TextInput`] has some local [`State`].
-//!
-//! [`TextInput`]: struct.TextInput.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::text_input::{Style, StyleSheet};

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -15,8 +15,6 @@ use std::mem::ManuallyDrop;
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
 /// settings.
-///
-/// [`Application`]: trait.Application.html
 pub fn run<A, E, C>(
     settings: Settings<A::Flags>,
     compositor_settings: C::Settings,

--- a/graphics/src/antialiasing.rs
+++ b/graphics/src/antialiasing.rs
@@ -13,8 +13,6 @@ pub enum Antialiasing {
 
 impl Antialiasing {
     /// Returns the amount of samples of the [`Antialiasing`].
-    ///
-    /// [`Antialiasing`]: enum.Antialiasing.html
     pub fn sample_count(self) -> u32 {
         match self {
             Antialiasing::MSAAx2 => 2,

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -22,12 +22,12 @@ pub trait Text {
 
     /// The `char` representing a ✔ icon in the [`ICON_FONT`].
     ///
-    /// [`ICON_FONT`]: #associatedconst.ICON_FONT
+    /// [`ICON_FONT`]: Self::ICON_FONT
     const CHECKMARK_ICON: char;
 
-    /// The `char` representing a ▼ icon in the built-in [`ICONS`] font.
+    /// The `char` representing a ▼ icon in the built-in [`ICON_FONT`].
     ///
-    /// [`ICON_FONT`]: #associatedconst.ICON_FONT
+    /// [`ICON_FONT`]: Self::ICON_FONT
     const ARROW_DOWN_ICON: char;
 
     /// Returns the default size of text.

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -5,7 +5,7 @@ use iced_native::{Font, Size};
 
 /// The graphics backend of a [`Renderer`].
 ///
-/// [`Renderer`]: ../struct.Renderer.html
+/// [`Renderer`]: crate::Renderer
 pub trait Backend {
     /// Trims the measurements cache.
     ///

--- a/graphics/src/font.rs
+++ b/graphics/src/font.rs
@@ -26,14 +26,10 @@ pub const ICONS: iced_native::Font = iced_native::Font::External {
 };
 
 /// The `char` representing a ✔ icon in the built-in [`ICONS`] font.
-///
-/// [`ICONS`]: const.ICONS.html
 #[cfg(feature = "font-icons")]
 #[cfg_attr(docsrs, doc(cfg(feature = "font-icons")))]
 pub const CHECKMARK_ICON: char = '\u{F00C}';
 
 /// The `char` representing a ▼ icon in the built-in [`ICONS`] font.
-///
-/// [`ICONS`]: const.ICONS.html
 #[cfg(feature = "font-icons")]
 pub const ARROW_DOWN_ICON: char = '\u{E800}';

--- a/graphics/src/font/source.rs
+++ b/graphics/src/font/source.rs
@@ -8,8 +8,6 @@ pub struct Source {
 
 impl Source {
     /// Creates a new [`Source`].
-    ///
-    /// [`Source`]: struct.Source.html
     pub fn new() -> Self {
         Source {
             raw: font_kit::source::SystemSource::new(),
@@ -17,8 +15,6 @@ impl Source {
     }
 
     /// Finds and loads a font matching the set of provided family priorities.
-    ///
-    /// [`Source`]: struct.Source.html
     pub fn load(&self, families: &[Family]) -> Result<Vec<u8>, LoadError> {
         let font = self.raw.select_best_match(
             families,

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -11,35 +11,23 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Layer<'a> {
     /// The clipping bounds of the [`Layer`].
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub bounds: Rectangle,
 
     /// The quads of the [`Layer`].
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub quads: Vec<Quad>,
 
     /// The triangle meshes of the [`Layer`].
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub meshes: Vec<Mesh<'a>>,
 
     /// The text of the [`Layer`].
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub text: Vec<Text<'a>>,
 
     /// The images of the [`Layer`].
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub images: Vec<Image>,
 }
 
 impl<'a> Layer<'a> {
     /// Creates a new [`Layer`] with the given clipping bounds.
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub fn new(bounds: Rectangle) -> Self {
         Self {
             bounds,
@@ -53,8 +41,6 @@ impl<'a> Layer<'a> {
     /// Creates a new [`Layer`] for the provided overlay text.
     ///
     /// This can be useful for displaying debug information.
-    ///
-    /// [`Layer`]: struct.Layer.html
     pub fn overlay(lines: &'a [impl AsRef<str>], viewport: &Viewport) -> Self {
         let mut overlay =
             Layer::new(Rectangle::with_size(viewport.logical_size()));
@@ -87,8 +73,6 @@ impl<'a> Layer<'a> {
 
     /// Distributes the given [`Primitive`] and generates a list of layers based
     /// on its contents.
-    ///
-    /// [`Primitive`]: ../enum.Primitive.html
     pub fn generate(
         primitive: &'a Primitive,
         viewport: &Viewport,
@@ -243,33 +227,21 @@ impl<'a> Layer<'a> {
 #[repr(C)]
 pub struct Quad {
     /// The position of the [`Quad`].
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub position: [f32; 2],
 
     /// The size of the [`Quad`].
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub size: [f32; 2],
 
     /// The color of the [`Quad`], in __linear RGB__.
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub color: [f32; 4],
 
     /// The border color of the [`Quad`], in __linear RGB__.
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub border_color: [f32; 4],
 
     /// The border radius of the [`Quad`].
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub border_radius: f32,
 
     /// The border width of the [`Quad`].
-    ///
-    /// [`Quad`]: struct.Quad.html
     pub border_width: f32,
 }
 
@@ -277,18 +249,12 @@ pub struct Quad {
 #[derive(Debug, Clone, Copy)]
 pub struct Mesh<'a> {
     /// The origin of the vertices of the [`Mesh`].
-    ///
-    /// [`Mesh`]: struct.Mesh.html
     pub origin: Point,
 
     /// The vertex and index buffers of the [`Mesh`].
-    ///
-    /// [`Mesh`]: struct.Mesh.html
     pub buffers: &'a triangle::Mesh2D,
 
     /// The clipping bounds of the [`Mesh`].
-    ///
-    /// [`Mesh`]: struct.Mesh.html
     pub clip_bounds: Rectangle<f32>,
 }
 
@@ -296,38 +262,24 @@ pub struct Mesh<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct Text<'a> {
     /// The content of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub content: &'a str,
 
     /// The layout bounds of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub bounds: Rectangle,
 
     /// The color of the [`Text`], in __linear RGB_.
-    ///
-    /// [`Text`]: struct.Text.html
     pub color: [f32; 4],
 
     /// The size of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub size: f32,
 
     /// The font of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub font: Font,
 
     /// The horizontal alignment of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub horizontal_alignment: HorizontalAlignment,
 
     /// The vertical alignment of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub vertical_alignment: VerticalAlignment,
 }
 

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -13,25 +13,16 @@ pub struct Renderer<B: Backend> {
 
 impl<B: Backend> Renderer<B> {
     /// Creates a new [`Renderer`] from the given [`Backend`].
-    ///
-    /// [`Renderer`]: struct.Renderer.html
-    /// [`Backend`]: backend/trait.Backend.html
     pub fn new(backend: B) -> Self {
         Self { backend }
     }
 
     /// Returns a reference to the [`Backend`] of the [`Renderer`].
-    ///
-    /// [`Renderer`]: struct.Renderer.html
-    /// [`Backend`]: backend/trait.Backend.html
     pub fn backend(&self) -> &B {
         &self.backend
     }
 
     /// Returns a mutable reference to the [`Backend`] of the [`Renderer`].
-    ///
-    /// [`Renderer`]: struct.Renderer.html
-    /// [`Backend`]: backend/trait.Backend.html
     pub fn backend_mut(&mut self) -> &mut B {
         &mut self.backend
     }

--- a/graphics/src/triangle.rs
+++ b/graphics/src/triangle.rs
@@ -2,8 +2,6 @@
 use bytemuck::{Pod, Zeroable};
 
 /// A set of [`Vertex2D`] and indices representing a list of triangles.
-///
-/// [`Vertex2D`]: struct.Vertex2D.html
 #[derive(Clone, Debug)]
 pub struct Mesh2D {
     /// The vertices of the mesh

--- a/graphics/src/viewport.rs
+++ b/graphics/src/viewport.rs
@@ -12,8 +12,6 @@ pub struct Viewport {
 impl Viewport {
     /// Creates a new [`Viewport`] with the given physical dimensions and scale
     /// factor.
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn with_physical_size(size: Size<u32>, scale_factor: f64) -> Viewport {
         Viewport {
             physical_size: size,
@@ -27,43 +25,31 @@ impl Viewport {
     }
 
     /// Returns the physical size of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn physical_size(&self) -> Size<u32> {
         self.physical_size
     }
 
     /// Returns the physical width of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn physical_width(&self) -> u32 {
         self.physical_size.height
     }
 
     /// Returns the physical height of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn physical_height(&self) -> u32 {
         self.physical_size.height
     }
 
     /// Returns the logical size of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn logical_size(&self) -> Size<f32> {
         self.logical_size
     }
 
     /// Returns the scale factor of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn scale_factor(&self) -> f64 {
         self.scale_factor
     }
 
     /// Returns the projection transformation of the [`Viewport`].
-    ///
-    /// [`Viewport`]: struct.Viewport.html
     pub fn projection(&self) -> Transformation {
         self.projection
     }

--- a/graphics/src/widget/button.rs
+++ b/graphics/src/widget/button.rs
@@ -1,9 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-//!
-//! [`Button`]: type.Button.html
-//! [`State`]: struct.State.html
 use crate::defaults::{self, Defaults};
 use crate::{Backend, Primitive, Renderer};
 use iced_native::mouse;

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -3,9 +3,6 @@
 //! A [`Canvas`] widget can be used to draw different kinds of 2D shapes in a
 //! [`Frame`]. It can be used for animation, data visualization, game graphics,
 //! and more!
-//!
-//! [`Canvas`]: struct.Canvas.html
-//! [`Frame`]: struct.Frame.html
 use crate::{Backend, Defaults, Primitive, Renderer};
 use iced_native::layout;
 use iced_native::mouse;
@@ -40,8 +37,6 @@ pub use stroke::{LineCap, LineJoin, Stroke};
 pub use text::Text;
 
 /// A widget capable of drawing 2D graphics.
-///
-/// [`Canvas`]: struct.Canvas.html
 ///
 /// # Examples
 /// The repository has a couple of [examples] showcasing how to use a
@@ -108,8 +103,6 @@ impl<Message, P: Program<Message>> Canvas<Message, P> {
     const DEFAULT_SIZE: u16 = 100;
 
     /// Creates a new [`Canvas`].
-    ///
-    /// [`Canvas`]: struct.Canvas.html
     pub fn new(program: P) -> Self {
         Canvas {
             width: Length::Units(Self::DEFAULT_SIZE),
@@ -120,16 +113,12 @@ impl<Message, P: Program<Message>> Canvas<Message, P> {
     }
 
     /// Sets the width of the [`Canvas`].
-    ///
-    /// [`Canvas`]: struct.Canvas.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Canvas`].
-    ///
-    /// [`Canvas`]: struct.Canvas.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self

--- a/graphics/src/widget/canvas/cache.rs
+++ b/graphics/src/widget/canvas/cache.rs
@@ -23,10 +23,6 @@ impl Default for State {
 ///
 /// A [`Cache`] will not redraw its geometry unless the dimensions of its layer
 /// change or it is explicitly cleared.
-///
-/// [`Layer`]: ../trait.Layer.html
-/// [`Cache`]: struct.Cache.html
-/// [`Geometry`]: struct.Geometry.html
 #[derive(Debug, Default)]
 pub struct Cache {
     state: RefCell<State>,
@@ -34,8 +30,6 @@ pub struct Cache {
 
 impl Cache {
     /// Creates a new empty [`Cache`].
-    ///
-    /// [`Cache`]: struct.Cache.html
     pub fn new() -> Self {
         Cache {
             state: Default::default(),
@@ -43,8 +37,6 @@ impl Cache {
     }
 
     /// Clears the [`Cache`], forcing a redraw the next time it is used.
-    ///
-    /// [`Cache`]: struct.Cache.html
     pub fn clear(&mut self) {
         *self.state.borrow_mut() = State::Empty;
     }
@@ -59,8 +51,6 @@ impl Cache {
     /// Otherwise, the previously stored [`Geometry`] will be returned. The
     /// [`Cache`] is not cleared in this case. In other words, it will keep
     /// returning the stored [`Geometry`] if needed.
-    ///
-    /// [`Cache`]: struct.Cache.html
     pub fn draw(&self, bounds: Size, draw_fn: impl Fn(&mut Frame)) -> Geometry {
         use std::ops::Deref;
 

--- a/graphics/src/widget/canvas/cursor.rs
+++ b/graphics/src/widget/canvas/cursor.rs
@@ -22,8 +22,6 @@ impl Cursor {
     }
 
     /// Returns the absolute position of the [`Cursor`], if available.
-    ///
-    /// [`Cursor`]: enum.Cursor.html
     pub fn position(&self) -> Option<Point> {
         match self {
             Cursor::Available(position) => Some(*position),
@@ -36,8 +34,6 @@ impl Cursor {
     ///
     /// If the [`Cursor`] is not over the provided bounds, this method will
     /// return `None`.
-    ///
-    /// [`Cursor`]: enum.Cursor.html
     pub fn position_in(&self, bounds: &Rectangle) -> Option<Point> {
         if self.is_over(bounds) {
             self.position_from(bounds.position())
@@ -48,8 +44,6 @@ impl Cursor {
 
     /// Returns the relative position of the [`Cursor`] from the given origin,
     /// if available.
-    ///
-    /// [`Cursor`]: enum.Cursor.html
     pub fn position_from(&self, origin: Point) -> Option<Point> {
         match self {
             Cursor::Available(position) => {
@@ -61,8 +55,6 @@ impl Cursor {
 
     /// Returns whether the [`Cursor`] is currently over the provided bounds
     /// or not.
-    ///
-    /// [`Cursor`]: enum.Cursor.html
     pub fn is_over(&self, bounds: &Rectangle) -> bool {
         match self {
             Cursor::Available(position) => bounds.contains(*position),

--- a/graphics/src/widget/canvas/event.rs
+++ b/graphics/src/widget/canvas/event.rs
@@ -6,7 +6,7 @@ pub use iced_native::event::Status;
 
 /// A [`Canvas`] event.
 ///
-/// [`Canvas`]: struct.Event.html
+/// [`Canvas`]: crate::widget::Canvas
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {
     /// A mouse event.

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// The frame of a [`Canvas`].
 ///
-/// [`Canvas`]: struct.Canvas.html
+/// [`Canvas`]: crate::widget::Canvas
 #[derive(Debug)]
 pub struct Frame {
     size: Size,
@@ -33,8 +33,6 @@ impl Frame {
     ///
     /// The default coordinate system of a [`Frame`] has its origin at the
     /// top-left corner of its bounds.
-    ///
-    /// [`Frame`]: struct.Frame.html
     pub fn new(size: Size) -> Frame {
         Frame {
             size,
@@ -51,32 +49,24 @@ impl Frame {
     }
 
     /// Returns the width of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn width(&self) -> f32 {
         self.size.width
     }
 
     /// Returns the width of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn height(&self) -> f32 {
         self.size.height
     }
 
     /// Returns the dimensions of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn size(&self) -> Size {
         self.size
     }
 
     /// Returns the coordinate of the center of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn center(&self) -> Point {
         Point::new(self.size.width / 2.0, self.size.height / 2.0)
@@ -84,9 +74,6 @@ impl Frame {
 
     /// Draws the given [`Path`] on the [`Frame`] by filling it with the
     /// provided style.
-    ///
-    /// [`Path`]: path/struct.Path.html
-    /// [`Frame`]: struct.Frame.html
     pub fn fill(&mut self, path: &Path, fill: impl Into<Fill>) {
         use lyon::tessellation::{
             BuffersBuilder, FillOptions, FillTessellator,
@@ -115,8 +102,6 @@ impl Frame {
 
     /// Draws an axis-aligned rectangle given its top-left corner coordinate and
     /// its `Size` on the [`Frame`] by filling it with the provided style.
-    ///
-    /// [`Frame`]: struct.Frame.html
     pub fn fill_rectangle(
         &mut self,
         top_left: Point,
@@ -152,9 +137,6 @@ impl Frame {
 
     /// Draws the stroke of the given [`Path`] on the [`Frame`] with the
     /// provided style.
-    ///
-    /// [`Path`]: path/struct.Path.html
-    /// [`Frame`]: struct.Frame.html
     pub fn stroke(&mut self, path: &Path, stroke: impl Into<Stroke>) {
         use lyon::tessellation::{
             BuffersBuilder, StrokeOptions, StrokeTessellator,
@@ -200,9 +182,7 @@ impl Frame {
     /// Support for vectorial text is planned, and should address all these
     /// limitations.
     ///
-    /// [`Text`]: struct.Text.html
-    /// [`Frame`]: struct.Frame.html
-    /// [`Canvas`]: struct.Canvas.html
+    /// [`Canvas`]: crate::widget::Canvas
     pub fn fill_text(&mut self, text: impl Into<Text>) {
         use std::f32;
 
@@ -240,8 +220,6 @@ impl Frame {
     ///
     /// This method is useful to compose transforms and perform drawing
     /// operations in different coordinate systems.
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn with_save(&mut self, f: impl FnOnce(&mut Frame)) {
         self.transforms.previous.push(self.transforms.current);
@@ -252,8 +230,6 @@ impl Frame {
     }
 
     /// Applies a translation to the current transform of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn translate(&mut self, translation: Vector) {
         self.transforms.current.raw = self
@@ -268,8 +244,6 @@ impl Frame {
     }
 
     /// Applies a rotation to the current transform of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn rotate(&mut self, angle: f32) {
         self.transforms.current.raw = self
@@ -281,8 +255,6 @@ impl Frame {
     }
 
     /// Applies a scaling to the current transform of the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
     #[inline]
     pub fn scale(&mut self, scale: f32) {
         self.transforms.current.raw =
@@ -291,9 +263,6 @@ impl Frame {
     }
 
     /// Produces the [`Geometry`] representing everything drawn on the [`Frame`].
-    ///
-    /// [`Frame`]: struct.Frame.html
-    /// [`Geometry`]: struct.Geometry.html
     pub fn into_geometry(mut self) -> Geometry {
         if !self.buffers.indices.is_empty() {
             self.primitives.push(Primitive::Mesh2D {

--- a/graphics/src/widget/canvas/geometry.rs
+++ b/graphics/src/widget/canvas/geometry.rs
@@ -5,9 +5,8 @@ use crate::Primitive;
 /// [`Geometry`] can be easily generated with a [`Frame`] or stored in a
 /// [`Cache`].
 ///
-/// [`Geometry`]: struct.Geometry.html
-/// [`Frame`]: struct.Frame.html
-/// [`Cache`]: struct.Cache.html
+/// [`Frame`]: crate::widget::canvas::Frame
+/// [`Cache`]: crate::widget::canvas::Cache
 #[derive(Debug, Clone)]
 pub struct Geometry(Primitive);
 
@@ -19,9 +18,6 @@ impl Geometry {
     /// Turns the [`Geometry`] into a [`Primitive`].
     ///
     /// This can be useful if you are building a custom widget.
-    ///
-    /// [`Geometry`]: struct.Geometry.html
-    /// [`Primitive`]: ../enum.Primitive.html
     pub fn into_primitive(self) -> Primitive {
         self.0
     }

--- a/graphics/src/widget/canvas/path.rs
+++ b/graphics/src/widget/canvas/path.rs
@@ -12,8 +12,6 @@ use iced_native::{Point, Size};
 /// An immutable set of points that may or may not be connected.
 ///
 /// A single [`Path`] can represent different kinds of 2D shapes!
-///
-/// [`Path`]: struct.Path.html
 #[derive(Debug, Clone)]
 pub struct Path {
     raw: lyon::path::Path,
@@ -23,9 +21,6 @@ impl Path {
     /// Creates a new [`Path`] with the provided closure.
     ///
     /// Use the [`Builder`] to configure your [`Path`].
-    ///
-    /// [`Path`]: struct.Path.html
-    /// [`Builder`]: struct.Builder.html
     pub fn new(f: impl FnOnce(&mut Builder)) -> Self {
         let mut builder = Builder::new();
 
@@ -37,8 +32,6 @@ impl Path {
 
     /// Creates a new [`Path`] representing a line segment given its starting
     /// and end points.
-    ///
-    /// [`Path`]: struct.Path.html
     pub fn line(from: Point, to: Point) -> Self {
         Self::new(|p| {
             p.move_to(from);
@@ -48,16 +41,12 @@ impl Path {
 
     /// Creates a new [`Path`] representing a rectangle given its top-left
     /// corner coordinate and its `Size`.
-    ///
-    /// [`Path`]: struct.Path.html
     pub fn rectangle(top_left: Point, size: Size) -> Self {
         Self::new(|p| p.rectangle(top_left, size))
     }
 
     /// Creates a new [`Path`] representing a circle given its center
     /// coordinate and its radius.
-    ///
-    /// [`Path`]: struct.Path.html
     pub fn circle(center: Point, radius: f32) -> Self {
         Self::new(|p| p.circle(center, radius))
     }

--- a/graphics/src/widget/canvas/path/arc.rs
+++ b/graphics/src/widget/canvas/path/arc.rs
@@ -15,8 +15,6 @@ pub struct Arc {
 }
 
 /// An elliptical [`Arc`].
-///
-/// [`Arc`]: struct.Arc.html
 #[derive(Debug, Clone, Copy)]
 pub struct Elliptical {
     /// The center of the arc.

--- a/graphics/src/widget/canvas/path/builder.rs
+++ b/graphics/src/widget/canvas/path/builder.rs
@@ -6,8 +6,6 @@ use lyon::path::builder::{Build, FlatPathBuilder, PathBuilder, SvgBuilder};
 /// A [`Path`] builder.
 ///
 /// Once a [`Path`] is built, it can no longer be mutated.
-///
-/// [`Path`]: struct.Path.html
 #[allow(missing_debug_implementations)]
 pub struct Builder {
     raw: lyon::path::builder::SvgPathBuilder<lyon::path::Builder>,
@@ -15,8 +13,6 @@ pub struct Builder {
 
 impl Builder {
     /// Creates a new [`Builder`].
-    ///
-    /// [`Builder`]: struct.Builder.html
     pub fn new() -> Builder {
         Builder {
             raw: lyon::path::Path::builder().with_svg(),
@@ -31,8 +27,6 @@ impl Builder {
 
     /// Connects the last point in the [`Path`] to the given `Point` with a
     /// straight line.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn line_to(&mut self, point: Point) {
         let _ = self.raw.line_to(lyon::math::Point::new(point.x, point.y));
@@ -40,9 +34,6 @@ impl Builder {
 
     /// Adds an [`Arc`] to the [`Path`] from `start_angle` to `end_angle` in
     /// a clockwise direction.
-    ///
-    /// [`Arc`]: struct.Arc.html
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn arc(&mut self, arc: Arc) {
         self.ellipse(arc.into());
@@ -53,8 +44,6 @@ impl Builder {
     ///
     /// The arc is connected to the previous point by a straight line, if
     /// necessary.
-    ///
-    /// [`Path`]: struct.Path.html
     pub fn arc_to(&mut self, a: Point, b: Point, radius: f32) {
         use lyon::{math, path};
 
@@ -72,10 +61,7 @@ impl Builder {
         );
     }
 
-    /// Adds an [`Ellipse`] to the [`Path`] using a clockwise direction.
-    ///
-    /// [`Ellipse`]: struct.Arc.html
-    /// [`Path`]: struct.Path.html
+    /// Adds an ellipse to the [`Path`] using a clockwise direction.
     pub fn ellipse(&mut self, arc: arc::Elliptical) {
         use lyon::{geom, math};
 
@@ -96,8 +82,6 @@ impl Builder {
 
     /// Adds a cubic Bézier curve to the [`Path`] given its two control points
     /// and its end point.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn bezier_curve_to(
         &mut self,
@@ -116,8 +100,6 @@ impl Builder {
 
     /// Adds a quadratic Bézier curve to the [`Path`] given its control point
     /// and its end point.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn quadratic_curve_to(&mut self, control: Point, to: Point) {
         use lyon::math;
@@ -130,8 +112,6 @@ impl Builder {
 
     /// Adds a rectangle to the [`Path`] given its top-left corner coordinate
     /// and its `Size`.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn rectangle(&mut self, top_left: Point, size: Size) {
         self.move_to(top_left);
@@ -146,8 +126,6 @@ impl Builder {
 
     /// Adds a circle to the [`Path`] given its center coordinate and its
     /// radius.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn circle(&mut self, center: Point, radius: f32) {
         self.arc(Arc {
@@ -160,17 +138,12 @@ impl Builder {
 
     /// Closes the current sub-path in the [`Path`] with a straight line to
     /// the starting point.
-    ///
-    /// [`Path`]: struct.Path.html
     #[inline]
     pub fn close(&mut self) {
         self.raw.close()
     }
 
     /// Builds the [`Path`] of this [`Builder`].
-    ///
-    /// [`Path`]: struct.Path.html
-    /// [`Builder`]: struct.Builder.html
     #[inline]
     pub fn build(self) -> Path {
         Path {

--- a/graphics/src/widget/canvas/program.rs
+++ b/graphics/src/widget/canvas/program.rs
@@ -7,8 +7,7 @@ use iced_native::{mouse, Rectangle};
 /// A [`Program`] can mutate internal state and produce messages for an
 /// application.
 ///
-/// [`Canvas`]: struct.Canvas.html
-/// [`Program`]: trait.Program.html
+/// [`Canvas`]: crate::widget::Canvas
 pub trait Program<Message> {
     /// Updates the state of the [`Program`].
     ///
@@ -20,9 +19,7 @@ pub trait Program<Message> {
     ///
     /// By default, this method does and returns nothing.
     ///
-    /// [`Program`]: trait.Program.html
-    /// [`Canvas`]: struct.Canvas.html
-    /// [`Event`]: enum.Event.html
+    /// [`Canvas`]: crate::widget::Canvas
     fn update(
         &mut self,
         _event: Event,
@@ -37,10 +34,8 @@ pub trait Program<Message> {
     /// [`Geometry`] can be easily generated with a [`Frame`] or stored in a
     /// [`Cache`].
     ///
-    /// [`Program`]: trait.Program.html
-    /// [`Geometry`]: struct.Geometry.html
-    /// [`Frame`]: struct.Frame.html
-    /// [`Cache`]: struct.Cache.html
+    /// [`Frame`]: crate::widget::canvas::Cache
+    /// [`Cache`]: crate::widget::canvas::Cache
     fn draw(&self, bounds: Rectangle, cursor: Cursor) -> Vec<Geometry>;
 
     /// Returns the current mouse interaction of the [`Program`].
@@ -48,8 +43,7 @@ pub trait Program<Message> {
     /// The interaction returned will be in effect even if the cursor position
     /// is out of bounds of the program's [`Canvas`].
     ///
-    /// [`Program`]: trait.Program.html
-    /// [`Canvas`]: struct.Canvas.html
+    /// [`Canvas`]: crate::widget::Canvas
     fn mouse_interaction(
         &self,
         _bounds: Rectangle,

--- a/graphics/src/widget/canvas/stroke.rs
+++ b/graphics/src/widget/canvas/stroke.rs
@@ -16,31 +16,21 @@ pub struct Stroke {
 
 impl Stroke {
     /// Sets the color of the [`Stroke`].
-    ///
-    /// [`Stroke`]: struct.Stroke.html
     pub fn with_color(self, color: Color) -> Stroke {
         Stroke { color, ..self }
     }
 
     /// Sets the width of the [`Stroke`].
-    ///
-    /// [`Stroke`]: struct.Stroke.html
     pub fn with_width(self, width: f32) -> Stroke {
         Stroke { width, ..self }
     }
 
     /// Sets the [`LineCap`] of the [`Stroke`].
-    ///
-    /// [`LineCap`]: enum.LineCap.html
-    /// [`Stroke`]: struct.Stroke.html
     pub fn with_line_cap(self, line_cap: LineCap) -> Stroke {
         Stroke { line_cap, ..self }
     }
 
     /// Sets the [`LineJoin`] of the [`Stroke`].
-    ///
-    /// [`LineJoin`]: enum.LineJoin.html
-    /// [`Stroke`]: struct.Stroke.html
     pub fn with_line_join(self, line_join: LineJoin) -> Stroke {
         Stroke { line_join, ..self }
     }

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -7,7 +7,6 @@
 //! drag and drop, and hotkey support.
 //!
 //! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
-//! [`PaneGrid`]: type.PaneGrid.html
 use crate::backend::{self, Backend};
 use crate::defaults;
 use crate::{Primitive, Renderer};

--- a/graphics/src/widget/progress_bar.rs
+++ b/graphics/src/widget/progress_bar.rs
@@ -2,8 +2,6 @@
 //!
 //! A [`ProgressBar`] has a range of possible values and a current value,
 //! as well as a length, height and style.
-//!
-//! [`ProgressBar`]: type.ProgressBar.html
 use crate::{Backend, Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::progress_bar;

--- a/graphics/src/widget/slider.rs
+++ b/graphics/src/widget/slider.rs
@@ -1,9 +1,6 @@
 //! Display an interactive selector of a single value from a range of values.
 //!
 //! A [`Slider`] has some local [`State`].
-//!
-//! [`Slider`]: struct.Slider.html
-//! [`State`]: struct.State.html
 use crate::{Backend, Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::slider;

--- a/graphics/src/widget/text_input.rs
+++ b/graphics/src/widget/text_input.rs
@@ -1,9 +1,6 @@
 //! Display fields that can be filled with text.
 //!
 //! A [`TextInput`] has some local [`State`].
-//!
-//! [`TextInput`]: struct.TextInput.html
-//! [`State`]: struct.State.html
 use crate::backend::{self, Backend};
 use crate::{Primitive, Renderer};
 use iced_native::mouse;

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -16,14 +16,12 @@ pub trait Compositor: Sized {
     /// The swap chain of the backend.
     type SwapChain;
 
-    /// Creates a new [`Backend`].
-    ///
-    /// [`Backend`]: trait.Backend.html
+    /// Creates a new [`Compositor`].
     fn new(settings: Self::Settings) -> Result<(Self, Self::Renderer), Error>;
 
     /// Crates a new [`Surface`] for the given window.
     ///
-    /// [`Surface`]: #associatedtype.Surface
+    /// [`Surface`]: Self::Surface
     fn create_surface<W: HasRawWindowHandle>(
         &mut self,
         window: &W,
@@ -31,8 +29,8 @@ pub trait Compositor: Sized {
 
     /// Crates a new [`SwapChain`] for the given [`Surface`].
     ///
-    /// [`SwapChain`]: #associatedtype.SwapChain
-    /// [`Surface`]: #associatedtype.Surface
+    /// [`SwapChain`]: Self::SwapChain
+    /// [`Surface`]: Self::Surface
     fn create_swap_chain(
         &mut self,
         surface: &Self::Surface,
@@ -42,8 +40,7 @@ pub trait Compositor: Sized {
 
     /// Draws the output primitives to the next frame of the given [`SwapChain`].
     ///
-    /// [`SwapChain`]: #associatedtype.SwapChain
-    /// [`Surface`]: #associatedtype.Surface
+    /// [`SwapChain`]: Self::SwapChain
     fn draw<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,

--- a/graphics/src/window/gl_compositor.rs
+++ b/graphics/src/window/gl_compositor.rs
@@ -15,28 +15,27 @@ use core::ffi::c_void;
 /// If you implement an OpenGL renderer, you can implement this trait to ease
 /// integration with existing windowing shells, like `iced_glutin`.
 pub trait GLCompositor: Sized {
-    /// The renderer of the [`Compositor`].
+    /// The renderer of the [`GLCompositor`].
     ///
     /// This should point to your renderer type, which could be a type alias
     /// of the [`Renderer`] provided in this crate with with a specific
     /// [`Backend`].
     ///
-    /// [`Compositor`]: trait.Compositor.html
-    /// [`Renderer`]: ../struct.Renderer.html
-    /// [`Backend`]: ../backend/trait.Backend.html
+    /// [`Renderer`]: crate::Renderer
+    /// [`Backend`]: crate::Backend
     type Renderer: iced_native::Renderer;
 
-    /// The settings of the [`Compositor`].
+    /// The settings of the [`GLCompositor`].
     ///
     /// It's up to you to decide the configuration supported by your renderer!
     type Settings: Default;
 
-    /// Creates a new [`Compositor`] and [`Renderer`] with the given
+    /// Creates a new [`GLCompositor`] and [`Renderer`] with the given
     /// [`Settings`] and an OpenGL address loader function.
     ///
-    /// [`Compositor`]: trait.Compositor.html
-    /// [`Renderer`]: #associatedtype.Renderer
-    /// [`Backend`]: ../backend/trait.Backend.html
+    /// [`Renderer`]: crate::Renderer
+    /// [`Backend`]: crate::Backend
+    /// [`Settings`]: Self::Settings
     #[allow(unsafe_code)]
     unsafe fn new(
         settings: Self::Settings,
@@ -44,19 +43,15 @@ pub trait GLCompositor: Sized {
     ) -> Result<(Self, Self::Renderer), Error>;
 
     /// Returns the amount of samples that should be used when configuring
-    /// an OpenGL context for this [`Compositor`].
-    ///
-    /// [`Compositor`]: trait.Compositor.html
+    /// an OpenGL context for this [`GLCompositor`].
     fn sample_count(settings: &Self::Settings) -> u32;
 
-    /// Resizes the viewport of the [`Compositor`].
-    ///
-    /// [`Compositor`]: trait.Compositor.html
+    /// Resizes the viewport of the [`GLCompositor`].
     fn resize_viewport(&mut self, physical_size: Size<u32>);
 
     /// Draws the provided output with the given [`Renderer`].
     ///
-    /// [`Compositor`]: trait.Compositor.html
+    /// [`Renderer`]: crate::Renderer
     fn draw<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -2,7 +2,5 @@
 /// applications.
 pub trait Clipboard {
     /// Returns the current content of the [`Clipboard`] as text.
-    ///
-    /// [`Clipboard`]: trait.Clipboard.html
     fn content(&self) -> Option<String>;
 }

--- a/native/src/debug/basic.rs
+++ b/native/src/debug/basic.rs
@@ -32,9 +32,7 @@ pub struct Debug {
 }
 
 impl Debug {
-    /// Creates a new [`Debug`].
-    ///
-    /// [`Debug`]: struct.Debug.html
+    /// Creates a new [`struct@Debug`].
     pub fn new() -> Self {
         let now = time::Instant::now();
 

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -14,8 +14,6 @@ use crate::{
 /// to turn it into an [`Element`].
 ///
 /// [built-in widget]: widget/index.html#built-in-widgets
-/// [`Widget`]: widget/trait.Widget.html
-/// [`Element`]: struct.Element.html
 #[allow(missing_debug_implementations)]
 pub struct Element<'a, Message, Renderer> {
     pub(crate) widget: Box<dyn Widget<Message, Renderer> + 'a>,
@@ -26,9 +24,6 @@ where
     Renderer: crate::Renderer,
 {
     /// Creates a new [`Element`] containing the given [`Widget`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Widget`]: widget/trait.Widget.html
     pub fn new(
         widget: impl Widget<Message, Renderer> + 'a,
     ) -> Element<'a, Message, Renderer> {
@@ -41,8 +36,6 @@ where
     ///
     /// This method is useful when you want to decouple different parts of your
     /// UI and make them __composable__.
-    ///
-    /// [`Element`]: struct.Element.html
     ///
     /// # Example
     /// Imagine we want to use [our counter](index.html#usage). But instead of
@@ -189,8 +182,7 @@ where
     /// The [`Renderer`] will explain the layout of the [`Element`] graphically.
     /// This can be very useful for debugging your layout!
     ///
-    /// [`Element`]: struct.Element.html
-    /// [`Renderer`]: trait.Renderer.html
+    /// [`Renderer`]: crate::Renderer
     pub fn explain<C: Into<Color>>(
         self,
         color: C,
@@ -205,23 +197,18 @@ where
     }
 
     /// Returns the width of the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn width(&self) -> Length {
         self.widget.width()
     }
 
     /// Returns the height of the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn height(&self) -> Length {
         self.widget.height()
     }
 
     /// Computes the layout of the [`Element`] in the given [`Limits`].
     ///
-    /// [`Element`]: struct.Element.html
-    /// [`Limits`]: layout/struct.Limits.html
+    /// [`Limits`]: layout::Limits
     pub fn layout(
         &self,
         renderer: &Renderer,
@@ -231,8 +218,6 @@ where
     }
 
     /// Processes a runtime [`Event`].
-    ///
-    /// [`Event`]: enum.Event.html
     pub fn on_event(
         &mut self,
         event: Event,
@@ -253,9 +238,6 @@ where
     }
 
     /// Draws the [`Element`] and its children using the given [`Layout`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Layout`]: layout/struct.Layout.html
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -269,15 +251,11 @@ where
     }
 
     /// Computes the _layout_ hash of the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn hash_layout(&self, state: &mut Hasher) {
         self.widget.hash_layout(state);
     }
 
     /// Returns the overlay of the [`Element`], if there is any.
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn overlay<'b>(
         &'b mut self,
         layout: Layout<'_>,

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -20,19 +20,12 @@ pub enum Event {
 }
 
 /// The status of an [`Event`] after being processed.
-///
-/// [`Event`]: enum.Event.html
-/// [`UserInterface`]: ../struct.UserInterface.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
     /// The [`Event`] was **NOT** handled by any widget.
-    ///
-    /// [`Event`]: enum.Event.html
     Ignored,
 
     /// The [`Event`] was handled and processed by a widget.
-    ///
-    /// [`Event`]: enum.Event.html
     Captured,
 }
 

--- a/native/src/layout.rs
+++ b/native/src/layout.rs
@@ -12,8 +12,6 @@ pub use node::Node;
 use crate::{Point, Rectangle, Vector};
 
 /// The bounds of a [`Node`] and its children, using absolute coordinates.
-///
-/// [`Node`]: struct.Node.html
 #[derive(Debug, Clone, Copy)]
 pub struct Layout<'a> {
     position: Point,
@@ -35,8 +33,6 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns the position of the [`Layout`].
-    ///
-    /// [`Layout`]: struct.Layout.html
     pub fn position(&self) -> Point {
         self.position
     }
@@ -45,10 +41,6 @@ impl<'a> Layout<'a> {
     ///
     /// The returned [`Rectangle`] describes the position and size of a
     /// [`Node`].
-    ///
-    /// [`Layout`]: struct.Layout.html
-    /// [`Rectangle`]: struct.Rectangle.html
-    /// [`Node`]: struct.Node.html
     pub fn bounds(&self) -> Rectangle {
         let bounds = self.node.bounds();
 
@@ -61,9 +53,6 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns an iterator over the [`Layout`] of the children of a [`Node`].
-    ///
-    /// [`Layout`]: struct.Layout.html
-    /// [`Node`]: struct.Node.html
     pub fn children(self) -> impl Iterator<Item = Layout<'a>> {
         self.node.children().iter().map(move |node| {
             Layout::with_offset(

--- a/native/src/layout/debugger.rs
+++ b/native/src/layout/debugger.rs
@@ -1,8 +1,6 @@
 use crate::{Color, Layout, Point, Rectangle, Renderer, Widget};
 
 /// A renderer able to graphically explain a [`Layout`].
-///
-/// [`Layout`]: struct.Layout.html
 pub trait Debugger: Renderer {
     /// Explains the [`Layout`] of an [`Element`] for debugging purposes.
     ///
@@ -12,9 +10,8 @@ pub trait Debugger: Renderer {
     /// A common approach consists in recursively rendering the bounds of the
     /// [`Layout`] and its children.
     ///
-    /// [`Layout`]: struct.Layout.html
-    /// [`Element`]: ../struct.Element.html
-    /// [`Element::explain`]: ../struct.Element.html#method.explain
+    /// [`Element`]: crate::Element
+    /// [`Element::explain`]: crate::Element::explain
     fn explain<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/layout/flex.rs
+++ b/native/src/layout/flex.rs
@@ -58,8 +58,6 @@ impl Axis {
 /// padding and alignment to the items as needed.
 ///
 /// It returns a new layout [`Node`].
-///
-/// [`Node`]: ../struct.Node.html
 pub fn resolve<Message, Renderer>(
     axis: Axis,
     renderer: &Renderer,

--- a/native/src/layout/limits.rs
+++ b/native/src/layout/limits.rs
@@ -17,9 +17,6 @@ impl Limits {
     };
 
     /// Creates new [`Limits`] with the given minimum and maximum [`Size`].
-    ///
-    /// [`Limits`]: struct.Limits.html
-    /// [`Size`]: ../struct.Size.html
     pub const fn new(min: Size, max: Size) -> Limits {
         Limits {
             min,
@@ -29,32 +26,21 @@ impl Limits {
     }
 
     /// Returns the minimum [`Size`] of the [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
-    /// [`Size`]: ../struct.Size.html
     pub fn min(&self) -> Size {
         self.min
     }
 
     /// Returns the maximum [`Size`] of the [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
-    /// [`Size`]: ../struct.Size.html
     pub fn max(&self) -> Size {
         self.max
     }
 
     /// Returns the fill [`Size`] of the [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
-    /// [`Size`]: ../struct.Size.html
     pub fn fill(&self) -> Size {
         self.fill
     }
 
     /// Applies a width constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn width(mut self, width: Length) -> Limits {
         match width {
             Length::Shrink => {
@@ -77,8 +63,6 @@ impl Limits {
     }
 
     /// Applies a height constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn height(mut self, height: Length) -> Limits {
         match height {
             Length::Shrink => {
@@ -101,8 +85,6 @@ impl Limits {
     }
 
     /// Applies a minimum width constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn min_width(mut self, min_width: u32) -> Limits {
         self.min.width =
             self.min.width.max(min_width as f32).min(self.max.width);
@@ -111,8 +93,6 @@ impl Limits {
     }
 
     /// Applies a maximum width constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn max_width(mut self, max_width: u32) -> Limits {
         self.max.width =
             self.max.width.min(max_width as f32).max(self.min.width);
@@ -121,8 +101,6 @@ impl Limits {
     }
 
     /// Applies a minimum height constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn min_height(mut self, min_height: u32) -> Limits {
         self.min.height =
             self.min.height.max(min_height as f32).min(self.max.height);
@@ -131,8 +109,6 @@ impl Limits {
     }
 
     /// Applies a maximum height constraint to the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn max_height(mut self, max_height: u32) -> Limits {
         self.max.height =
             self.max.height.min(max_height as f32).max(self.min.height);
@@ -141,16 +117,11 @@ impl Limits {
     }
 
     /// Shrinks the current [`Limits`] to account for the given padding.
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn pad(&self, padding: f32) -> Limits {
         self.shrink(Size::new(padding * 2.0, padding * 2.0))
     }
 
     /// Shrinks the current [`Limits`] by the given [`Size`].
-    ///
-    /// [`Limits`]: struct.Limits.html
-    /// [`Size`]: ../struct.Size.html
     pub fn shrink(&self, size: Size) -> Limits {
         let min = Size::new(
             (self.min().width - size.width).max(0.0),
@@ -171,8 +142,6 @@ impl Limits {
     }
 
     /// Removes the minimum width constraint for the current [`Limits`].
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn loose(&self) -> Limits {
         Limits {
             min: Size::ZERO,
@@ -183,8 +152,6 @@ impl Limits {
 
     /// Computes the resulting [`Size`] that fits the [`Limits`] given the
     /// intrinsic size of some content.
-    ///
-    /// [`Limits`]: struct.Limits.html
     pub fn resolve(&self, intrinsic_size: Size) -> Size {
         Size::new(
             intrinsic_size

--- a/native/src/layout/node.rs
+++ b/native/src/layout/node.rs
@@ -9,17 +9,11 @@ pub struct Node {
 
 impl Node {
     /// Creates a new [`Node`] with the given [`Size`].
-    ///
-    /// [`Node`]: struct.Node.html
-    /// [`Size`]: ../struct.Size.html
     pub const fn new(size: Size) -> Self {
         Self::with_children(size, Vec::new())
     }
 
     /// Creates a new [`Node`] with the given [`Size`] and children.
-    ///
-    /// [`Node`]: struct.Node.html
-    /// [`Size`]: ../struct.Size.html
     pub const fn with_children(size: Size, children: Vec<Node>) -> Self {
         Node {
             bounds: Rectangle {
@@ -33,30 +27,21 @@ impl Node {
     }
 
     /// Returns the [`Size`] of the [`Node`].
-    ///
-    /// [`Node`]: struct.Node.html
-    /// [`Size`]: ../struct.Size.html
     pub fn size(&self) -> Size {
         Size::new(self.bounds.width, self.bounds.height)
     }
 
     /// Returns the bounds of the [`Node`].
-    ///
-    /// [`Node`]: struct.Node.html
     pub fn bounds(&self) -> Rectangle {
         self.bounds
     }
 
     /// Returns the children of the [`Node`].
-    ///
-    /// [`Node`]: struct.Node.html
     pub fn children(&self) -> &[Node] {
         &self.children
     }
 
     /// Aligns the [`Node`] in the given space.
-    ///
-    /// [`Node`]: struct.Node.html
     pub fn align(
         &mut self,
         horizontal_alignment: Align,
@@ -85,8 +70,6 @@ impl Node {
     }
 
     /// Moves the [`Node`] to the given position.
-    ///
-    /// [`Node`]: struct.Node.html
     pub fn move_to(&mut self, position: Point) {
         self.bounds.x = position.x;
         self.bounds.y = position.y;

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -27,9 +27,7 @@
 //! [`iced_winit`]: https://github.com/hecrj/iced/tree/master/winit
 //! [`druid`]: https://github.com/xi-editor/druid
 //! [`raw-window-handle`]: https://github.com/rust-windowing/raw-window-handle
-//! [`Widget`]: widget/trait.Widget.html
-//! [`UserInterface`]: struct.UserInterface.html
-//! [renderer]: renderer/index.html
+//! [renderer]: crate::renderer
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]

--- a/native/src/mouse/click.rs
+++ b/native/src/mouse/click.rs
@@ -36,8 +36,6 @@ impl Kind {
 impl Click {
     /// Creates a new [`Click`] with the given position and previous last
     /// [`Click`].
-    ///
-    /// [`Click`]: struct.Click.html
     pub fn new(position: Point, previous: Option<Click>) -> Click {
         let time = Instant::now();
 
@@ -59,9 +57,6 @@ impl Click {
     }
 
     /// Returns the [`Kind`] of [`Click`].
-    ///
-    /// [`Kind`]: enum.Kind.html
-    /// [`Click`]: struct.Click.html
     pub fn kind(&self) -> Kind {
         self.kind
     }

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -20,9 +20,7 @@ where
     /// This [`Node`] is used by the runtime to compute the [`Layout`] of the
     /// user interface.
     ///
-    /// [`Node`]: ../layout/struct.Node.html
-    /// [`Widget`]: trait.Overlay.html
-    /// [`Layout`]: ../layout/struct.Layout.html
+    /// [`Node`]: layout::Node
     fn layout(
         &self,
         renderer: &Renderer,
@@ -31,8 +29,6 @@ where
     ) -> layout::Node;
 
     /// Draws the [`Overlay`] using the associated `Renderer`.
-    ///
-    /// [`Overlay`]: trait.Overlay.html
     fn draw(
         &self,
         renderer: &mut Renderer,
@@ -51,9 +47,7 @@ where
     /// For example, the [`Text`] widget does not hash its color property, as
     /// its value cannot affect the overall [`Layout`] of the user interface.
     ///
-    /// [`Overlay`]: trait.Overlay.html
-    /// [`Layout`]: ../layout/struct.Layout.html
-    /// [`Text`]: text/struct.Text.html
+    /// [`Text`]: crate::widget::Text
     fn hash_layout(&self, state: &mut Hasher, position: Point);
 
     /// Processes a runtime [`Event`].
@@ -68,11 +62,6 @@ where
     ///   * a [`Clipboard`], if available
     ///
     /// By default, it does nothing.
-    ///
-    /// [`Event`]: ../enum.Event.html
-    /// [`Overlay`]: trait.Widget.html
-    /// [`Layout`]: ../layout/struct.Layout.html
-    /// [`Clipboard`]: ../trait.Clipboard.html
     fn on_event(
         &mut self,
         _event: Event,

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -5,8 +5,6 @@ use crate::layout;
 use crate::{Clipboard, Hasher, Layout, Point, Size, Vector};
 
 /// A generic [`Overlay`].
-///
-/// [`Overlay`]: trait.Overlay.html
 #[allow(missing_debug_implementations)]
 pub struct Element<'a, Message, Renderer> {
     position: Point,
@@ -18,9 +16,6 @@ where
     Renderer: crate::Renderer,
 {
     /// Creates a new [`Element`] containing the given [`Overlay`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Overlay`]: trait.Overlay.html
     pub fn new(
         position: Point,
         overlay: Box<dyn Overlay<Message, Renderer> + 'a>,
@@ -29,16 +24,12 @@ where
     }
 
     /// Translates the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn translate(mut self, translation: Vector) -> Self {
         self.position = self.position + translation;
         self
     }
 
     /// Applies a transformation to the produced message of the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn map<B>(self, f: &'a dyn Fn(Message) -> B) -> Element<'a, B, Renderer>
     where
         Message: 'a,
@@ -52,15 +43,11 @@ where
     }
 
     /// Computes the layout of the [`Element`] in the given bounds.
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn layout(&self, renderer: &Renderer, bounds: Size) -> layout::Node {
         self.overlay.layout(renderer, bounds, self.position)
     }
 
     /// Processes a runtime [`Event`].
-    ///
-    /// [`Event`]: enum.Event.html
     pub fn on_event(
         &mut self,
         event: Event,
@@ -81,9 +68,6 @@ where
     }
 
     /// Draws the [`Element`] and its children using the given [`Layout`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Layout`]: layout/struct.Layout.html
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -96,8 +80,6 @@ where
     }
 
     /// Computes the _layout_ hash of the [`Element`].
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn hash_layout(&self, state: &mut Hasher) {
         self.overlay.hash_layout(state, self.position);
     }

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -32,9 +32,6 @@ where
 {
     /// Creates a new [`Menu`] with the given [`State`], a list of options, and
     /// the message to produced when an option is selected.
-    ///
-    /// [`Menu`]: struct.Menu.html
-    /// [`State`]: struct.State.html
     pub fn new(
         state: &'a mut State,
         options: &'a [T],
@@ -55,40 +52,30 @@ where
     }
 
     /// Sets the width of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn width(mut self, width: u16) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the padding of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
     /// Sets the text size of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn text_size(mut self, text_size: u16) -> Self {
         self.text_size = Some(text_size);
         self
     }
 
     /// Sets the font of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = font;
         self
     }
 
     /// Sets the style of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn style(
         mut self,
         style: impl Into<<Renderer as self::Renderer>::Style>,
@@ -103,8 +90,6 @@ where
     /// The `target_height` will be used to display the menu either on top
     /// of the target or under it, depending on the screen position and the
     /// dimensions of the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     pub fn overlay<Message: 'a>(
         self,
         position: Point,
@@ -118,8 +103,6 @@ where
 }
 
 /// The local state of a [`Menu`].
-///
-/// [`Menu`]: struct.Menu.html
 #[derive(Debug, Clone, Default)]
 pub struct State {
     scrollable: scrollable::State,
@@ -127,9 +110,6 @@ pub struct State {
 
 impl State {
     /// Creates a new [`State`] for a [`Menu`].
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Menu`]: struct.Menu.html
     pub fn new() -> Self {
         Self::default()
     }
@@ -402,21 +382,16 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Menu`] in your user interface.
 ///
-/// [`Menu`]: struct.Menu.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer:
     scrollable::Renderer + container::Renderer + text::Renderer
 {
     /// The [`Menu`] style supported by this renderer.
-    ///
-    /// [`Menu`]: struct.Menu.html
     type Style: Default + Clone;
 
     /// Decorates a the list of options of a [`Menu`].
     ///
     /// This method can be used to draw a background for the [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     fn decorate(
         &mut self,
         bounds: Rectangle,
@@ -426,8 +401,6 @@ pub trait Renderer:
     ) -> Self::Output;
 
     /// Draws the list of options of a [`Menu`].
-    ///
-    /// [`Menu`]: struct.Menu.html
     fn draw<T: ToString>(
         &mut self,
         bounds: Rectangle,

--- a/native/src/program.rs
+++ b/native/src/program.rs
@@ -8,13 +8,9 @@ pub use state::State;
 /// The core of a user interface application following The Elm Architecture.
 pub trait Program: Sized {
     /// The graphics backend to use to draw the [`Program`].
-    ///
-    /// [`Program`]: trait.Program.html
     type Renderer: Renderer;
 
     /// The type of __messages__ your [`Program`] will produce.
-    ///
-    /// [`Program`]: trait.Program.html
     type Message: std::fmt::Debug + Send;
 
     /// Handles a __message__ and updates the state of the [`Program`].
@@ -25,15 +21,10 @@ pub trait Program: Sized {
     ///
     /// Any [`Command`] returned will be executed immediately in the
     /// background by shells.
-    ///
-    /// [`Program`]: trait.Application.html
-    /// [`Command`]: struct.Command.html
     fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
 
     /// Returns the widgets to display in the [`Program`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    ///
-    /// [`Program`]: trait.Program.html
     fn view(&mut self) -> Element<'_, Self::Message, Self::Renderer>;
 }

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -5,8 +5,6 @@ use crate::{
 
 /// The execution state of a [`Program`]. It leverages caching, event
 /// processing, and rendering primitive storage.
-///
-/// [`Program`]: trait.Program.html
 #[allow(missing_debug_implementations)]
 pub struct State<P>
 where
@@ -25,9 +23,6 @@ where
 {
     /// Creates a new [`State`] with the provided [`Program`], initializing its
     /// primitive with the given logical bounds and renderer.
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Program`]: trait.Program.html
     pub fn new(
         mut program: P,
         bounds: Size,
@@ -59,39 +54,30 @@ where
     }
 
     /// Returns a reference to the [`Program`] of the [`State`].
-    ///
-    /// [`Program`]: trait.Program.html
-    /// [`State`]: struct.State.html
     pub fn program(&self) -> &P {
         &self.program
     }
 
     /// Returns a reference to the current rendering primitive of the [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn primitive(&self) -> &<P::Renderer as Renderer>::Output {
         &self.primitive
     }
 
     /// Queues an event in the [`State`] for processing during an [`update`].
     ///
-    /// [`State`]: struct.State.html
-    /// [`update`]: #method.update
+    /// [`update`]: Self::update
     pub fn queue_event(&mut self, event: Event) {
         self.queued_events.push(event);
     }
 
     /// Queues a message in the [`State`] for processing during an [`update`].
     ///
-    /// [`State`]: struct.State.html
-    /// [`update`]: #method.update
+    /// [`update`]: Self::update
     pub fn queue_message(&mut self, message: P::Message) {
         self.queued_messages.push(message);
     }
 
     /// Returns whether the event queue of the [`State`] is empty or not.
-    ///
-    /// [`State`]: struct.State.html
     pub fn is_queue_empty(&self) -> bool {
         self.queued_events.is_empty() && self.queued_messages.is_empty()
     }
@@ -101,8 +87,6 @@ where
     ///
     /// Returns the [`Command`] obtained from [`Program`] after updating it,
     /// only if an update was necessary.
-    ///
-    /// [`Program`]: trait.Program.html
     pub fn update(
         &mut self,
         bounds: Size,

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -13,12 +13,12 @@
 //! In the end, a __renderer__ satisfying all the constraints is
 //! needed to build a [`UserInterface`].
 //!
-//! [`Widget`]: ../widget/trait.Widget.html
-//! [`UserInterface`]: ../struct.UserInterface.html
-//! [`Text`]: ../widget/text/struct.Text.html
-//! [`text::Renderer`]: ../widget/text/trait.Renderer.html
-//! [`Checkbox`]: ../widget/checkbox/struct.Checkbox.html
-//! [`checkbox::Renderer`]: ../widget/checkbox/trait.Renderer.html
+//! [`Widget`]: crate::Widget
+//! [`UserInterface`]: crate::UserInterface
+//! [`Text`]: crate::widget::Text
+//! [`text::Renderer`]: crate::widget::text::Renderer
+//! [`Checkbox`]: crate::widget::Checkbox
+//! [`checkbox::Renderer`]: crate::widget::checkbox::Renderer
 
 #[cfg(debug_assertions)]
 mod null;
@@ -34,15 +34,11 @@ pub trait Renderer: Sized {
     ///
     /// If you are implementing a graphical renderer, your output will most
     /// likely be a tree of visual primitives.
-    ///
-    /// [`Renderer`]: trait.Renderer.html
     type Output;
 
     /// The default styling attributes of the [`Renderer`].
     ///
     /// This type can be leveraged to implement style inheritance.
-    ///
-    /// [`Renderer`]: trait.Renderer.html
     type Defaults: Default;
 
     /// Lays out the elements of a user interface.

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -13,8 +13,6 @@ pub struct Null;
 
 impl Null {
     /// Creates a new [`Null`] renderer.
-    ///
-    /// [`Null`]: struct.Null.html
     pub fn new() -> Null {
         Null
     }

--- a/native/src/runtime.rs
+++ b/native/src/runtime.rs
@@ -7,8 +7,8 @@ use crate::Hasher;
 /// It can be used by shells to easily spawn a [`Command`] or track a
 /// [`Subscription`].
 ///
-/// [`Command`]: ../struct.Command.html
-/// [`Subscription`]: ../struct.Subscription.html
+/// [`Command`]: crate::Command
+/// [`Subscription`]: crate::Subscription
 pub type Runtime<Executor, Receiver, Message> = iced_futures::Runtime<
     Hasher,
     (Event, event::Status),

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -14,21 +14,16 @@ use iced_futures::futures::stream::BoxStream;
 /// For instance, you can use a [`Subscription`] to listen to a WebSocket
 /// connection, keyboard presses, mouse events, time ticks, etc.
 ///
-/// [`Command`]: ../struct.Command.html
-/// [`Subscription`]: struct.Subscription.html
+/// [`Command`]: crate::Command
 pub type Subscription<T> =
     iced_futures::Subscription<Hasher, (Event, event::Status), T>;
 
 /// A stream of runtime events.
 ///
 /// It is the input of a [`Subscription`] in the native runtime.
-///
-/// [`Subscription`]: type.Subscription.html
 pub type EventStream = BoxStream<'static, (Event, event::Status)>;
 
 /// A native [`Subscription`] tracker.
-///
-/// [`Subscription`]: type.Subscription.html
 pub type Tracker =
     iced_futures::subscription::Tracker<Hasher, (Event, event::Status)>;
 
@@ -42,9 +37,6 @@ use events::Events;
 ///
 /// This subscription will notify your application of any [`Event`] that was
 /// not captured by any widget.
-///
-/// [`Subscription`]: type.Subscription.html
-/// [`Event`]: ../enum.Event.html
 pub fn events() -> Subscription<Event> {
     Subscription::from_recipe(Events {
         f: |event, status| match status {
@@ -62,9 +54,6 @@ pub fn events() -> Subscription<Event> {
 ///
 /// - Returns `None`, the [`Event`] will be discarded.
 /// - Returns `Some` message, the `Message` will be produced.
-///
-/// [`Subscription`]: type.Subscription.html
-/// [`Event`]: ../enum.Event.html
 pub fn events_with<Message>(
     f: fn(Event, event::Status) -> Option<Message>,
 ) -> Subscription<Message>

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -12,14 +12,11 @@ use std::hash::Hasher;
 /// Iced tries to avoid dictating how to write your event loop. You are in
 /// charge of using this type in your system in any way you want.
 ///
-/// [`Layout`]: struct.Layout.html
-///
 /// # Example
 /// The [`integration` example] uses a [`UserInterface`] to integrate Iced in
 /// an existing graphical application.
 ///
 /// [`integration` example]: https://github.com/hecrj/iced/tree/0.1/examples/integration
-/// [`UserInterface`]: struct.UserInterface.html
 #[allow(missing_debug_implementations)]
 pub struct UserInterface<'a, Message, Renderer> {
     root: Element<'a, Message, Renderer>,
@@ -36,10 +33,6 @@ where
     ///
     /// It is able to avoid expensive computations when using a [`Cache`]
     /// obtained from a previous instance of a [`UserInterface`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Cache`]: struct.Cache.html
-    /// [`UserInterface`]: struct.UserInterface.html
     ///
     /// # Example
     /// Imagine we want to build a [`UserInterface`] for
@@ -135,9 +128,6 @@ where
     ///
     /// It returns __messages__ that may have been produced as a result of user
     /// interactions. You should feed these to your __update logic__.
-    ///
-    /// [`UserInterface`]: struct.UserInterface.html
-    /// [`Event`]: enum.Event.html
     ///
     /// # Example
     /// Let's allow our [counter](index.html#usage) to change state by
@@ -268,12 +258,11 @@ where
 
     /// Draws the [`UserInterface`] with the provided [`Renderer`].
     ///
-    /// It returns the current state of the [`MouseCursor`]. You should update
-    /// the icon of the mouse cursor accordingly in your system.
+    /// It returns the some [`Renderer::Output`]. You should update the icon of
+    /// the mouse cursor accordingly in your system.
     ///
-    /// [`UserInterface`]: struct.UserInterface.html
-    /// [`Renderer`]: trait.Renderer.html
-    /// [`MouseCursor`]: enum.MouseCursor.html
+    /// [`Renderer`]: crate::Renderer
+    /// [`Renderer::Output`]: crate::Renderer::Output
     ///
     /// # Example
     /// We can finally draw our [counter](index.html#usage) by
@@ -404,8 +393,6 @@ where
 
     /// Relayouts and returns a new  [`UserInterface`] using the provided
     /// bounds.
-    ///
-    /// [`UserInterface`]: struct.UserInterface.html
     pub fn relayout(self, bounds: Size, renderer: &mut Renderer) -> Self {
         Self::build(
             self.root,
@@ -421,9 +408,6 @@ where
 
     /// Extract the [`Cache`] of the [`UserInterface`], consuming it in the
     /// process.
-    ///
-    /// [`Cache`]: struct.Cache.html
-    /// [`UserInterface`]: struct.UserInterface.html
     pub fn into_cache(self) -> Cache {
         Cache {
             base: self.base,
@@ -464,8 +448,6 @@ struct Layer {
 }
 
 /// Reusable data of a specific [`UserInterface`].
-///
-/// [`UserInterface`]: struct.UserInterface.html
 #[derive(Debug, Clone)]
 pub struct Cache {
     base: Layer,
@@ -478,9 +460,6 @@ impl Cache {
     ///
     /// You should use this to initialize a [`Cache`] before building your first
     /// [`UserInterface`].
-    ///
-    /// [`Cache`]: struct.Cache.html
-    /// [`UserInterface`]: struct.UserInterface.html
     pub fn new() -> Cache {
         Cache {
             base: Layer {

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -18,8 +18,7 @@
 //! use iced_native::{button, Button, Widget};
 //! ```
 //!
-//! [`Widget`]: trait.Widget.html
-//! [renderer]: ../renderer/index.html
+//! [renderer]: crate::renderer
 pub mod button;
 pub mod checkbox;
 pub mod column;
@@ -83,9 +82,6 @@ use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle};
 /// If you want to build your own widgets, you will need to implement this
 /// trait.
 ///
-/// [`Widget`]: trait.Widget.html
-/// [`Element`]: ../struct.Element.html
-///
 /// # Examples
 /// The repository has some [examples] showcasing how to implement a custom
 /// widget:
@@ -108,13 +104,9 @@ where
     Renderer: crate::Renderer,
 {
     /// Returns the width of the [`Widget`].
-    ///
-    /// [`Widget`]: trait.Widget.html
     fn width(&self) -> Length;
 
     /// Returns the height of the [`Widget`].
-    ///
-    /// [`Widget`]: trait.Widget.html
     fn height(&self) -> Length;
 
     /// Returns the [`Node`] of the [`Widget`].
@@ -122,9 +114,7 @@ where
     /// This [`Node`] is used by the runtime to compute the [`Layout`] of the
     /// user interface.
     ///
-    /// [`Node`]: ../layout/struct.Node.html
-    /// [`Widget`]: trait.Widget.html
-    /// [`Layout`]: ../layout/struct.Layout.html
+    /// [`Node`]: layout::Node
     fn layout(
         &self,
         renderer: &Renderer,
@@ -132,8 +122,6 @@ where
     ) -> layout::Node;
 
     /// Draws the [`Widget`] using the associated `Renderer`.
-    ///
-    /// [`Widget`]: trait.Widget.html
     fn draw(
         &self,
         renderer: &mut Renderer,
@@ -153,9 +141,7 @@ where
     /// For example, the [`Text`] widget does not hash its color property, as
     /// its value cannot affect the overall [`Layout`] of the user interface.
     ///
-    /// [`Widget`]: trait.Widget.html
-    /// [`Layout`]: ../layout/struct.Layout.html
-    /// [`Text`]: text/struct.Text.html
+    /// [`Text`]: crate::widget::Text
     fn hash_layout(&self, state: &mut Hasher);
 
     /// Processes a runtime [`Event`].
@@ -170,11 +156,6 @@ where
     ///   * a [`Clipboard`], if available
     ///
     /// By default, it does nothing.
-    ///
-    /// [`Event`]: ../enum.Event.html
-    /// [`Widget`]: trait.Widget.html
-    /// [`Layout`]: ../layout/struct.Layout.html
-    /// [`Clipboard`]: ../trait.Clipboard.html
     fn on_event(
         &mut self,
         _event: Event,
@@ -187,9 +168,7 @@ where
         event::Status::Ignored
     }
 
-    /// Returns the overlay of the [`Element`], if there is any.
-    ///
-    /// [`Element`]: struct.Element.html
+    /// Returns the overlay of the [`Widget`], if there is any.
     fn overlay(
         &mut self,
         _layout: Layout<'_>,

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -1,9 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-//!
-//! [`Button`]: struct.Button.html
-//! [`State`]: struct.State.html
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
@@ -49,9 +46,6 @@ where
 {
     /// Creates a new [`Button`] with some local [`State`] and the given
     /// content.
-    ///
-    /// [`Button`]: struct.Button.html
-    /// [`State`]: struct.State.html
     pub fn new<E>(state: &'a mut State, content: E) -> Self
     where
         E: Into<Element<'a, Message, Renderer>>,
@@ -70,56 +64,42 @@ where
     }
 
     /// Sets the width of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the minimum width of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn min_width(mut self, min_width: u32) -> Self {
         self.min_width = min_width;
         self
     }
 
     /// Sets the minimum height of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn min_height(mut self, min_height: u32) -> Self {
         self.min_height = min_height;
         self
     }
 
     /// Sets the padding of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
     /// Sets the message that will be produced when the [`Button`] is pressed.
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn on_press(mut self, msg: Message) -> Self {
         self.on_press = Some(msg);
         self
     }
 
     /// Sets the style of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -127,8 +107,6 @@ where
 }
 
 /// The local state of a [`Button`].
-///
-/// [`Button`]: struct.Button.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State {
     is_pressed: bool,
@@ -136,8 +114,6 @@ pub struct State {
 
 impl State {
     /// Creates a new [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> State {
         State::default()
     }
@@ -254,20 +230,15 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Button`] in your user interface.
 ///
-/// [`Button`]: struct.Button.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer + Sized {
     /// The default padding of a [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     const DEFAULT_PADDING: u16;
 
     /// The style supported by this renderer.
     type Style: Default;
 
     /// Draws a [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -52,8 +52,6 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     ///   * a function that will be called when the [`Checkbox`] is toggled. It
     ///     will receive the new state of the [`Checkbox`] and must produce a
     ///     `Message`.
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn new<F>(is_checked: bool, label: impl Into<String>, f: F) -> Self
     where
         F: 'static + Fn(bool) -> Message,
@@ -72,32 +70,24 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     }
 
     /// Sets the size of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = size;
         self
     }
 
     /// Sets the width of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the spacing between the [`Checkbox`] and the text.
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn spacing(mut self, spacing: u16) -> Self {
         self.spacing = spacing;
         self
     }
 
     /// Sets the text size of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn text_size(mut self, text_size: u16) -> Self {
         self.text_size = Some(text_size);
         self
@@ -105,16 +95,13 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
 
     /// Sets the [`Font`] of the text of the [`Checkbox`].
     ///
-    /// [`Checkbox`]: struct.Checkbox.html
-    /// [`Font`]: ../../struct.Font.html
+    /// [`Font`]: crate::widget::text::Renderer::Font
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = font;
         self
     }
 
     /// Sets the style of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -234,20 +221,15 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Checkbox`] in your user interface.
 ///
-/// [`Checkbox`]: struct.Checkbox.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::Renderer
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// The default size of a [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     const DEFAULT_SIZE: u16;
 
     /// The default spacing of a [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     const DEFAULT_SPACING: u16;
 
     /// Draws a [`Checkbox`].
@@ -257,8 +239,6 @@ pub trait Renderer: crate::Renderer {
     ///   * whether the [`Checkbox`] is selected or not
     ///   * whether the mouse is over the [`Checkbox`] or not
     ///   * the drawn label of the [`Checkbox`]
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     fn draw(
         &mut self,
         bounds: Rectangle,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -25,15 +25,11 @@ pub struct Column<'a, Message, Renderer> {
 
 impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
     /// Creates an empty [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn new() -> Self {
         Self::with_children(Vec::new())
     }
 
     /// Creates a [`Column`] with the given elements.
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn with_children(
         children: Vec<Element<'a, Message, Renderer>>,
     ) -> Self {
@@ -60,56 +56,42 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
     }
 
     /// Sets the padding of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Column`] in pixels.
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the horizontal alignment of the contents of the [`Column`] .
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn align_items(mut self, align: Align) -> Self {
         self.align_items = align;
         self
     }
 
     /// Adds an element to the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message, Renderer>>,
@@ -230,8 +212,7 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Column`] in your user interface.
 ///
-/// [`Column`]: struct.Column.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer + Sized {
     /// Draws a [`Column`].
     ///
@@ -239,9 +220,6 @@ pub trait Renderer: crate::Renderer + Sized {
     /// - the children of the [`Column`]
     /// - the [`Layout`] of the [`Column`] and its children
     /// - the cursor position
-    ///
-    /// [`Column`]: struct.Column.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -31,8 +31,6 @@ where
     Renderer: self::Renderer,
 {
     /// Creates an empty [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn new<T>(content: T) -> Self
     where
         T: Into<Element<'a, Message, Renderer>>,
@@ -51,80 +49,60 @@ where
     }
 
     /// Sets the padding of the [`Container`].
-    ///
-    /// [`Container`]: struct.Column.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Container`] in pixels.
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the content alignment for the horizontal axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn align_x(mut self, alignment: Align) -> Self {
         self.horizontal_alignment = alignment;
         self
     }
 
     /// Sets the content alignment for the vertical axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn align_y(mut self, alignment: Align) -> Self {
         self.vertical_alignment = alignment;
         self
     }
 
     /// Centers the contents in the horizontal axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn center_x(mut self) -> Self {
         self.horizontal_alignment = Align::Center;
         self
     }
 
     /// Centers the contents in the vertical axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn center_y(mut self) -> Self {
         self.vertical_alignment = Align::Center;
         self
     }
 
     /// Sets the style of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -232,15 +210,12 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Container`] in your user interface.
 ///
-/// [`Container`]: struct.Container.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// Draws a [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -28,8 +28,6 @@ pub struct Image {
 
 impl Image {
     /// Creates a new [`Image`] with the given path.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn new<T: Into<Handle>>(handle: T) -> Self {
         Image {
             handle: handle.into(),
@@ -39,16 +37,12 @@ impl Image {
     }
 
     /// Sets the width of the [`Image`] boundaries.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Image`] boundaries.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
@@ -114,8 +108,6 @@ where
 }
 
 /// An [`Image`] handle.
-///
-/// [`Image`]: struct.Image.html
 #[derive(Debug, Clone)]
 pub struct Handle {
     id: u64,
@@ -126,8 +118,6 @@ impl Handle {
     /// Creates an image [`Handle`] pointing to the image of the given path.
     ///
     /// Makes an educated guess about the image format by examining the data in the file.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
         Self::from_data(Data::Path(path.into()))
     }
@@ -137,8 +127,6 @@ impl Handle {
     /// pixels.
     ///
     /// This is useful if you have already decoded your image.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_pixels(width: u32, height: u32, pixels: Vec<u8>) -> Handle {
         Self::from_data(Data::Pixels {
             width,
@@ -153,8 +141,6 @@ impl Handle {
     ///
     /// This is useful if you already have your image loaded in-memory, maybe
     /// because you downloaded or generated it procedurally.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_memory(bytes: Vec<u8>) -> Handle {
         Self::from_data(Data::Bytes(bytes))
     }
@@ -170,15 +156,11 @@ impl Handle {
     }
 
     /// Returns the unique identifier of the [`Handle`].
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn id(&self) -> u64 {
         self.id
     }
 
     /// Returns a reference to the image [`Data`].
-    ///
-    /// [`Data`]: enum.Data.html
     pub fn data(&self) -> &Data {
         &self.data
     }
@@ -200,8 +182,6 @@ impl Hash for Handle {
 }
 
 /// The data of an [`Image`].
-///
-/// [`Image`]: struct.Image.html
 #[derive(Clone, Hash)]
 pub enum Data {
     /// File data
@@ -238,17 +218,12 @@ impl std::fmt::Debug for Data {
 /// Your [renderer] will need to implement this trait before being able to use
 /// an [`Image`] in your user interface.
 ///
-/// [`Image`]: struct.Image.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// Returns the dimensions of an [`Image`] located on the given path.
-    ///
-    /// [`Image`]: struct.Image.html
     fn dimensions(&self, handle: &Handle) -> (u32, u32);
 
     /// Draws an [`Image`].
-    ///
-    /// [`Image`]: struct.Image.html
     fn draw(&mut self, handle: Handle, layout: Layout<'_>) -> Self::Output;
 }
 

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -6,8 +6,7 @@
 //! The [`pane_grid` example] showcases how to use a [`PaneGrid`] with resizing,
 //! drag and drop, and hotkey support.
 //!
-//! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
-//! [`PaneGrid`]: struct.PaneGrid.html
+//! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.2/examples/pane_grid
 mod axis;
 mod configuration;
 mod content;
@@ -89,9 +88,6 @@ use crate::{
 ///     .on_drag(Message::PaneDragged)
 ///     .on_resize(10, Message::PaneResized);
 /// ```
-///
-/// [`PaneGrid`]: struct.PaneGrid.html
-/// [`State`]: struct.State.html
 #[allow(missing_debug_implementations)]
 pub struct PaneGrid<'a, Message, Renderer: self::Renderer> {
     state: &'a mut state::Internal,
@@ -112,10 +108,6 @@ where
     ///
     /// The view function will be called to display each [`Pane`] present in the
     /// [`State`].
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
-    /// [`State`]: struct.State.html
-    /// [`Pane`]: struct.Pane.html
     pub fn new<T>(
         state: &'a mut State<T>,
         view: impl Fn(Pane, &'a mut T) -> Content<'a, Message, Renderer>,
@@ -141,24 +133,18 @@ where
     }
 
     /// Sets the width of the [`PaneGrid`].
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`PaneGrid`].
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the spacing _between_ the panes of the [`PaneGrid`].
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn spacing(mut self, units: u16) -> Self {
         self.spacing = units;
         self
@@ -166,9 +152,6 @@ where
 
     /// Sets the message that will be produced when a [`Pane`] of the
     /// [`PaneGrid`] is clicked.
-    ///
-    /// [`Pane`]: struct.Pane.html
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn on_click<F>(mut self, f: F) -> Self
     where
         F: 'a + Fn(Pane) -> Message,
@@ -179,8 +162,6 @@ where
 
     /// Enables the drag and drop interactions of the [`PaneGrid`], which will
     /// use the provided function to produce messages.
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn on_drag<F>(mut self, f: F) -> Self
     where
         F: 'a + Fn(DragEvent) -> Message,
@@ -198,8 +179,6 @@ where
     /// The grabbable area of a split will have a length of `spacing + leeway`,
     /// properly centered. In other words, a length of
     /// `(spacing + leeway) / 2.0` on either side of the split line.
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
     pub fn on_resize<F>(mut self, leeway: u16, f: F) -> Self
     where
         F: 'a + Fn(ResizeEvent) -> Message,
@@ -287,63 +266,41 @@ where
 }
 
 /// An event produced during a drag and drop interaction of a [`PaneGrid`].
-///
-/// [`PaneGrid`]: struct.PaneGrid.html
 #[derive(Debug, Clone, Copy)]
 pub enum DragEvent {
     /// A [`Pane`] was picked for dragging.
-    ///
-    /// [`Pane`]: struct.Pane.html
     Picked {
         /// The picked [`Pane`].
-        ///
-        /// [`Pane`]: struct.Pane.html
         pane: Pane,
     },
 
     /// A [`Pane`] was dropped on top of another [`Pane`].
-    ///
-    /// [`Pane`]: struct.Pane.html
     Dropped {
         /// The picked [`Pane`].
-        ///
-        /// [`Pane`]: struct.Pane.html
         pane: Pane,
 
         /// The [`Pane`] where the picked one was dropped on.
-        ///
-        /// [`Pane`]: struct.Pane.html
         target: Pane,
     },
 
     /// A [`Pane`] was picked and then dropped outside of other [`Pane`]
     /// boundaries.
-    ///
-    /// [`Pane`]: struct.Pane.html
     Canceled {
         /// The picked [`Pane`].
-        ///
-        /// [`Pane`]: struct.Pane.html
         pane: Pane,
     },
 }
 
 /// An event produced during a resize interaction of a [`PaneGrid`].
-///
-/// [`PaneGrid`]: struct.PaneGrid.html
 #[derive(Debug, Clone, Copy)]
 pub struct ResizeEvent {
     /// The [`Split`] that is being dragged for resizing.
-    ///
-    /// [`Split`]: struct.Split.html
     pub split: Split,
 
     /// The new ratio of the [`Split`].
     ///
     /// The ratio is a value in [0, 1], representing the exact position of a
     /// [`Split`] between two panes.
-    ///
-    /// [`Split`]: struct.Split.html
     pub ratio: f32,
 }
 
@@ -585,8 +542,7 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`PaneGrid`] in your user interface.
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer:
     crate::Renderer + container::Renderer + text::Renderer + Sized
 {
@@ -598,10 +554,6 @@ pub trait Renderer:
     /// - the [`Axis`] that is currently being resized
     /// - the [`Layout`] of the [`PaneGrid`] and its elements
     /// - the cursor position
-    ///
-    /// [`PaneGrid`]: struct.PaneGrid.html
-    /// [`Pane`]: struct.Pane.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,
@@ -619,9 +571,6 @@ pub trait Renderer:
     /// - the [`Content`] of the [`Pane`]
     /// - the [`Layout`] of the [`Pane`] and its elements
     /// - the cursor position
-    ///
-    /// [`Pane`]: struct.Pane.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw_pane<Message>(
         &mut self,
         defaults: &Self::Defaults,
@@ -640,9 +589,6 @@ pub trait Renderer:
     /// - the title of the [`TitleBar`] with its size, font, and bounds
     /// - the controls of the [`TitleBar`] with their [`Layout`+, if any
     /// - the cursor position
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw_title_bar<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/pane_grid/configuration.rs
+++ b/native/src/widget/pane_grid/configuration.rs
@@ -2,7 +2,7 @@ use crate::pane_grid::Axis;
 
 /// The arrangement of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
+/// [`PaneGrid`]: crate::pane_grid::PaneGrid
 #[derive(Debug, Clone)]
 pub enum Configuration<T> {
     /// A split of the available space.
@@ -13,18 +13,14 @@ pub enum Configuration<T> {
         /// The ratio of the split in [0.0, 1.0].
         ratio: f32,
 
-        /// The left/top [`Content`] of the split.
-        ///
-        /// [`Configuration`]: enum.Node.html
+        /// The left/top [`Configuration`] of the split.
         a: Box<Configuration<T>>,
 
-        /// The right/bottom [`Content`] of the split.
-        ///
-        /// [`Configuration`]: enum.Node.html
+        /// The right/bottom [`Configuration`] of the split.
         b: Box<Configuration<T>>,
     },
     /// A [`Pane`].
     ///
-    /// [`Pane`]: struct.Pane.html
+    /// [`Pane`]: crate::pane_grid::Pane
     Pane(T),
 }

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -7,7 +7,7 @@ use crate::{Clipboard, Element, Hasher, Layout, Point, Size};
 
 /// The content of a [`Pane`].
 ///
-/// [`Pane`]: struct.Pane.html
+/// [`Pane`]: crate::widget::pane_grid::Pane
 #[allow(missing_debug_implementations)]
 pub struct Content<'a, Message, Renderer: pane_grid::Renderer> {
     title_bar: Option<TitleBar<'a, Message, Renderer>>,
@@ -20,8 +20,6 @@ where
     Renderer: pane_grid::Renderer,
 {
     /// Creates a new [`Content`] with the provided body.
-    ///
-    /// [`Content`]: struct.Content.html
     pub fn new(body: impl Into<Element<'a, Message, Renderer>>) -> Self {
         Self {
             title_bar: None,
@@ -31,9 +29,6 @@ where
     }
 
     /// Sets the [`TitleBar`] of this [`Content`].
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
-    /// [`Content`]: struct.Content.html
     pub fn title_bar(
         mut self,
         title_bar: TitleBar<'a, Message, Renderer>,
@@ -43,8 +38,6 @@ where
     }
 
     /// Sets the style of the [`Content`].
-    ///
-    /// [`Content`]: struct.Content.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -57,9 +50,7 @@ where
 {
     /// Draws the [`Content`] with the provided [`Renderer`] and [`Layout`].
     ///
-    /// [`Content`]: struct.Content.html
-    /// [`Renderer`]: trait.Renderer.html
-    /// [`Layout`]: ../layout/struct.Layout.html
+    /// [`Renderer`]: crate::widget::pane_grid::Renderer
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -94,9 +85,6 @@ where
 
     /// Returns whether the [`Content`] with the given [`Layout`] can be picked
     /// at the provided cursor position.
-    ///
-    /// [`Content`]: struct.Content.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     pub fn can_be_picked_at(
         &self,
         layout: Layout<'_>,

--- a/native/src/widget/pane_grid/node.rs
+++ b/native/src/widget/pane_grid/node.rs
@@ -7,17 +7,12 @@ use std::collections::HashMap;
 
 /// A layout node of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
+/// [`PaneGrid`]: crate::widget::PaneGrid
 #[derive(Debug, Clone)]
 pub enum Node {
     /// The region of this [`Node`] is split into two.
-    ///
-    /// [`Node`]: enum.Node.html
     Split {
         /// The [`Split`] of this [`Node`].
-        ///
-        /// [`Split`]: struct.Split.html
-        /// [`Node`]: enum.Node.html
         id: Split,
 
         /// The direction of the split.
@@ -27,26 +22,17 @@ pub enum Node {
         ratio: f32,
 
         /// The left/top [`Node`] of the split.
-        ///
-        /// [`Node`]: enum.Node.html
         a: Box<Node>,
 
         /// The right/bottom [`Node`] of the split.
-        ///
-        /// [`Node`]: enum.Node.html
         b: Box<Node>,
     },
     /// The region of this [`Node`] is taken by a [`Pane`].
-    ///
-    /// [`Pane`]: struct.Pane.html
     Pane(Pane),
 }
 
 impl Node {
     /// Returns an iterator over each [`Split`] in this [`Node`].
-    ///
-    /// [`Split`]: struct.Split.html
-    /// [`Node`]: enum.Node.html
     pub fn splits(&self) -> impl Iterator<Item = &Split> {
         let mut unvisited_nodes = vec![self];
 
@@ -69,9 +55,6 @@ impl Node {
 
     /// Returns the rectangular region for each [`Pane`] in the [`Node`] given
     /// the spacing between panes and the total available space.
-    ///
-    /// [`Pane`]: struct.Pane.html
-    /// [`Node`]: enum.Node.html
     pub fn pane_regions(
         &self,
         spacing: f32,
@@ -96,9 +79,6 @@ impl Node {
     /// Returns the axis, rectangular region, and ratio for each [`Split`] in
     /// the [`Node`] given the spacing between panes and the total available
     /// space.
-    ///
-    /// [`Split`]: struct.Split.html
-    /// [`Node`]: enum.Node.html
     pub fn split_regions(
         &self,
         spacing: f32,

--- a/native/src/widget/pane_grid/pane.rs
+++ b/native/src/widget/pane_grid/pane.rs
@@ -1,5 +1,5 @@
 /// A rectangular region in a [`PaneGrid`] used to display widgets.
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
+/// [`PaneGrid`]: crate::widget::PaneGrid
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Pane(pub(super) usize);

--- a/native/src/widget/pane_grid/split.rs
+++ b/native/src/widget/pane_grid/split.rs
@@ -1,5 +1,5 @@
 /// A divider that splits a region in a [`PaneGrid`] into two different panes.
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
+/// [`PaneGrid`]: crate::widget::PaneGrid
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Split(pub(super) usize);

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -15,11 +15,8 @@ use std::collections::HashMap;
 /// provided to the view function of [`PaneGrid::new`] for displaying each
 /// [`Pane`].
 ///
-/// [`PaneGrid`]: struct.PaneGrid.html
-/// [`PaneGrid::new`]: struct.PaneGrid.html#method.new
-/// [`Pane`]: struct.Pane.html
-/// [`Split`]: struct.Split.html
-/// [`State`]: struct.State.html
+/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid::new`]: crate::widget::PaneGrid::new
 #[derive(Debug, Clone)]
 pub struct State<T> {
     pub(super) panes: HashMap<Pane, T>,
@@ -31,9 +28,6 @@ impl<T> State<T> {
     /// state.
     ///
     /// Alongside the [`State`], it returns the first [`Pane`] identifier.
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Pane`]: struct.Pane.html
     pub fn new(first_pane_state: T) -> (Self, Pane) {
         (
             Self::with_configuration(Configuration::Pane(first_pane_state)),
@@ -42,9 +36,6 @@ impl<T> State<T> {
     }
 
     /// Creates a new [`State`] with the given [`Configuration`].
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Configuration`]: enum.Configuration.html
     pub fn with_configuration(config: impl Into<Configuration<T>>) -> Self {
         let mut panes = HashMap::new();
 
@@ -62,54 +53,40 @@ impl<T> State<T> {
     }
 
     /// Returns the total amount of panes in the [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn len(&self) -> usize {
         self.panes.len()
     }
 
     /// Returns the internal state of the given [`Pane`], if it exists.
-    ///
-    /// [`Pane`]: struct.Pane.html
     pub fn get(&self, pane: &Pane) -> Option<&T> {
         self.panes.get(pane)
     }
 
     /// Returns the internal state of the given [`Pane`] with mutability, if it
     /// exists.
-    ///
-    /// [`Pane`]: struct.Pane.html
     pub fn get_mut(&mut self, pane: &Pane) -> Option<&mut T> {
         self.panes.get_mut(pane)
     }
 
     /// Returns an iterator over all the panes of the [`State`], alongside its
     /// internal state.
-    ///
-    /// [`State`]: struct.State.html
     pub fn iter(&self) -> impl Iterator<Item = (&Pane, &T)> {
         self.panes.iter()
     }
 
     /// Returns a mutable iterator over all the panes of the [`State`],
     /// alongside its internal state.
-    ///
-    /// [`State`]: struct.State.html
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Pane, &mut T)> {
         self.panes.iter_mut()
     }
 
     /// Returns the layout of the [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn layout(&self) -> &Node {
         &self.internal.layout
     }
 
     /// Returns the adjacent [`Pane`] of another [`Pane`] in the given
     /// direction, if there is one.
-    ///
-    /// [`Pane`]: struct.Pane.html
     pub fn adjacent(&self, pane: &Pane, direction: Direction) -> Option<Pane> {
         let regions = self
             .internal
@@ -145,9 +122,6 @@ impl<T> State<T> {
 
     /// Splits the given [`Pane`] into two in the given [`Axis`] and
     /// initializing the new [`Pane`] with the provided internal state.
-    ///
-    /// [`Pane`]: struct.Pane.html
-    /// [`Axis`]: enum.Axis.html
     pub fn split(
         &mut self,
         axis: Axis,
@@ -180,9 +154,8 @@ impl<T> State<T> {
     /// If you want to swap panes on drag and drop in your [`PaneGrid`], you
     /// will need to call this method when handling a [`DragEvent`].
     ///
-    /// [`State`]: struct.State.html
-    /// [`PaneGrid`]: struct.PaneGrid.html
-    /// [`DragEvent`]: struct.DragEvent.html
+    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`DragEvent`]: crate::widget::pane_grid::DragEvent
     pub fn swap(&mut self, a: &Pane, b: &Pane) {
         self.internal.layout.update(&|node| match node {
             Node::Split { .. } => {}
@@ -204,17 +177,14 @@ impl<T> State<T> {
     /// If you want to enable resize interactions in your [`PaneGrid`], you will
     /// need to call this method when handling a [`ResizeEvent`].
     ///
-    /// [`Split`]: struct.Split.html
-    /// [`PaneGrid`]: struct.PaneGrid.html
-    /// [`ResizeEvent`]: struct.ResizeEvent.html
+    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`ResizeEvent`]: crate::widget::pane_grid::ResizeEvent
     pub fn resize(&mut self, split: &Split, ratio: f32) {
         let _ = self.internal.layout.resize(split, ratio);
     }
 
     /// Closes the given [`Pane`] and returns its internal state and its closest
     /// sibling, if it exists.
-    ///
-    /// [`Pane`]: struct.Pane.html
     pub fn close(&mut self, pane: &Pane) -> Option<(T, Pane)> {
         if let Some(sibling) = self.internal.layout.remove(pane) {
             self.panes.remove(pane).map(|state| (state, sibling))

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -5,7 +5,7 @@ use crate::{Clipboard, Element, Hasher, Layout, Point, Rectangle, Size};
 
 /// The title bar of a [`Pane`].
 ///
-/// [`Pane`]: struct.Pane.html
+/// [`Pane`]: crate::widget::pane_grid::Pane
 #[allow(missing_debug_implementations)]
 pub struct TitleBar<'a, Message, Renderer: pane_grid::Renderer> {
     title: String,
@@ -21,8 +21,6 @@ where
     Renderer: pane_grid::Renderer,
 {
     /// Creates a new [`TitleBar`] with the given title.
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn new(title: impl Into<String>) -> Self {
         Self {
             title: title.into(),
@@ -35,16 +33,12 @@ where
     }
 
     /// Sets the size of the title of the [`TitleBar`].
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn title_size(mut self, size: u16) -> Self {
         self.title_size = Some(size);
         self
     }
 
     /// Sets the controls of the [`TitleBar`].
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn controls(
         mut self,
         controls: impl Into<Element<'a, Message, Renderer>>,
@@ -54,16 +48,12 @@ where
     }
 
     /// Sets the padding of the [`TitleBar`].
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the style of the [`TitleBar`].
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -75,9 +65,8 @@ where
     /// By default, the controls are only visible when the [`Pane`] of this
     /// [`TitleBar`] is hovered.
     ///
-    /// [`TitleBar`]: struct.TitleBar.html
-    /// [`controls`]: struct.TitleBar.html#method.controls
-    /// [`Pane`]: struct.Pane.html
+    /// [`controls`]: Self::controls
+    /// [`Pane`]: crate::widget::pane_grid::Pane
     pub fn always_show_controls(mut self) -> Self {
         self.always_show_controls = true;
         self
@@ -90,9 +79,7 @@ where
 {
     /// Draws the [`TitleBar`] with the provided [`Renderer`] and [`Layout`].
     ///
-    /// [`TitleBar`]: struct.TitleBar.html
-    /// [`Renderer`]: trait.Renderer.html
-    /// [`Layout`]: ../layout/struct.Layout.html
+    /// [`Renderer`]: crate::widget::pane_grid::Renderer
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -152,8 +139,6 @@ where
     /// [`TitleBar`] or not.
     ///
     /// The whole [`TitleBar`] is a pick area, except its controls.
-    ///
-    /// [`TitleBar`]: struct.TitleBar.html
     pub fn is_over_pick_area(
         &self,
         layout: Layout<'_>,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -32,8 +32,6 @@ where
 }
 
 /// The local state of a [`PickList`].
-///
-/// [`PickList`]: struct.PickList.html
 #[derive(Debug, Clone)]
 pub struct State<T> {
     menu: menu::State,
@@ -62,9 +60,6 @@ where
     /// Creates a new [`PickList`] with the given [`State`], a list of options,
     /// the current selected value, and the message to produce when an option is
     /// selected.
-    ///
-    /// [`PickList`]: struct.PickList.html
-    /// [`State`]: struct.State.html
     pub fn new(
         state: &'a mut State<T>,
         options: impl Into<Cow<'a, [T]>>,
@@ -95,40 +90,30 @@ where
     }
 
     /// Sets the width of the [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the padding of the [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     pub fn padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
     /// Sets the text size of the [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     pub fn text_size(mut self, size: u16) -> Self {
         self.text_size = Some(size);
         self
     }
 
     /// Sets the font of the [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = font;
         self
     }
 
     /// Sets the style of the [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     pub fn style(
         mut self,
         style: impl Into<<Renderer as self::Renderer>::Style>,
@@ -318,30 +303,20 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`PickList`] in your user interface.
 ///
-/// [`PickList`]: struct.PickList.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: text::Renderer + menu::Renderer {
     /// The default padding of a [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     const DEFAULT_PADDING: u16;
 
     /// The [`PickList`] style supported by this renderer.
-    ///
-    /// [`PickList`]: struct.PickList.html
     type Style: Default;
 
     /// Returns the style of the [`Menu`] of the [`PickList`].
-    ///
-    /// [`Menu`]: ../../overlay/menu/struct.Menu.html
-    /// [`PickList`]: struct.PickList.html
     fn menu_style(
         style: &<Self as Renderer>::Style,
     ) -> <Self as menu::Renderer>::Style;
 
     /// Draws a [`PickList`].
-    ///
-    /// [`PickList`]: struct.PickList.html
     fn draw(
         &mut self,
         bounds: Rectangle,

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -33,8 +33,6 @@ impl<Renderer: self::Renderer> ProgressBar<Renderer> {
     /// It expects:
     ///   * an inclusive range of possible values
     ///   * the current value of the [`ProgressBar`]
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn new(range: RangeInclusive<f32>, value: f32) -> Self {
         ProgressBar {
             value: value.max(*range.start()).min(*range.end()),
@@ -46,24 +44,18 @@ impl<Renderer: self::Renderer> ProgressBar<Renderer> {
     }
 
     /// Sets the width of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = Some(height);
         self
     }
 
     /// Sets the style of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -128,15 +120,12 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`ProgressBar`] in your user interface.
 ///
-/// [`ProgressBar`]: struct.ProgressBar.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// The default height of a [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     const DEFAULT_HEIGHT: u16;
 
     /// Draws a [`ProgressBar`].
@@ -147,8 +136,6 @@ pub trait Renderer: crate::Renderer {
     ///   * the current value of the [`ProgressBar`]
     ///   * maybe a specific background of the [`ProgressBar`]
     ///   * maybe a specific active color of the [`ProgressBar`]
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     fn draw(
         &self,
         bounds: Rectangle,

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -62,8 +62,6 @@ where
     ///   * the current selected value
     ///   * a function that will be called when the [`Radio`] is selected. It
     ///   receives the value of the radio and must produce a `Message`.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn new<F, V>(
         value: V,
         label: impl Into<String>,
@@ -87,40 +85,30 @@ where
     }
 
     /// Sets the size of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = size;
         self
     }
 
     /// Sets the width of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the spacing between the [`Radio`] button and the text.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn spacing(mut self, spacing: u16) -> Self {
         self.spacing = spacing;
         self
     }
 
     /// Sets the text size of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn text_size(mut self, text_size: u16) -> Self {
         self.text_size = Some(text_size);
         self
     }
 
     /// Sets the style of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -237,20 +225,15 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Radio`] button in your user interface.
 ///
-/// [`Radio`]: struct.Radio.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// The default size of a [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     const DEFAULT_SIZE: u16;
 
     /// The default spacing of a [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     const DEFAULT_SPACING: u16;
 
     /// Draws a [`Radio`] button.
@@ -260,8 +243,6 @@ pub trait Renderer: crate::Renderer {
     ///   * whether the [`Radio`] is selected or not
     ///   * whether the mouse is over the [`Radio`] or not
     ///   * the drawn label of the [`Radio`]
-    ///
-    /// [`Radio`]: struct.Radio.html
     fn draw(
         &mut self,
         bounds: Rectangle,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -24,15 +24,11 @@ pub struct Row<'a, Message, Renderer> {
 
 impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
     /// Creates an empty [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn new() -> Self {
         Self::with_children(Vec::new())
     }
 
     /// Creates a [`Row`] with the given elements.
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn with_children(
         children: Vec<Element<'a, Message, Renderer>>,
     ) -> Self {
@@ -59,57 +55,42 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
     }
 
     /// Sets the padding of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the vertical alignment of the contents of the [`Row`] .
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn align_items(mut self, align: Align) -> Self {
         self.align_items = align;
         self
     }
 
     /// Adds an [`Element`] to the [`Row`].
-    ///
-    /// [`Element`]: ../struct.Element.html
-    /// [`Row`]: struct.Row.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message, Renderer>>,
@@ -230,8 +211,7 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Row`] in your user interface.
 ///
-/// [`Row`]: struct.Row.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer + Sized {
     /// Draws a [`Row`].
     ///
@@ -239,9 +219,6 @@ pub trait Renderer: crate::Renderer + Sized {
     /// - the children of the [`Row`]
     /// - the [`Layout`] of the [`Row`] and its children
     /// - the cursor position
-    ///
-    /// [`Row`]: struct.Row.html
-    /// [`Layout`]: ../layout/struct.Layout.html
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -17,8 +17,6 @@ pub struct Rule<Renderer: self::Renderer> {
 
 impl<Renderer: self::Renderer> Rule<Renderer> {
     /// Creates a horizontal [`Rule`] for dividing content by the given vertical spacing.
-    ///
-    /// [`Rule`]: struct.Rule.html
     pub fn horizontal(spacing: u16) -> Self {
         Rule {
             width: Length::Fill,
@@ -29,8 +27,6 @@ impl<Renderer: self::Renderer> Rule<Renderer> {
     }
 
     /// Creates a vertical [`Rule`] for dividing content by the given horizontal spacing.
-    ///
-    /// [`Rule`]: struct.Rule.html
     pub fn vertical(spacing: u16) -> Self {
         Rule {
             width: Length::from(Length::Units(spacing)),
@@ -41,8 +37,6 @@ impl<Renderer: self::Renderer> Rule<Renderer> {
     }
 
     /// Sets the style of the [`Rule`].
-    ///
-    /// [`Rule`]: struct.Rule.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
@@ -92,8 +86,6 @@ where
 }
 
 /// The renderer of a [`Rule`].
-///
-/// [`Rule`]: struct.Rule.html
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
@@ -104,8 +96,6 @@ pub trait Renderer: crate::Renderer {
     ///   * the bounds of the [`Rule`]
     ///   * the style of the [`Rule`]
     ///   * whether the [`Rule`] is horizontal (true) or vertical (false)
-    ///
-    /// [`Rule`]: struct.Rule.html
     fn draw(
         &mut self,
         bounds: Rectangle,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -27,9 +27,6 @@ pub struct Scrollable<'a, Message, Renderer: self::Renderer> {
 
 impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
     /// Creates a new [`Scrollable`] with the given [`State`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     pub fn new(state: &'a mut State) -> Self {
         Scrollable {
             state,
@@ -54,48 +51,36 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
     }
 
     /// Sets the padding of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn padding(mut self, units: u16) -> Self {
         self.content = self.content.padding(units);
         self
     }
 
     /// Sets the width of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn width(mut self, width: Length) -> Self {
         self.content = self.content.width(width);
         self
     }
 
     /// Sets the height of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.content = self.content.max_width(max_width);
         self
     }
 
     /// Sets the maximum height of the [`Scrollable`] in pixels.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the horizontal alignment of the contents of the [`Scrollable`] .
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn align_items(mut self, align_items: Align) -> Self {
         self.content = self.content.align_items(align_items);
         self
@@ -103,16 +88,12 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
 
     /// Sets the scrollbar width of the [`Scrollable`] .
     /// Silently enforces a minimum value of 1.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn scrollbar_width(mut self, scrollbar_width: u16) -> Self {
         self.scrollbar_width = scrollbar_width.max(1);
         self
     }
 
     /// Sets the scrollbar margin of the [`Scrollable`] .
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn scrollbar_margin(mut self, scrollbar_margin: u16) -> Self {
         self.scrollbar_margin = scrollbar_margin;
         self
@@ -120,24 +101,18 @@ impl<'a, Message, Renderer: self::Renderer> Scrollable<'a, Message, Renderer> {
 
     /// Sets the scroller width of the [`Scrollable`] .
     /// Silently enforces a minimum value of 1.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn scroller_width(mut self, scroller_width: u16) -> Self {
         self.scroller_width = scroller_width.max(1);
         self
     }
 
     /// Sets the style of the [`Scrollable`] .
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Adds an element to the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message, Renderer>>,
@@ -407,8 +382,6 @@ where
 }
 
 /// The local state of a [`Scrollable`].
-///
-/// [`Scrollable`]: struct.Scrollable.html
 #[derive(Debug, Clone, Copy, Default)]
 pub struct State {
     scroller_grabbed_at: Option<f32>,
@@ -417,17 +390,12 @@ pub struct State {
 
 impl State {
     /// Creates a new [`State`] with the scrollbar located at the top.
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         State::default()
     }
 
     /// Apply a scrolling offset to the current [`State`], given the bounds of
     /// the [`Scrollable`] and its contents.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     pub fn scroll(
         &mut self,
         delta_y: f32,
@@ -448,9 +416,6 @@ impl State {
     ///
     /// `0` represents scrollbar at the top, while `1` represents scrollbar at
     /// the bottom.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     pub fn scroll_to(
         &mut self,
         percentage: f32,
@@ -463,9 +428,6 @@ impl State {
 
     /// Returns the current scrolling offset of the [`State`], given the bounds
     /// of the [`Scrollable`] and its contents.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     pub fn offset(&self, bounds: Rectangle, content_bounds: Rectangle) -> u32 {
         let hidden_content =
             (content_bounds.height - bounds.height).max(0.0).round() as u32;
@@ -480,30 +442,19 @@ impl State {
 }
 
 /// The scrollbar of a [`Scrollable`].
-///
-/// [`Scrollable`]: struct.Scrollable.html
 #[derive(Debug)]
 pub struct Scrollbar {
     /// The outer bounds of the scrollable, including the [`Scrollbar`] and
     /// [`Scroller`].
-    ///
-    /// [`Scrollbar`]: struct.Scrollbar.html
-    /// [`Scroller`]: struct.Scroller.html
     pub outer_bounds: Rectangle,
 
     /// The bounds of the [`Scrollbar`].
-    ///
-    /// [`Scrollbar`]: struct.Scrollbar.html
     pub bounds: Rectangle,
 
     /// The margin within the [`Scrollbar`].
-    ///
-    /// [`Scrollbar`]: struct.Scrollbar.html
     pub margin: u16,
 
     /// The bounds of the [`Scroller`].
-    ///
-    /// [`Scroller`]: struct.Scroller.html
     pub scroller: Scroller,
 }
 
@@ -538,13 +489,9 @@ impl Scrollbar {
 }
 
 /// The handle of a [`Scrollbar`].
-///
-/// [`Scrollbar`]: struct.Scrollbar.html
 #[derive(Debug, Clone, Copy)]
 pub struct Scroller {
     /// The bounds of the [`Scroller`].
-    ///
-    /// [`Scroller`]: struct.Scrollbar.html
     pub bounds: Rectangle,
 }
 
@@ -553,17 +500,13 @@ pub struct Scroller {
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Scrollable`] in your user interface.
 ///
-/// [`Scrollable`]: struct.Scrollable.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: column::Renderer + Sized {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// Returns the [`Scrollbar`] given the bounds and content bounds of a
     /// [`Scrollable`].
-    ///
-    /// [`Scrollbar`]: struct.Scrollbar.html
-    /// [`Scrollable`]: struct.Scrollable.html
     fn scrollbar(
         &self,
         bounds: Rectangle,
@@ -585,10 +528,6 @@ pub trait Renderer: column::Renderer + Sized {
     /// - a optional [`Scrollbar`] to be rendered
     /// - the scrolling offset
     /// - the drawn content
-    ///
-    /// [`Scrollbar`]: struct.Scrollbar.html
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     fn draw(
         &mut self,
         scrollable: &State,

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -1,9 +1,6 @@
 //! Display an interactive selector of a single value from a range of values.
 //!
 //! A [`Slider`] has some local [`State`].
-//!
-//! [`Slider`]: struct.Slider.html
-//! [`State`]: struct.State.html
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
@@ -20,8 +17,6 @@ use std::{hash::Hash, ops::RangeInclusive};
 ///
 /// The [`Slider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
-///
-/// [`Slider`]: struct.Slider.html
 ///
 /// # Example
 /// ```
@@ -68,9 +63,6 @@ where
     ///   * a function that will be called when the [`Slider`] is dragged.
     ///   It receives the new value of the [`Slider`] and must produce a
     ///   `Message`.
-    ///
-    /// [`Slider`]: struct.Slider.html
-    /// [`State`]: struct.State.html
     pub fn new<F>(
         state: &'a mut State,
         range: RangeInclusive<T>,
@@ -111,40 +103,30 @@ where
     /// Typically, the user's interaction with the slider is finished when this message is produced.
     /// This is useful if you need to spawn a long-running task from the slider's result, where
     /// the default on_change message could create too many events.
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn on_release(mut self, on_release: Message) -> Self {
         self.on_release = Some(on_release);
         self
     }
 
     /// Sets the width of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn height(mut self, height: u16) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the style of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Sets the step size of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn step(mut self, step: T) -> Self {
         self.step = step;
         self
@@ -152,8 +134,6 @@ where
 }
 
 /// The local state of a [`Slider`].
-///
-/// [`Slider`]: struct.Slider.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State {
     is_dragging: bool,
@@ -161,8 +141,6 @@ pub struct State {
 
 impl State {
     /// Creates a new [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> State {
         State::default()
     }
@@ -297,15 +275,12 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`Slider`] in your user interface.
 ///
-/// [`Slider`]: struct.Slider.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// The default height of a [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     const DEFAULT_HEIGHT: u16;
 
     /// Draws a [`Slider`].
@@ -316,10 +291,6 @@ pub trait Renderer: crate::Renderer {
     ///   * the local state of the [`Slider`]
     ///   * the range of values of the [`Slider`]
     ///   * the current value of the [`Slider`]
-    ///
-    /// [`Slider`]: struct.Slider.html
-    /// [`State`]: struct.State.html
-    /// [`Class`]: enum.Class.html
     fn draw(
         &mut self,
         bounds: Rectangle,

--- a/native/src/widget/space.rs
+++ b/native/src/widget/space.rs
@@ -16,15 +16,11 @@ pub struct Space {
 
 impl Space {
     /// Creates an amount of empty [`Space`] with the given width and height.
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn new(width: Length, height: Length) -> Self {
         Space { width, height }
     }
 
     /// Creates an amount of horizontal [`Space`].
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn with_width(width: Length) -> Self {
         Space {
             width,
@@ -33,8 +29,6 @@ impl Space {
     }
 
     /// Creates an amount of vertical [`Space`].
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn with_height(height: Length) -> Self {
         Space {
             width: Length::Shrink,
@@ -85,14 +79,10 @@ where
 }
 
 /// The renderer of an amount of [`Space`].
-///
-/// [`Space`]: struct.Space.html
 pub trait Renderer: crate::Renderer {
     /// Draws an amount of empty [`Space`].
     ///
     /// You should most likely return an empty primitive here.
-    ///
-    /// [`Space`]: struct.Space.html
     fn draw(&mut self, bounds: Rectangle) -> Self::Output;
 }
 

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -14,8 +14,6 @@ use std::{
 ///
 /// [`Svg`] images can have a considerable rendering cost when resized,
 /// specially when they are complex.
-///
-/// [`Svg`]: struct.Svg.html
 #[derive(Debug, Clone)]
 pub struct Svg {
     handle: Handle,
@@ -25,9 +23,6 @@ pub struct Svg {
 
 impl Svg {
     /// Creates a new [`Svg`] from the given [`Handle`].
-    ///
-    /// [`Svg`]: struct.Svg.html
-    /// [`Handle`]: struct.Handle.html
     pub fn new(handle: impl Into<Handle>) -> Self {
         Svg {
             handle: handle.into(),
@@ -38,23 +33,17 @@ impl Svg {
 
     /// Creates a new [`Svg`] that will display the contents of the file at the
     /// provided path.
-    ///
-    /// [`Svg`]: struct.Svg.html
     pub fn from_path(path: impl Into<PathBuf>) -> Self {
         Self::new(Handle::from_path(path))
     }
 
     /// Sets the width of the [`Svg`].
-    ///
-    /// [`Svg`]: struct.Svg.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Svg`].
-    ///
-    /// [`Svg`]: struct.Svg.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
@@ -119,8 +108,6 @@ where
 }
 
 /// An [`Svg`] handle.
-///
-/// [`Svg`]: struct.Svg.html
 #[derive(Debug, Clone)]
 pub struct Handle {
     id: u64,
@@ -130,8 +117,6 @@ pub struct Handle {
 impl Handle {
     /// Creates an SVG [`Handle`] pointing to the vector image of the given
     /// path.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_path(path: impl Into<PathBuf>) -> Handle {
         Self::from_data(Data::Path(path.into()))
     }
@@ -141,8 +126,6 @@ impl Handle {
     ///
     /// This is useful if you already have your SVG data in-memory, maybe
     /// because you downloaded or generated it procedurally.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_memory(bytes: impl Into<Vec<u8>>) -> Handle {
         Self::from_data(Data::Bytes(bytes.into()))
     }
@@ -158,15 +141,11 @@ impl Handle {
     }
 
     /// Returns the unique identifier of the [`Handle`].
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn id(&self) -> u64 {
         self.id
     }
 
     /// Returns a reference to the SVG [`Data`].
-    ///
-    /// [`Data`]: enum.Data.html
     pub fn data(&self) -> &Data {
         &self.data
     }
@@ -179,8 +158,6 @@ impl Hash for Handle {
 }
 
 /// The data of an [`Svg`].
-///
-/// [`Svg`]: struct.Svg.html
 #[derive(Clone, Hash)]
 pub enum Data {
     /// File data
@@ -206,18 +183,12 @@ impl std::fmt::Debug for Data {
 /// Your [renderer] will need to implement this trait before being able to use
 /// an [`Svg`] in your user interface.
 ///
-/// [`Svg`]: struct.Svg.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// Returns the default dimensions of an [`Svg`] for the given [`Handle`].
-    ///
-    /// [`Svg`]: struct.Svg.html
-    /// [`Handle`]: struct.Handle.html
     fn dimensions(&self, handle: &Handle) -> (u32, u32);
 
     /// Draws an [`Svg`].
-    ///
-    /// [`Svg`]: struct.Svg.html
     fn draw(&mut self, handle: Handle, layout: Layout<'_>) -> Self::Output;
 }
 

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -33,8 +33,6 @@ pub struct Text<Renderer: self::Renderer> {
 
 impl<Renderer: self::Renderer> Text<Renderer> {
     /// Create a new fragment of [`Text`] with the given contents.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn new<T: Into<String>>(label: T) -> Self {
         Text {
             content: label.into(),
@@ -49,17 +47,12 @@ impl<Renderer: self::Renderer> Text<Renderer> {
     }
 
     /// Sets the size of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = Some(size);
         self
     }
 
     /// Sets the [`Color`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`Color`]: ../../struct.Color.html
     pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
         self.color = Some(color.into());
         self
@@ -67,33 +60,25 @@ impl<Renderer: self::Renderer> Text<Renderer> {
 
     /// Sets the [`Font`] of the [`Text`].
     ///
-    /// [`Text`]: struct.Text.html
-    /// [`Font`]: ../../struct.Font.html
+    /// [`Font`]: Renderer::Font
     pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
         self.font = font.into();
         self
     }
 
     /// Sets the width of the [`Text`] boundaries.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Text`] boundaries.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the [`HorizontalAlignment`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`HorizontalAlignment`]: enum.HorizontalAlignment.html
     pub fn horizontal_alignment(
         mut self,
         alignment: HorizontalAlignment,
@@ -103,9 +88,6 @@ impl<Renderer: self::Renderer> Text<Renderer> {
     }
 
     /// Sets the [`VerticalAlignment`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`VerticalAlignment`]: enum.VerticalAlignment.html
     pub fn vertical_alignment(mut self, alignment: VerticalAlignment) -> Self {
         self.vertical_alignment = alignment;
         self
@@ -177,26 +159,18 @@ where
 /// The renderer of a [`Text`] fragment.
 ///
 /// Your [renderer] will need to implement this trait before being
-/// able to use [`Text`] in your [`UserInterface`].
+/// able to use [`Text`] in your user interface.
 ///
-/// [`Text`]: struct.Text.html
-/// [renderer]: ../../renderer/index.html
-/// [`UserInterface`]: ../../struct.UserInterface.html
+/// [renderer]: crate::Renderer
 pub trait Renderer: crate::Renderer {
     /// The font type used for [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     type Font: Default + Copy;
 
     /// Returns the default size of [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     fn default_size(&self) -> u16;
 
     /// Measures the [`Text`] in the given bounds and returns the minimum
     /// boundaries that can fit the contents.
-    ///
-    /// [`Text`]: struct.Text.html
     fn measure(
         &self,
         content: &str,
@@ -214,10 +188,6 @@ pub trait Renderer: crate::Renderer {
     ///   * the color of the [`Text`]
     ///   * the [`HorizontalAlignment`] of the [`Text`]
     ///   * the [`VerticalAlignment`] of the [`Text`]
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`HorizontalAlignment`]: enum.HorizontalAlignment.html
-    /// [`VerticalAlignment`]: enum.VerticalAlignment.html
     fn draw(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -570,7 +570,7 @@ where
                         self.state.is_pasting = None;
 
                         self.state.keyboard_modifiers =
-                            keyboard::ModifiersState::default();
+                            keyboard::Modifiers::default();
                     }
                     _ => {}
                 }
@@ -734,7 +734,7 @@ pub struct State {
     is_pasting: Option<Value>,
     last_click: Option<mouse::Click>,
     cursor: Cursor,
-    keyboard_modifiers: keyboard::ModifiersState,
+    keyboard_modifiers: keyboard::Modifiers,
     // TODO: Add stateful horizontal scrolling offset
 }
 
@@ -756,7 +756,7 @@ impl State {
             is_pasting: None,
             last_click: None,
             cursor: Cursor::default(),
-            keyboard_modifiers: keyboard::ModifiersState::default(),
+            keyboard_modifiers: keyboard::Modifiers::default(),
         }
     }
 
@@ -873,9 +873,7 @@ fn find_cursor_position<Renderer: self::Renderer>(
 mod platform {
     use crate::keyboard;
 
-    pub fn is_jump_modifier_pressed(
-        modifiers: keyboard::ModifiersState,
-    ) -> bool {
+    pub fn is_jump_modifier_pressed(modifiers: keyboard::Modifiers) -> bool {
         if cfg!(target_os = "macos") {
             modifiers.alt
         } else {

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -1,9 +1,6 @@
 //! Display fields that can be filled with text.
 //!
 //! A [`TextInput`] has some local [`State`].
-//!
-//! [`TextInput`]: struct.TextInput.html
-//! [`State`]: struct.State.html
 mod editor;
 mod value;
 
@@ -77,9 +74,6 @@ where
     /// - a placeholder
     /// - the current value
     /// - a function that produces a message when the [`TextInput`] changes
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`State`]: struct.State.html
     pub fn new<F>(
         state: &'a mut State,
         placeholder: &str,
@@ -106,8 +100,6 @@ where
     }
 
     /// Converts the [`TextInput`] into a secure password input.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn password(mut self) -> Self {
         self.is_secure = true;
         self
@@ -115,39 +107,31 @@ where
 
     /// Sets the [`Font`] of the [`Text`].
     ///
-    /// [`Text`]: struct.Text.html
-    /// [`Font`]: ../../struct.Font.html
+    /// [`Font`]: crate::widget::text::Renderer::Font
+    /// [`Text`]: crate::widget::Text
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = font;
         self
     }
     /// Sets the width of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the maximum width of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the padding of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the text size of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = Some(size);
         self
@@ -155,26 +139,18 @@ where
 
     /// Sets the message that should be produced when the [`TextInput`] is
     /// focused and the enter key is pressed.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn on_submit(mut self, message: Message) -> Self {
         self.on_submit = Some(message);
         self
     }
 
     /// Sets the style of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`State`]: struct.State.html
     pub fn style(mut self, style: impl Into<Renderer::Style>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Returns the current [`State`] of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`State`]: struct.State.html
     pub fn state(&self) -> &State {
         self.state
     }
@@ -186,10 +162,6 @@ where
 {
     /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
     /// [`Value`] if provided.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`Renderer`]: trait.Render.html
-    /// [`Value`]: struct.Value.html
     pub fn draw(
         &self,
         renderer: &mut Renderer,
@@ -628,15 +600,12 @@ where
 /// Your [renderer] will need to implement this trait before being
 /// able to use a [`TextInput`] in your user interface.
 ///
-/// [`TextInput`]: struct.TextInput.html
-/// [renderer]: ../../renderer/index.html
+/// [renderer]: crate::renderer
 pub trait Renderer: text::Renderer + Sized {
     /// The style supported by this renderer.
     type Style: Default;
 
     /// Returns the width of the value of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     fn measure_value(&self, value: &str, size: u16, font: Self::Font) -> f32;
 
     /// Returns the current horizontal offset of the value of the
@@ -644,9 +613,6 @@ pub trait Renderer: text::Renderer + Sized {
     ///
     /// This is the amount of horizontal scrolling applied when the [`Value`]
     /// does not fit the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`Value`]: struct.Value.html
     fn offset(
         &self,
         text_bounds: Rectangle,
@@ -665,10 +631,6 @@ pub trait Renderer: text::Renderer + Sized {
     /// - the placeholder to show when the value is empty
     /// - the current [`Value`]
     /// - the current [`State`]
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`Value`]: struct.Value.html
-    /// [`State`]: struct.State.html
     fn draw(
         &mut self,
         bounds: Rectangle,
@@ -684,8 +646,6 @@ pub trait Renderer: text::Renderer + Sized {
 
     /// Computes the position of the text cursor at the given X coordinate of
     /// a [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     fn find_cursor_position(
         &self,
         text_bounds: Rectangle,
@@ -725,8 +685,6 @@ where
 }
 
 /// The state of a [`TextInput`].
-///
-/// [`TextInput`]: struct.TextInput.html
 #[derive(Debug, Default, Clone)]
 pub struct State {
     is_focused: bool,
@@ -740,15 +698,11 @@ pub struct State {
 
 impl State {
     /// Creates a new [`State`], representing an unfocused [`TextInput`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a new [`State`], representing a focused [`TextInput`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn focused() -> Self {
         Self {
             is_focused: true,
@@ -761,54 +715,36 @@ impl State {
     }
 
     /// Returns whether the [`TextInput`] is currently focused or not.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn is_focused(&self) -> bool {
         self.is_focused
     }
 
     /// Returns the [`Cursor`] of the [`TextInput`].
-    ///
-    /// [`Cursor`]: struct.Cursor.html
-    /// [`TextInput`]: struct.TextInput.html
     pub fn cursor(&self) -> Cursor {
         self.cursor
     }
 
     /// Focuses the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn focus(&mut self) {
         self.is_focused = true;
     }
 
     /// Unfocuses the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn unfocus(&mut self) {
         self.is_focused = false;
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to the front of the input text.
-    ///
-    /// [`Cursor`]: struct.Cursor.html
-    /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to_front(&mut self) {
         self.cursor.move_to(0);
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to the end of the input text.
-    ///
-    /// [`Cursor`]: struct.Cursor.html
-    /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to_end(&mut self) {
         self.cursor.move_to(usize::MAX);
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to an arbitrary location.
-    ///
-    /// [`Cursor`]: struct.Cursor.html
-    /// [`TextInput`]: struct.TextInput.html
     pub fn move_cursor_to(&mut self, position: usize) {
         self.cursor.move_to(position);
     }

--- a/native/src/widget/text_input/cursor.rs
+++ b/native/src/widget/text_input/cursor.rs
@@ -8,8 +8,6 @@ pub struct Cursor {
 }
 
 /// The state of a [`Cursor`].
-///
-/// [`Cursor`]: struct.Cursor.html
 #[derive(Debug, Copy, Clone)]
 pub enum State {
     /// Cursor without a selection
@@ -34,9 +32,6 @@ impl Default for Cursor {
 
 impl Cursor {
     /// Returns the [`State`] of the [`Cursor`].
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Cursor`]: struct.Cursor.html
     pub fn state(&self, value: &Value) -> State {
         match self.state {
             State::Index(index) => State::Index(index.min(value.len())),

--- a/native/src/widget/text_input/value.rs
+++ b/native/src/widget/text_input/value.rs
@@ -2,7 +2,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 /// The value of a [`TextInput`].
 ///
-/// [`TextInput`]: struct.TextInput.html
+/// [`TextInput`]: crate::widget::TextInput
 // TODO: Reduce allocations, cache results (?)
 #[derive(Debug, Clone)]
 pub struct Value {
@@ -11,8 +11,6 @@ pub struct Value {
 
 impl Value {
     /// Creates a new [`Value`] from a string slice.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn new(string: &str) -> Self {
         let graphemes = UnicodeSegmentation::graphemes(string, true)
             .map(String::from)
@@ -24,23 +22,17 @@ impl Value {
     /// Returns whether the [`Value`] is empty or not.
     ///
     /// A [`Value`] is empty when it contains no graphemes.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the total amount of graphemes in the [`Value`].
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn len(&self) -> usize {
         self.graphemes.len()
     }
 
     /// Returns the position of the previous start of a word from the given
     /// grapheme `index`.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn previous_start_of_word(&self, index: usize) -> usize {
         let previous_string =
             &self.graphemes[..index.min(self.graphemes.len())].concat();
@@ -63,8 +55,6 @@ impl Value {
 
     /// Returns the position of the next end of a word from the given grapheme
     /// `index`.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn next_end_of_word(&self, index: usize) -> usize {
         let next_string = &self.graphemes[index..].concat();
 
@@ -85,8 +75,6 @@ impl Value {
 
     /// Returns a new [`Value`] containing the graphemes until the given
     /// `index`.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn until(&self, index: usize) -> Self {
         let graphemes = self.graphemes[..index.min(self.len())].to_vec();
 
@@ -94,8 +82,6 @@ impl Value {
     }
 
     /// Converts the [`Value`] into a `String`.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn to_string(&self) -> String {
         self.graphemes.concat()
     }
@@ -118,8 +104,6 @@ impl Value {
     }
 
     /// Removes the grapheme at the given `index`.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn remove(&mut self, index: usize) {
         let _ = self.graphemes.remove(index);
     }
@@ -131,8 +115,6 @@ impl Value {
 
     /// Returns a new [`Value`] with all its graphemes replaced with the
     /// dot ('•') character.
-    ///
-    /// [`Value`]: struct.Value.html
     pub fn secure(&self) -> Self {
         Self {
             graphemes: std::iter::repeat(String::from("•"))

--- a/src/application.rs
+++ b/src/application.rs
@@ -11,14 +11,12 @@ use crate::{Color, Command, Element, Executor, Settings, Subscription};
 ///   document.
 ///
 /// An [`Application`] can execute asynchronous actions by returning a
-/// [`Command`](struct.Command.html) in some of its methods. If
-/// you do not intend to perform any background work in your program, the
-/// [`Sandbox`](trait.Sandbox.html) trait offers a simplified interface.
+/// [`Command`] in some of its methods. If you do not intend to perform any
+/// background work in your program, the [`Sandbox`] trait offers a simplified
+/// interface.
 ///
 /// When using an [`Application`] with the `debug` feature enabled, a debug view
 /// can be toggled by pressing `F12`.
-///
-/// [`Application`]: trait.Application.html
 ///
 /// # Examples
 /// [The repository has a bunch of examples] that use the [`Application`] trait:
@@ -45,9 +43,9 @@ use crate::{Color, Command, Element, Executor, Settings, Subscription};
 /// [`solar_system`]: https://github.com/hecrj/iced/tree/0.1/examples/solar_system
 /// [`stopwatch`]: https://github.com/hecrj/iced/tree/0.1/examples/stopwatch
 /// [`todos`]: https://github.com/hecrj/iced/tree/0.1/examples/todos
-/// [`Canvas`]: widget/canvas/struct.Canvas.html
+/// [`Sandbox`]: crate::Sandbox
+/// [`Canvas`]: crate::widget::Canvas
 /// [PokéAPI]: https://pokeapi.co/
-/// [`Subscription`]: type.Subscription.html
 /// [TodoMVC]: http://todomvc.com/
 ///
 /// ## A simple "Hello, world!"
@@ -91,18 +89,14 @@ pub trait Application: Sized {
     ///
     /// The [default executor] can be a good starting point!
     ///
-    /// [`Executor`]: trait.Executor.html
-    /// [default executor]: executor/struct.Default.html
+    /// [`Executor`]: Self::Executor
+    /// [default executor]: crate::executor::Default
     type Executor: Executor;
 
     /// The type of __messages__ your [`Application`] will produce.
-    ///
-    /// [`Application`]: trait.Application.html
     type Message: std::fmt::Debug + Send;
 
     /// The data needed to initialize your [`Application`].
-    ///
-    /// [`Application`]: trait.Application.html
     type Flags;
 
     /// Initializes the [`Application`] with the flags provided to
@@ -110,22 +104,17 @@ pub trait Application: Sized {
     ///
     /// Here is where you should return the initial state of your app.
     ///
-    /// Additionally, you can return a [`Command`](struct.Command.html) if you
-    /// need to perform some async action in the background on startup. This is
-    /// useful if you want to load state from a file, perform an initial HTTP
-    /// request, etc.
+    /// Additionally, you can return a [`Command`] if you need to perform some
+    /// async action in the background on startup. This is useful if you want to
+    /// load state from a file, perform an initial HTTP request, etc.
     ///
-    /// [`Application`]: trait.Application.html
-    /// [`run`]: #method.run.html
-    /// [`Settings`]: struct.Settings.html
+    /// [`run`]: Self::run
     fn new(flags: Self::Flags) -> (Self, Command<Self::Message>);
 
     /// Returns the current title of the [`Application`].
     ///
     /// This title can be dynamic! The runtime will automatically update the
     /// title of your application when necessary.
-    ///
-    /// [`Application`]: trait.Application.html
     fn title(&self) -> String;
 
     /// Handles a __message__ and updates the state of the [`Application`].
@@ -135,9 +124,6 @@ pub trait Application: Sized {
     /// this method.
     ///
     /// Any [`Command`] returned will be executed immediately in the background.
-    ///
-    /// [`Application`]: trait.Application.html
-    /// [`Command`]: struct.Command.html
     fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
 
     /// Returns the event [`Subscription`] for the current state of the
@@ -148,8 +134,6 @@ pub trait Application: Sized {
     /// [`update`](#tymethod.update).
     ///
     /// By default, this method returns an empty [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     fn subscription(&self) -> Subscription<Self::Message> {
         Subscription::none()
     }
@@ -157,8 +141,6 @@ pub trait Application: Sized {
     /// Returns the widgets to display in the [`Application`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    ///
-    /// [`Application`]: trait.Application.html
     fn view(&mut self) -> Element<'_, Self::Message>;
 
     /// Returns the current [`Application`] mode.
@@ -169,8 +151,6 @@ pub trait Application: Sized {
     /// Currently, the mode only has an effect in native platforms.
     ///
     /// By default, an application will run in windowed mode.
-    ///
-    /// [`Application`]: trait.Application.html
     fn mode(&self) -> window::Mode {
         window::Mode::Windowed
     }
@@ -178,9 +158,6 @@ pub trait Application: Sized {
     /// Returns the background color of the [`Application`].
     ///
     /// By default, it returns [`Color::WHITE`].
-    ///
-    /// [`Application`]: trait.Application.html
-    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
     fn background_color(&self) -> Color {
         Color::WHITE
     }
@@ -194,8 +171,6 @@ pub trait Application: Sized {
     /// while a scale factor of `0.5` will shrink them to half their size.
     ///
     /// By default, it returns `1.0`.
-    ///
-    /// [`Application`]: trait.Application.html
     fn scale_factor(&self) -> f64 {
         1.0
     }
@@ -207,8 +182,7 @@ pub trait Application: Sized {
     ///
     /// It should probably be that last thing you call in your `main` function.
     ///
-    /// [`Application`]: trait.Application.html
-    /// [`Error`]: enum.Error.html
+    /// [`Error`]: crate::Error
     fn run(settings: Settings<Self::Flags>) -> crate::Result
     where
         Self: 'static,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,2 +1,2 @@
 //! Listen and react to keyboard events.
-pub use crate::runtime::keyboard::{Event, KeyCode, ModifiersState};
+pub use crate::runtime::keyboard::{Event, KeyCode, Modifiers};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,6 @@
 //!
 //! [Elm]: https://elm-lang.org/
 //! [The Elm Architecture]: https://guide.elm-lang.org/architecture/
-//! [`Application`]: trait.Application.html
-//! [`Sandbox`]: trait.Sandbox.html
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]

--- a/src/result.rs
+++ b/src/result.rs
@@ -2,5 +2,5 @@ use crate::Error;
 
 /// The result of running an [`Application`].
 ///
-/// [`Application`]: trait.Application.html
+/// [`Application`]: crate::Application
 pub type Result = std::result::Result<(), Error>;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -14,11 +14,6 @@ use crate::{
 /// Therefore, it is recommended to always start by implementing this trait and
 /// upgrade only once necessary.
 ///
-/// [`Application`]: trait.Application.html
-/// [`Sandbox`]: trait.Sandbox.html
-/// [`Command`]: struct.Command.html
-/// [`Command::none`]: struct.Command.html#method.none
-///
 /// # Examples
 /// [The repository has a bunch of examples] that use the [`Sandbox`] trait:
 ///
@@ -53,7 +48,7 @@ use crate::{
 /// [`lyon`]: https://github.com/nical/lyon
 /// [the overview]: index.html#overview
 /// [`iced_wgpu`]: https://github.com/hecrj/iced/tree/0.1/wgpu
-/// [`Svg` widget]: widget/svg/struct.Svg.html
+/// [`Svg` widget]: crate::widget::Svg
 /// [Ghostscript Tiger]: https://commons.wikimedia.org/wiki/File:Ghostscript_Tiger.svg
 ///
 /// ## A simple "Hello, world!"
@@ -92,46 +87,33 @@ use crate::{
 /// ```
 pub trait Sandbox {
     /// The type of __messages__ your [`Sandbox`] will produce.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     type Message: std::fmt::Debug + Send;
 
     /// Initializes the [`Sandbox`].
     ///
     /// Here is where you should return the initial state of your app.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn new() -> Self;
 
     /// Returns the current title of the [`Sandbox`].
     ///
     /// This title can be dynamic! The runtime will automatically update the
     /// title of your application when necessary.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn title(&self) -> String;
 
     /// Handles a __message__ and updates the state of the [`Sandbox`].
     ///
     /// This is where you define your __update logic__. All the __messages__,
     /// produced by user interactions, will be handled by this method.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn update(&mut self, message: Self::Message);
 
     /// Returns the widgets to display in the [`Sandbox`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn view(&mut self) -> Element<'_, Self::Message>;
 
     /// Returns the background color of the [`Sandbox`].
     ///
     /// By default, it returns [`Color::WHITE`].
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
-    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
     fn background_color(&self) -> Color {
         Color::WHITE
     }
@@ -145,8 +127,6 @@ pub trait Sandbox {
     /// while a scale factor of `0.5` will shrink them to half their size.
     ///
     /// By default, it returns `1.0`.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn scale_factor(&self) -> f64 {
         1.0
     }
@@ -157,8 +137,6 @@ pub trait Sandbox {
     /// and __will NOT return__.
     ///
     /// It should probably be that last thing you call in your `main` function.
-    ///
-    /// [`Sandbox`]: trait.Sandbox.html
     fn run(settings: Settings<()>) -> Result<(), Error>
     where
         Self: 'static + Sized,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,13 +7,11 @@ pub struct Settings<Flags> {
     /// The window settings.
     ///
     /// They will be ignored on the Web.
-    ///
-    /// [`Window`]: struct.Window.html
     pub window: window::Settings,
 
     /// The data needed to initialize an [`Application`].
     ///
-    /// [`Application`]: ../trait.Application.html
+    /// [`Application`]: crate::Application
     pub flags: Flags,
 
     /// The bytes of the font that will be used by default.
@@ -35,14 +33,14 @@ pub struct Settings<Flags> {
     ///
     /// By default, it is disabled.
     ///
-    /// [`Canvas`]: ../widget/canvas/struct.Canvas.html
+    /// [`Canvas`]: crate::widget::Canvas
     pub antialiasing: bool,
 }
 
 impl<Flags> Settings<Flags> {
-    /// Initialize application settings using the given data.
+    /// Initialize [`Application`] settings using the given data.
     ///
-    /// [`Application`]: ../trait.Application.html
+    /// [`Application`]: crate::Application
     pub fn with_flags(flags: Flags) -> Self {
         let default_settings = Settings::<()>::default();
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,8 +5,6 @@ use crate::Subscription;
 ///
 /// The first message is produced after a `duration`, and then continues to
 /// produce more messages every `duration` after that.
-///
-/// [`Subscription`]: ../subscription/struct.Subscription.html
 pub fn every(
     duration: std::time::Duration,
 ) -> Subscription<std::time::Instant> {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -13,9 +13,6 @@
 //!
 //! These widgets have their own module with a `State` type. For instance, a
 //! [`TextInput`] has some [`text_input::State`].
-//!
-//! [`TextInput`]: text_input/struct.TextInput.html
-//! [`text_input::State`]: text_input/struct.State.html
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
     pub use crate::renderer::widget::{

--- a/style/src/rule.rs
+++ b/style/src/rule.rs
@@ -76,8 +76,6 @@ pub struct Style {
     /// The radius of the line corners.
     pub radius: f32,
     /// The [`FillMode`] of the rule.
-    ///
-    /// [`FillMode`]: enum.FillMode.html
     pub fill_mode: FillMode,
 }
 

--- a/web/src/bus.rs
+++ b/web/src/bus.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 ///
 /// It can be used to route messages back to the [`Application`].
 ///
-/// [`Application`]: trait.Application.html
+/// [`Application`]: crate::Application
 #[allow(missing_debug_implementations)]
 pub struct Bus<Message> {
     publish: Rc<Box<dyn Fn(Message) -> ()>>,
@@ -33,15 +33,13 @@ where
 
     /// Publishes a new message for the [`Application`].
     ///
-    /// [`Application`]: trait.Application.html
+    /// [`Application`]: crate::Application
     pub fn publish(&self, message: Message) {
         (self.publish)(message)
     }
 
     /// Creates a new [`Bus`] that applies the given function to the messages
     /// before publishing.
-    ///
-    /// [`Bus`]: struct.Bus.html
     pub fn map<B>(&self, mapper: Rc<Box<dyn Fn(B) -> Message>>) -> Bus<B>
     where
         B: 'static,

--- a/web/src/css.rs
+++ b/web/src/css.rs
@@ -20,9 +20,7 @@ pub enum Rule {
 }
 
 impl Rule {
-    /// Returns the class name of the [`Style`].
-    ///
-    /// [`Style`]: enum.Style.html
+    /// Returns the class name of the [`Rule`].
     pub fn class<'a>(&self) -> String {
         match self {
             Rule::Column => String::from("c"),
@@ -32,9 +30,7 @@ impl Rule {
         }
     }
 
-    /// Returns the declaration of the [`Style`].
-    ///
-    /// [`Style`]: enum.Style.html
+    /// Returns the declaration of the [`Rule`].
     pub fn declaration<'a>(&self, bump: &'a bumpalo::Bump) -> &'a str {
         let class = self.class();
 
@@ -81,22 +77,17 @@ pub struct Css<'a> {
 }
 
 impl<'a> Css<'a> {
-    /// Creates an empty style [`Sheet`].
-    ///
-    /// [`Sheet`]: struct.Sheet.html
+    /// Creates an empty [`Css`].
     pub fn new() -> Self {
         Css {
             rules: BTreeMap::new(),
         }
     }
 
-    /// Inserts the [`rule`] in the [`Sheet`], if it was not previously
+    /// Inserts the [`Rule`] in the [`Css`], if it was not previously
     /// inserted.
     ///
     /// It returns the class name of the provided [`Rule`].
-    ///
-    /// [`Sheet`]: struct.Sheet.html
-    /// [`Rule`]: enum.Rule.html
     pub fn insert(&mut self, bump: &'a bumpalo::Bump, rule: Rule) -> String {
         let class = rule.class();
 
@@ -107,9 +98,7 @@ impl<'a> Css<'a> {
         class
     }
 
-    /// Produces the VDOM node of the style [`Sheet`].
-    ///
-    /// [`Sheet`]: struct.Sheet.html
+    /// Produces the VDOM node of the [`Css`].
     pub fn node(self, bump: &'a bumpalo::Bump) -> dodrio::Node<'a> {
         use dodrio::builder::*;
 
@@ -133,8 +122,6 @@ impl<'a> Css<'a> {
 }
 
 /// Returns the style value for the given [`Length`].
-///
-/// [`Length`]: ../enum.Length.html
 pub fn length(length: Length) -> String {
     match length {
         Length::Shrink => String::from("auto"),
@@ -164,15 +151,11 @@ pub fn min_length(units: u32) -> String {
 }
 
 /// Returns the style value for the given [`Color`].
-///
-/// [`Color`]: ../struct.Color.html
 pub fn color(Color { r, g, b, a }: Color) -> String {
     format!("rgba({}, {}, {}, {})", 255.0 * r, 255.0 * g, 255.0 * b, a)
 }
 
 /// Returns the style value for the given [`Background`].
-///
-/// [`Background`]: ../struct.Background.html
 pub fn background(background: Background) -> String {
     match background {
         Background::Color(c) => color(c),
@@ -180,8 +163,6 @@ pub fn background(background: Background) -> String {
 }
 
 /// Returns the style value for the given [`Align`].
-///
-/// [`Align`]: ../enum.Align.html
 pub fn align(align: Align) -> &'static str {
     match align {
         Align::Start => "flex-start",

--- a/web/src/element.rs
+++ b/web/src/element.rs
@@ -11,9 +11,7 @@ use std::rc::Rc;
 /// If you have a [built-in widget], you should be able to use `Into<Element>`
 /// to turn it into an [`Element`].
 ///
-/// [built-in widget]: widget/index.html
-/// [`Widget`]: widget/trait.Widget.html
-/// [`Element`]: struct.Element.html
+/// [built-in widget]: mod@crate::widget
 #[allow(missing_debug_implementations)]
 pub struct Element<'a, Message> {
     pub(crate) widget: Box<dyn Widget<Message> + 'a>,
@@ -21,9 +19,6 @@ pub struct Element<'a, Message> {
 
 impl<'a, Message> Element<'a, Message> {
     /// Create a new [`Element`] containing the given [`Widget`].
-    ///
-    /// [`Element`]: struct.Element.html
-    /// [`Widget`]: widget/trait.Widget.html
     pub fn new(widget: impl Widget<Message> + 'a) -> Self {
         Self {
             widget: Box::new(widget),
@@ -34,8 +29,6 @@ impl<'a, Message> Element<'a, Message> {
     ///
     /// This method is useful when you want to decouple different parts of your
     /// UI and make them __composable__.
-    ///
-    /// [`Element`]: struct.Element.html
     pub fn map<F, B>(self, f: F) -> Element<'a, B>
     where
         Message: 'static,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -97,8 +97,6 @@ pub use executor::Executor;
 pub trait Application {
     /// The [`Executor`] that will run commands and subscriptions.
     ///
-    /// The [`executor::WasmBindgen`] can be a good choice for the Web.
-    ///
     /// [`Executor`]: trait.Executor.html
     /// [`executor::Default`]: executor/struct.Default.html
     type Executor: Executor;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -96,31 +96,21 @@ pub use executor::Executor;
 /// by returning a [`Command`](struct.Command.html) in some of its methods.
 pub trait Application {
     /// The [`Executor`] that will run commands and subscriptions.
-    ///
-    /// [`Executor`]: trait.Executor.html
-    /// [`executor::Default`]: executor/struct.Default.html
     type Executor: Executor;
 
     /// The type of __messages__ your [`Application`] will produce.
-    ///
-    /// [`Application`]: trait.Application.html
     type Message: Send;
 
     /// The data needed to initialize your [`Application`].
-    ///
-    /// [`Application`]: trait.Application.html
     type Flags;
 
     /// Initializes the [`Application`].
     ///
     /// Here is where you should return the initial state of your app.
     ///
-    /// Additionally, you can return a [`Command`](struct.Command.html) if you
-    /// need to perform some async action in the background on startup. This is
-    /// useful if you want to load state from a file, perform an initial HTTP
-    /// request, etc.
-    ///
-    /// [`Application`]: trait.Application.html
+    /// Additionally, you can return a [`Command`] if you need to perform some
+    /// async action in the background on startup. This is useful if you want to
+    /// load state from a file, perform an initial HTTP request, etc.
     fn new(flags: Self::Flags) -> (Self, Command<Self::Message>)
     where
         Self: Sized;
@@ -129,8 +119,6 @@ pub trait Application {
     ///
     /// This title can be dynamic! The runtime will automatically update the
     /// title of your application when necessary.
-    ///
-    /// [`Application`]: trait.Application.html
     fn title(&self) -> String;
 
     /// Handles a __message__ and updates the state of the [`Application`].
@@ -140,16 +128,11 @@ pub trait Application {
     /// this method.
     ///
     /// Any [`Command`] returned will be executed immediately in the background.
-    ///
-    /// [`Application`]: trait.Application.html
-    /// [`Command`]: struct.Command.html
     fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
 
     /// Returns the widgets to display in the [`Application`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    ///
-    /// [`Application`]: trait.Application.html
     fn view(&mut self) -> Element<'_, Self::Message>;
 
     /// Returns the event [`Subscription`] for the current state of the
@@ -160,15 +143,11 @@ pub trait Application {
     /// [`update`](#tymethod.update).
     ///
     /// By default, this method returns an empty [`Subscription`].
-    ///
-    /// [`Subscription`]: struct.Subscription.html
     fn subscription(&self) -> Subscription<Self::Message> {
         Subscription::none()
     }
 
     /// Runs the [`Application`].
-    ///
-    /// [`Application`]: trait.Application.html
     fn run(flags: Self::Flags)
     where
         Self: 'static + Sized,

--- a/web/src/subscription.rs
+++ b/web/src/subscription.rs
@@ -12,8 +12,7 @@ use crate::Hasher;
 /// For instance, you can use a [`Subscription`] to listen to a WebSocket
 /// connection, keyboard presses, mouse events, time ticks, etc.
 ///
-/// [`Command`]: ../struct.Command.html
-/// [`Subscription`]: struct.Subscription.html
+/// [`Command`]: crate::Command
 pub type Subscription<T> = iced_futures::Subscription<Hasher, (), T>;
 
 pub use iced_futures::subscription::Recipe;

--- a/web/src/widget.rs
+++ b/web/src/widget.rs
@@ -12,8 +12,6 @@
 //! ```
 //! use iced_web::{button, Button, Widget};
 //! ```
-//!
-//! [`Widget`]: trait.Widget.html
 use crate::{Bus, Css};
 use dodrio::bumpalo;
 
@@ -56,12 +54,8 @@ pub use space::Space;
 ///
 /// If you want to build your own widgets, you will need to implement this
 /// trait.
-///
-/// [`Widget`]: trait.Widget.html
 pub trait Widget<Message> {
     /// Produces a VDOM node for the [`Widget`].
-    ///
-    /// [`Widget`]: trait.Widget.html
     fn node<'b>(
         &self,
         bump: &'b bumpalo::Bump,

--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -1,9 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-//!
-//! [`Button`]: struct.Button.html
-//! [`State`]: struct.State.html
 use crate::{css, Background, Bus, Css, Element, Length, Widget};
 
 pub use iced_style::button::{Style, StyleSheet};
@@ -38,9 +35,6 @@ pub struct Button<'a, Message> {
 impl<'a, Message> Button<'a, Message> {
     /// Creates a new [`Button`] with some local [`State`] and the given
     /// content.
-    ///
-    /// [`Button`]: struct.Button.html
-    /// [`State`]: struct.State.html
     pub fn new<E>(_state: &'a mut State, content: E) -> Self
     where
         E: Into<Element<'a, Message>>,
@@ -58,56 +52,42 @@ impl<'a, Message> Button<'a, Message> {
     }
 
     /// Sets the width of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the minimum width of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn min_width(mut self, min_width: u32) -> Self {
         self.min_width = min_width;
         self
     }
 
     /// Sets the minimum height of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn min_height(mut self, min_height: u32) -> Self {
         self.min_height = min_height;
         self
     }
 
     /// Sets the padding of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn padding(mut self, padding: u16) -> Self {
         self.padding = padding;
         self
     }
 
     /// Sets the style of the [`Button`].
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Sets the message that will be produced when the [`Button`] is pressed.
-    ///
-    /// [`Button`]: struct.Button.html
     pub fn on_press(mut self, msg: Message) -> Self {
         self.on_press = Some(msg);
         self
@@ -115,15 +95,11 @@ impl<'a, Message> Button<'a, Message> {
 }
 
 /// The local state of a [`Button`].
-///
-/// [`Button`]: struct.Button.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State;
 
 impl State {
     /// Creates a new [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> State {
         State::default()
     }

--- a/web/src/widget/checkbox.rs
+++ b/web/src/widget/checkbox.rs
@@ -42,8 +42,6 @@ impl<Message> Checkbox<Message> {
     ///   * a function that will be called when the [`Checkbox`] is toggled. It
     ///     will receive the new state of the [`Checkbox`] and must produce a
     ///     `Message`.
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn new<F>(is_checked: bool, label: impl Into<String>, f: F) -> Self
     where
         F: 'static + Fn(bool) -> Message,
@@ -59,24 +57,18 @@ impl<Message> Checkbox<Message> {
     }
 
     /// Sets the width of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the style of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Sets the id of the [`Checkbox`].
-    ///
-    /// [`Checkbox`]: struct.Checkbox.html
     pub fn id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self

--- a/web/src/widget/column.rs
+++ b/web/src/widget/column.rs
@@ -6,8 +6,6 @@ use std::u32;
 /// A container that distributes its contents vertically.
 ///
 /// A [`Column`] will try to fill the horizontal space of its container.
-///
-/// [`Column`]: struct.Column.html
 #[allow(missing_debug_implementations)]
 pub struct Column<'a, Message> {
     spacing: u16,
@@ -22,15 +20,11 @@ pub struct Column<'a, Message> {
 
 impl<'a, Message> Column<'a, Message> {
     /// Creates an empty [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn new() -> Self {
         Self::with_children(Vec::new())
     }
 
     /// Creates a [`Column`] with the given elements.
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn with_children(children: Vec<Element<'a, Message>>) -> Self {
         Column {
             spacing: 0,
@@ -55,56 +49,42 @@ impl<'a, Message> Column<'a, Message> {
     }
 
     /// Sets the padding of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Column`] in pixels.
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the horizontal alignment of the contents of the [`Column`] .
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn align_items(mut self, align: Align) -> Self {
         self.align_items = align;
         self
     }
 
     /// Adds an element to the [`Column`].
-    ///
-    /// [`Column`]: struct.Column.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message>>,

--- a/web/src/widget/container.rs
+++ b/web/src/widget/container.rs
@@ -21,8 +21,6 @@ pub struct Container<'a, Message> {
 
 impl<'a, Message> Container<'a, Message> {
     /// Creates an empty [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn new<T>(content: T) -> Self
     where
         T: Into<Element<'a, Message>>,
@@ -43,48 +41,36 @@ impl<'a, Message> Container<'a, Message> {
     }
 
     /// Sets the padding of the [`Container`].
-    ///
-    /// [`Container`]: struct.Column.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Container`] in pixels.
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Centers the contents in the horizontal axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn center_x(mut self) -> Self {
         self.horizontal_alignment = Align::Center;
 
@@ -92,8 +78,6 @@ impl<'a, Message> Container<'a, Message> {
     }
 
     /// Centers the contents in the vertical axis of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn center_y(mut self) -> Self {
         self.vertical_alignment = Align::Center;
 
@@ -101,8 +85,6 @@ impl<'a, Message> Container<'a, Message> {
     }
 
     /// Sets the style of the [`Container`].
-    ///
-    /// [`Container`]: struct.Container.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style_sheet = style.into();
         self

--- a/web/src/widget/image.rs
+++ b/web/src/widget/image.rs
@@ -34,8 +34,6 @@ pub struct Image {
 
 impl Image {
     /// Creates a new [`Image`] with the given path.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn new<T: Into<Handle>>(handle: T) -> Self {
         Image {
             handle: handle.into(),
@@ -46,24 +44,18 @@ impl Image {
     }
 
     /// Sets the width of the [`Image`] boundaries.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Image`] boundaries.
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the alt text of the [`Image`].
-    ///
-    /// [`Image`]: struct.Image.html
     pub fn alt(mut self, alt: impl Into<String>) -> Self {
         self.alt = alt.into();
         self
@@ -118,8 +110,6 @@ impl<'a, Message> From<Image> for Element<'a, Message> {
 }
 
 /// An [`Image`] handle.
-///
-/// [`Image`]: struct.Image.html
 #[derive(Debug, Clone)]
 pub struct Handle {
     id: u64,
@@ -128,8 +118,6 @@ pub struct Handle {
 
 impl Handle {
     /// Creates an image [`Handle`] pointing to the image of the given path.
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
         Self::from_data(Data::Path(path.into()))
     }
@@ -145,15 +133,11 @@ impl Handle {
     }
 
     /// Returns the unique identifier of the [`Handle`].
-    ///
-    /// [`Handle`]: struct.Handle.html
     pub fn id(&self) -> u64 {
         self.id
     }
 
     /// Returns a reference to the image [`Data`].
-    ///
-    /// [`Data`]: enum.Data.html
     pub fn data(&self) -> &Data {
         &self.data
     }
@@ -172,8 +156,6 @@ impl From<&str> for Handle {
 }
 
 /// The data of an [`Image`].
-///
-/// [`Image`]: struct.Image.html
 #[derive(Clone, Hash)]
 pub enum Data {
     /// A remote image

--- a/web/src/widget/progress_bar.rs
+++ b/web/src/widget/progress_bar.rs
@@ -32,8 +32,6 @@ impl ProgressBar {
     /// It expects:
     ///   * an inclusive range of possible values
     ///   * the current value of the [`ProgressBar`]
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn new(range: RangeInclusive<f32>, value: f32) -> Self {
         ProgressBar {
             value: value.max(*range.start()).min(*range.end()),
@@ -45,24 +43,18 @@ impl ProgressBar {
     }
 
     /// Sets the width of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = Some(height);
         self
     }
 
     /// Sets the style of the [`ProgressBar`].
-    ///
-    /// [`ProgressBar`]: struct.ProgressBar.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self

--- a/web/src/widget/radio.rs
+++ b/web/src/widget/radio.rs
@@ -49,8 +49,6 @@ impl<Message> Radio<Message> {
     ///   * the current selected value
     ///   * a function that will be called when the [`Radio`] is selected. It
     ///   receives the value of the radio and must produce a `Message`.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn new<F, V>(
         value: V,
         label: impl Into<String>,
@@ -72,24 +70,18 @@ impl<Message> Radio<Message> {
     }
 
     /// Sets the style of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Sets the name attribute of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
     /// Sets the id of the [`Radio`] button.
-    ///
-    /// [`Radio`]: struct.Radio.html
     pub fn id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self

--- a/web/src/widget/row.rs
+++ b/web/src/widget/row.rs
@@ -6,8 +6,6 @@ use std::u32;
 /// A container that distributes its contents horizontally.
 ///
 /// A [`Row`] will try to fill the horizontal space of its container.
-///
-/// [`Row`]: struct.Row.html
 #[allow(missing_debug_implementations)]
 pub struct Row<'a, Message> {
     spacing: u16,
@@ -22,15 +20,11 @@ pub struct Row<'a, Message> {
 
 impl<'a, Message> Row<'a, Message> {
     /// Creates an empty [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn new() -> Self {
         Self::with_children(Vec::new())
     }
 
     /// Creates a [`Row`] with the given elements.
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn with_children(children: Vec<Element<'a, Message>>) -> Self {
         Row {
             spacing: 0,
@@ -55,57 +49,42 @@ impl<'a, Message> Row<'a, Message> {
     }
 
     /// Sets the padding of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the width of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the maximum height of the [`Row`].
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the vertical alignment of the contents of the [`Row`] .
-    ///
-    /// [`Row`]: struct.Row.html
     pub fn align_items(mut self, align: Align) -> Self {
         self.align_items = align;
         self
     }
 
     /// Adds an [`Element`] to the [`Row`].
-    ///
-    /// [`Element`]: ../struct.Element.html
-    /// [`Row`]: struct.Row.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message>>,

--- a/web/src/widget/scrollable.rs
+++ b/web/src/widget/scrollable.rs
@@ -16,9 +16,6 @@ pub struct Scrollable<'a, Message> {
 
 impl<'a, Message> Scrollable<'a, Message> {
     /// Creates a new [`Scrollable`] with the given [`State`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
-    /// [`State`]: struct.State.html
     pub fn new(_state: &'a mut State) -> Self {
         use std::u32;
 
@@ -42,64 +39,48 @@ impl<'a, Message> Scrollable<'a, Message> {
     }
 
     /// Sets the padding of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn padding(mut self, units: u16) -> Self {
         self.content = self.content.padding(units);
         self
     }
 
     /// Sets the width of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the maximum width of the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.content = self.content.max_width(max_width);
         self
     }
 
     /// Sets the maximum height of the [`Scrollable`] in pixels.
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn max_height(mut self, max_height: u32) -> Self {
         self.max_height = max_height;
         self
     }
 
     /// Sets the horizontal alignment of the contents of the [`Scrollable`] .
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn align_items(mut self, align_items: Align) -> Self {
         self.content = self.content.align_items(align_items);
         self
     }
 
     /// Sets the style of the [`Scrollable`] .
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Adds an element to the [`Scrollable`].
-    ///
-    /// [`Scrollable`]: struct.Scrollable.html
     pub fn push<E>(mut self, child: E) -> Self
     where
         E: Into<Element<'a, Message>>,
@@ -154,15 +135,11 @@ where
 }
 
 /// The local state of a [`Scrollable`].
-///
-/// [`Scrollable`]: struct.Scrollable.html
 #[derive(Debug, Clone, Copy, Default)]
 pub struct State;
 
 impl State {
     /// Creates a new [`State`] with the scrollbar located at the top.
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         State::default()
     }

--- a/web/src/widget/slider.rs
+++ b/web/src/widget/slider.rs
@@ -1,9 +1,6 @@
 //! Display an interactive selector of a single value from a range of values.
 //!
 //! A [`Slider`] has some local [`State`].
-//!
-//! [`Slider`]: struct.Slider.html
-//! [`State`]: struct.State.html
 use crate::{Bus, Css, Element, Length, Widget};
 
 pub use iced_style::slider::{Handle, HandleShape, Style, StyleSheet};
@@ -18,8 +15,6 @@ use std::{ops::RangeInclusive, rc::Rc};
 ///
 /// The [`Slider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
-///
-/// [`Slider`]: struct.Slider.html
 ///
 /// # Example
 /// ```
@@ -60,9 +55,6 @@ where
     ///   * a function that will be called when the [`Slider`] is dragged.
     ///   It receives the new value of the [`Slider`] and must produce a
     ///   `Message`.
-    ///
-    /// [`Slider`]: struct.Slider.html
-    /// [`State`]: struct.State.html
     pub fn new<F>(
         state: &'a mut State,
         range: RangeInclusive<T>,
@@ -96,24 +88,18 @@ where
     }
 
     /// Sets the width of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the style of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style = style.into();
         self
     }
 
     /// Sets the step size of the [`Slider`].
-    ///
-    /// [`Slider`]: struct.Slider.html
     pub fn step(mut self, step: T) -> Self {
         self.step = step;
         self
@@ -181,15 +167,11 @@ where
 }
 
 /// The local state of a [`Slider`].
-///
-/// [`Slider`]: struct.Slider.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State;
 
 impl State {
     /// Creates a new [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         Self
     }

--- a/web/src/widget/space.rs
+++ b/web/src/widget/space.rs
@@ -12,15 +12,11 @@ pub struct Space {
 
 impl Space {
     /// Creates an amount of empty [`Space`] with the given width and height.
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn new(width: Length, height: Length) -> Self {
         Space { width, height }
     }
 
     /// Creates an amount of horizontal [`Space`].
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn with_width(width: Length) -> Self {
         Space {
             width,
@@ -29,8 +25,6 @@ impl Space {
     }
 
     /// Creates an amount of vertical [`Space`].
-    ///
-    /// [`Space`]: struct.Space.html
     pub fn with_height(height: Length) -> Self {
         Space {
             width: Length::Shrink,

--- a/web/src/widget/text.rs
+++ b/web/src/widget/text.rs
@@ -28,8 +28,6 @@ pub struct Text {
 
 impl Text {
     /// Create a new fragment of [`Text`] with the given contents.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn new<T: Into<String>>(label: T) -> Self {
         Text {
             content: label.into(),
@@ -44,51 +42,36 @@ impl Text {
     }
 
     /// Sets the size of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = Some(size);
         self
     }
 
     /// Sets the [`Color`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`Color`]: ../../struct.Color.html
     pub fn color<C: Into<Color>>(mut self, color: C) -> Self {
         self.color = Some(color.into());
         self
     }
 
     /// Sets the [`Font`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`Font`]: ../../struct.Font.html
     pub fn font(mut self, font: Font) -> Self {
         self.font = font;
         self
     }
 
     /// Sets the width of the [`Text`] boundaries.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Text`] boundaries.
-    ///
-    /// [`Text`]: struct.Text.html
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// Sets the [`HorizontalAlignment`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`HorizontalAlignment`]: enum.HorizontalAlignment.html
     pub fn horizontal_alignment(
         mut self,
         alignment: HorizontalAlignment,
@@ -98,9 +81,6 @@ impl Text {
     }
 
     /// Sets the [`VerticalAlignment`] of the [`Text`].
-    ///
-    /// [`Text`]: struct.Text.html
-    /// [`VerticalAlignment`]: enum.VerticalAlignment.html
     pub fn vertical_alignment(mut self, alignment: VerticalAlignment) -> Self {
         self.vertical_alignment = alignment;
         self

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -1,9 +1,6 @@
 //! Display fields that can be filled with text.
 //!
 //! A [`TextInput`] has some local [`State`].
-//!
-//! [`TextInput`]: struct.TextInput.html
-//! [`State`]: struct.State.html
 use crate::{bumpalo, css, Bus, Css, Element, Length, Widget};
 
 pub use iced_style::text_input::{Style, StyleSheet};
@@ -53,9 +50,6 @@ impl<'a, Message> TextInput<'a, Message> {
     /// - a placeholder
     /// - the current value
     /// - a function that produces a message when the [`TextInput`] changes
-    ///
-    /// [`TextInput`]: struct.TextInput.html
-    /// [`State`]: struct.State.html
     pub fn new<F>(
         state: &'a mut State,
         placeholder: &str,
@@ -81,40 +75,30 @@ impl<'a, Message> TextInput<'a, Message> {
     }
 
     /// Converts the [`TextInput`] into a secure password input.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn password(mut self) -> Self {
         self.is_secure = true;
         self
     }
 
     /// Sets the width of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the maximum width of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn max_width(mut self, max_width: u32) -> Self {
         self.max_width = max_width;
         self
     }
 
     /// Sets the padding of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn padding(mut self, units: u16) -> Self {
         self.padding = units;
         self
     }
 
     /// Sets the text size of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn size(mut self, size: u16) -> Self {
         self.size = Some(size);
         self
@@ -122,16 +106,12 @@ impl<'a, Message> TextInput<'a, Message> {
 
     /// Sets the message that should be produced when the [`TextInput`] is
     /// focused and the enter key is pressed.
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn on_submit(mut self, message: Message) -> Self {
         self.on_submit = Some(message);
         self
     }
 
     /// Sets the style of the [`TextInput`].
-    ///
-    /// [`TextInput`]: struct.TextInput.html
     pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style_sheet = style.into();
         self
@@ -238,22 +218,16 @@ where
 }
 
 /// The state of a [`TextInput`].
-///
-/// [`TextInput`]: struct.TextInput.html
 #[derive(Debug, Clone, Copy, Default)]
 pub struct State;
 
 impl State {
     /// Creates a new [`State`], representing an unfocused [`TextInput`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a new [`State`], representing a focused [`TextInput`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn focused() -> Self {
         // TODO
         Self::default()

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -30,8 +30,6 @@ pub struct Backend {
 
 impl Backend {
     /// Creates a new [`Backend`].
-    ///
-    /// [`Backend`]: struct.Backend.html
     pub fn new(device: &wgpu::Device, settings: Settings) -> Self {
         let text_pipeline =
             text::Pipeline::new(device, settings.format, settings.default_font);

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -1,19 +1,19 @@
 //! Configure a renderer.
 pub use crate::Antialiasing;
 
-/// The settings of a [`Renderer`].
+/// The settings of a [`Backend`].
 ///
-/// [`Renderer`]: ../struct.Renderer.html
+/// [`Backend`]: crate::Backend
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings {
-    /// The output format of the [`Renderer`].
+    /// The output format of the [`Backend`].
     ///
-    /// [`Renderer`]: ../struct.Renderer.html
+    /// [`Backend`]: crate::Backend
     pub format: wgpu::TextureFormat,
 
-    /// The present mode of the [`Renderer`].
+    /// The present mode of the [`Backend`].
     ///
-    /// [`Renderer`]: ../struct.Renderer.html
+    /// [`Backend`]: crate::Backend
     pub present_mode: wgpu::PresentMode,
 
     /// The bytes of the font that will be used by default.

--- a/wgpu/src/widget/button.rs
+++ b/wgpu/src/widget/button.rs
@@ -1,9 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-//!
-//! [`Button`]: type.Button.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::button::{Style, StyleSheet};

--- a/wgpu/src/widget/canvas.rs
+++ b/wgpu/src/widget/canvas.rs
@@ -3,7 +3,4 @@
 //! A [`Canvas`] widget can be used to draw different kinds of 2D shapes in a
 //! [`Frame`]. It can be used for animation, data visualization, game graphics,
 //! and more!
-//!
-//! [`Canvas`]: struct.Canvas.html
-//! [`Frame`]: struct.Frame.html
 pub use iced_graphics::canvas::*;

--- a/wgpu/src/widget/pane_grid.rs
+++ b/wgpu/src/widget/pane_grid.rs
@@ -6,8 +6,7 @@
 //! The [`pane_grid` example] showcases how to use a [`PaneGrid`] with resizing,
 //! drag and drop, and hotkey support.
 //!
-//! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
-//! [`PaneGrid`]: type.PaneGrid.html
+//! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.2/examples/pane_grid
 use crate::Renderer;
 
 pub use iced_native::pane_grid::{
@@ -24,13 +23,9 @@ pub use iced_native::pane_grid::{
 pub type PaneGrid<'a, Message> = iced_native::PaneGrid<'a, Message, Renderer>;
 
 /// The content of a [`Pane`].
-///
-/// [`Pane`]: struct.Pane.html
 pub type Content<'a, Message> =
     iced_native::pane_grid::Content<'a, Message, Renderer>;
 
 /// The title bar of a [`Pane`].
-///
-/// [`Pane`]: struct.Pane.html
 pub type TitleBar<'a, Message> =
     iced_native::pane_grid::TitleBar<'a, Message, Renderer>;

--- a/wgpu/src/widget/progress_bar.rs
+++ b/wgpu/src/widget/progress_bar.rs
@@ -2,8 +2,6 @@
 //!
 //! A [`ProgressBar`] has a range of possible values and a current value,
 //! as well as a length, height and style.
-//!
-//! [`ProgressBar`]: type.ProgressBar.html
 use crate::Renderer;
 
 pub use iced_graphics::progress_bar::{Style, StyleSheet};

--- a/wgpu/src/widget/slider.rs
+++ b/wgpu/src/widget/slider.rs
@@ -1,9 +1,6 @@
 //! Display an interactive selector of a single value from a range of values.
 //!
 //! A [`Slider`] has some local [`State`].
-//!
-//! [`Slider`]: struct.Slider.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::slider::{Handle, HandleShape, Style, StyleSheet};

--- a/wgpu/src/widget/text_input.rs
+++ b/wgpu/src/widget/text_input.rs
@@ -1,9 +1,6 @@
 //! Display fields that can be filled with text.
 //!
 //! A [`TextInput`] has some local [`State`].
-//!
-//! [`TextInput`]: struct.TextInput.html
-//! [`State`]: struct.State.html
 use crate::Renderer;
 
 pub use iced_graphics::text_input::{Style, StyleSheet};

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -21,9 +21,6 @@ impl Compositor {
     /// Requests a new [`Compositor`] with the given [`Settings`].
     ///
     /// Returns `None` if no compatible graphics adapter could be found.
-    ///
-    /// [`Compositor`]: struct.Compositor.html
-    /// [`Settings`]: struct.Settings.html
     pub async fn request(settings: Settings) -> Option<Self> {
         let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 
@@ -67,9 +64,6 @@ impl Compositor {
     }
 
     /// Creates a new rendering [`Backend`] for this [`Compositor`].
-    ///
-    /// [`Compositor`]: struct.Compositor.html
-    /// [`Backend`]: struct.Backend.html
     pub fn create_backend(&self) -> Backend {
         Backend::new(&self.device, self.settings)
     }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -24,17 +24,13 @@ use std::mem::ManuallyDrop;
 /// your GUI application by simply calling [`run`](#method.run). It will run in
 /// its own window.
 ///
-/// An [`Application`](trait.Application.html) can execute asynchronous actions
-/// by returning a [`Command`](struct.Command.html) in some of its methods.
+/// An [`Application`] can execute asynchronous actions by returning a
+/// [`Command`] in some of its methods.
 ///
 /// When using an [`Application`] with the `debug` feature enabled, a debug view
 /// can be toggled by pressing `F12`.
-///
-/// [`Application`]: trait.Application.html
 pub trait Application: Program {
     /// The data needed to initialize your [`Application`].
-    ///
-    /// [`Application`]: trait.Application.html
     type Flags;
 
     /// Initializes the [`Application`] with the flags provided to
@@ -42,22 +38,15 @@ pub trait Application: Program {
     ///
     /// Here is where you should return the initial state of your app.
     ///
-    /// Additionally, you can return a [`Command`](struct.Command.html) if you
-    /// need to perform some async action in the background on startup. This is
-    /// useful if you want to load state from a file, perform an initial HTTP
-    /// request, etc.
-    ///
-    /// [`Application`]: trait.Application.html
-    /// [`run`]: #method.run.html
-    /// [`Settings`]: ../settings/struct.Settings.html
+    /// Additionally, you can return a [`Command`] if you need to perform some
+    /// async action in the background on startup. This is useful if you want to
+    /// load state from a file, perform an initial HTTP request, etc.
     fn new(flags: Self::Flags) -> (Self, Command<Self::Message>);
 
     /// Returns the current title of the [`Application`].
     ///
     /// This title can be dynamic! The runtime will automatically update the
     /// title of your application when necessary.
-    ///
-    /// [`Application`]: trait.Application.html
     fn title(&self) -> String;
 
     /// Returns the event `Subscription` for the current state of the
@@ -79,8 +68,6 @@ pub trait Application: Program {
     /// is returned.
     ///
     /// By default, an application will run in windowed mode.
-    ///
-    /// [`Application`]: trait.Application.html
     fn mode(&self) -> Mode {
         Mode::Windowed
     }
@@ -88,10 +75,6 @@ pub trait Application: Program {
     /// Returns the background [`Color`] of the [`Application`].
     ///
     /// By default, it returns [`Color::WHITE`].
-    ///
-    /// [`Color`]: struct.Color.html
-    /// [`Application`]: trait.Application.html
-    /// [`Color::WHITE`]: struct.Color.html#const.WHITE
     fn background_color(&self) -> Color {
         Color::WHITE
     }
@@ -105,8 +88,6 @@ pub trait Application: Program {
     /// while a scale factor of `0.5` will shrink them to half their size.
     ///
     /// By default, it returns `1.0`.
-    ///
-    /// [`Application`]: trait.Application.html
     fn scale_factor(&self) -> f64 {
         1.0
     }
@@ -114,8 +95,6 @@ pub trait Application: Program {
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
 /// settings.
-///
-/// [`Application`]: trait.Application.html
 pub fn run<A, E, C>(
     settings: Settings<A::Flags>,
     compositor_settings: C::Settings,
@@ -382,8 +361,6 @@ async fn run_instance<A, E, C>(
 
 /// Returns true if the provided event should cause an [`Application`] to
 /// exit.
-///
-/// [`Application`]: trait.Application.html
 pub fn requests_exit(
     event: &winit::event::WindowEvent<'_>,
     _modifiers: winit::event::ModifiersState,
@@ -407,11 +384,7 @@ pub fn requests_exit(
 }
 
 /// Builds a [`UserInterface`] for the provided [`Application`], logging
-/// [`Debug`] information accordingly.
-///
-/// [`UserInterface`]: struct.UserInterface.html
-/// [`Application`]: trait.Application.html
-/// [`Debug`]: struct.Debug.html
+/// [`struct@Debug`] information accordingly.
 pub fn build_user_interface<'a, A: Application>(
     application: &'a mut A,
     cache: Cache,
@@ -432,10 +405,6 @@ pub fn build_user_interface<'a, A: Application>(
 
 /// Updates an [`Application`] by feeding it the provided messages, spawning any
 /// resulting [`Command`], and tracking its [`Subscription`].
-///
-/// [`Application`]: trait.Application.html
-/// [`Command`]: struct.Command.html
-/// [`Subscription`]: struct.Subscription.html
 pub fn update<A: Application, E: Executor>(
     application: &mut A,
     runtime: &mut Runtime<E, Proxy<A::Message>, A::Message>,

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -6,8 +6,6 @@ use winit::event::WindowEvent;
 use winit::window::Window;
 
 /// The state of a windowed [`Application`].
-///
-/// [`Application`]: ../trait.Application.html
 #[derive(Debug, Clone)]
 pub struct State<A: Application> {
     title: String,
@@ -23,9 +21,6 @@ pub struct State<A: Application> {
 
 impl<A: Application> State<A> {
     /// Creates a new [`State`] for the provided [`Application`] and window.
-    ///
-    /// [`State`]: struct.State.html
-    /// [`Application`]: ../trait.Application.html
     pub fn new(application: &A, window: &Window) -> Self {
         let title = application.title();
         let mode = application.mode();
@@ -56,17 +51,11 @@ impl<A: Application> State<A> {
     }
 
     /// Returns the current background [`Color`] of the [`State`].
-    ///
-    /// [`Color`]: ../struct.Color.html
-    /// [`State`]: struct.State.html
     pub fn background_color(&self) -> Color {
         self.background_color
     }
 
     /// Returns the current [`Viewport`] of the [`State`].
-    ///
-    /// [`Viewport`]: ../struct.Viewport.html
-    /// [`State`]: struct.State.html
     pub fn viewport(&self) -> &Viewport {
         &self.viewport
     }
@@ -74,42 +63,26 @@ impl<A: Application> State<A> {
     /// Returns the version of the [`Viewport`] of the [`State`].
     ///
     /// The version is incremented every time the [`Viewport`] changes.
-    ///
-    /// [`Viewport`]: ../struct.Viewport.html
-    /// [`State`]: struct.State.html
     pub fn viewport_version(&self) -> usize {
         self.viewport_version
     }
 
     /// Returns the physical [`Size`] of the [`Viewport`] of the [`State`].
-    ///
-    /// [`Size`]: ../struct.Size.html
-    /// [`Viewport`]: ../struct.Viewport.html
-    /// [`State`]: struct.State.html
     pub fn physical_size(&self) -> Size<u32> {
         self.viewport.physical_size()
     }
 
     /// Returns the logical [`Size`] of the [`Viewport`] of the [`State`].
-    ///
-    /// [`Size`]: ../struct.Size.html
-    /// [`Viewport`]: ../struct.Viewport.html
-    /// [`State`]: struct.State.html
     pub fn logical_size(&self) -> Size<f32> {
         self.viewport.logical_size()
     }
 
     /// Returns the current scale factor of the [`Viewport`] of the [`State`].
-    ///
-    /// [`Viewport`]: ../struct.Viewport.html
-    /// [`State`]: struct.State.html
     pub fn scale_factor(&self) -> f64 {
         self.viewport.scale_factor()
     }
 
     /// Returns the current cursor position of the [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn cursor_position(&self) -> Point {
         conversion::cursor_position(
             self.cursor_position,
@@ -118,16 +91,12 @@ impl<A: Application> State<A> {
     }
 
     /// Returns the current keyboard modifiers of the [`State`].
-    ///
-    /// [`State`]: struct.State.html
     pub fn modifiers(&self) -> winit::event::ModifiersState {
         self.modifiers
     }
 
     /// Processes the provided window event and updates the [`State`]
     /// accordingly.
-    ///
-    /// [`State`]: struct.State.html
     pub fn update(
         &mut self,
         window: &Window,
@@ -190,9 +159,7 @@ impl<A: Application> State<A> {
     /// Normally an [`Application`] should be synchronized with its [`State`]
     /// and window after calling [`Application::update`].
     ///
-    /// [`State`]: struct.State.html
-    /// [`Application`]: ../trait.Application.html
-    /// [`Application::update`]: ../trait.Application.html#tymethod.update
+    /// [`Application::update`]: crate::Program::update
     pub fn synchronize(&mut self, application: &A, window: &Window) {
         // Update window title
         let new_title = application.title();

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -5,8 +5,6 @@ pub struct Clipboard(window_clipboard::Clipboard);
 
 impl Clipboard {
     /// Creates a new [`Clipboard`] for the given window.
-    ///
-    /// [`Clipboard`]: struct.Clipboard.html
     pub fn new(window: &winit::window::Window) -> Option<Clipboard> {
         window_clipboard::Clipboard::new(window).map(Clipboard).ok()
     }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -3,7 +3,7 @@
 //! [`winit`]: https://github.com/rust-windowing/winit
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
 use crate::{
-    keyboard::{self, KeyCode, ModifiersState},
+    keyboard::{self, KeyCode, Modifiers},
     mouse, window, Event, Mode, Point,
 };
 
@@ -89,7 +89,7 @@ pub fn window_event(
             ..
         } => Some(Event::Keyboard({
             let key_code = key_code(*virtual_keycode);
-            let modifiers = modifiers_state(modifiers);
+            let modifiers = self::modifiers(modifiers);
 
             match state {
                 winit::event::ElementState::Pressed => {
@@ -107,7 +107,7 @@ pub fn window_event(
             }
         })),
         WindowEvent::ModifiersChanged(new_modifiers) => Some(Event::Keyboard(
-            keyboard::Event::ModifiersChanged(modifiers_state(*new_modifiers)),
+            keyboard::Event::ModifiersChanged(self::modifiers(*new_modifiers)),
         )),
         WindowEvent::HoveredFile(path) => {
             Some(Event::Window(window::Event::FileHovered(path.clone())))
@@ -180,10 +180,8 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
-pub fn modifiers_state(
-    modifiers: winit::event::ModifiersState,
-) -> ModifiersState {
-    ModifiersState {
+pub fn modifiers(modifiers: winit::event::ModifiersState) -> Modifiers {
+    Modifiers {
         shift: modifiers.shift(),
         control: modifiers.ctrl(),
         alt: modifiers.alt(),

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -124,7 +124,6 @@ pub fn window_event(
 
 /// Converts a [`Mode`] to a [`winit`] fullscreen mode.
 ///
-/// [`Mode`]: ../enum.Mode.html
 /// [`winit`]: https://github.com/rust-windowing/winit
 pub fn fullscreen(
     monitor: Option<winit::monitor::MonitorHandle>,

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -13,8 +13,7 @@
 //!
 //! [`iced_native`]: https://github.com/hecrj/iced/tree/master/native
 //! [`winit`]: https://github.com/rust-windowing/winit
-//! [`Application`]: trait.Application.html
-//! [`conversion`]: conversion
+//! [`conversion`]: crate::conversion
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]

--- a/winit/src/proxy.rs
+++ b/winit/src/proxy.rs
@@ -21,8 +21,6 @@ impl<Message: 'static> Clone for Proxy<Message> {
 
 impl<Message: 'static> Proxy<Message> {
     /// Creates a new [`Proxy`] from an `EventLoopProxy`.
-    ///
-    /// [`Proxy`]: struct.Proxy.html
     pub fn new(raw: winit::event_loop::EventLoopProxy<Message>) -> Self {
         Self { raw }
     }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -17,13 +17,11 @@ use winit::window::WindowBuilder;
 #[derive(Debug, Clone, Default)]
 pub struct Settings<Flags> {
     /// The [`Window`] settings
-    ///
-    /// [`Window`]: struct.Window.html
     pub window: Window,
 
     /// The data needed to initialize an [`Application`].
     ///
-    /// [`Application`]: trait.Application.html
+    /// [`Application`]: crate::Application
     pub flags: Flags,
 }
 


### PR DESCRIPTION
This PR updates all the internal documentation links to use the new intra-doc link format, increasing readability and reliability.

Related RFC: https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md