### PR TITLE
Add license to iced-graphics' Cargo.toml

### DIFF
--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -3,6 +3,7 @@ name = "iced_graphics"
 version = "0.1.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2018"
+license = "MIT"
 
 [features]
 canvas = ["lyon"]


### PR DESCRIPTION
[cargo-deny](https://github.com/EmbarkStudios/cargo-deny) complains that `iced_graphics = 0.1.0 is unlicensed`, fix that