### PR TITLE
Disabled button docs and consistent behavior

### DIFF
--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -70,15 +70,13 @@ impl Sandbox for Tour {
 
         controls = controls.push(Space::with_width(Length::Fill));
 
-        let mut button = button(next_button, "Next");
-        button = if steps.can_continue() {
-            button
-                .style(style::Button::Primary)
-                .on_press(Message::NextPressed)
-        } else {
-            button.style(style::Button::Disabled)
-        };
-        controls = controls.push(button);
+        if steps.can_continue() {
+            controls = controls.push(
+                button(next_button, "Next")
+                    .on_press(Message::NextPressed)
+                    .style(style::Button::Primary),
+            );
+        }
 
         let content: Element<_> = Column::new()
             .max_width(540)
@@ -792,7 +790,6 @@ mod style {
     pub enum Button {
         Primary,
         Secondary,
-        Disabled,
     }
 
     impl button::StyleSheet for Button {
@@ -800,8 +797,7 @@ mod style {
             button::Style {
                 background: Some(Background::Color(match self {
                     Button::Primary => Color::from_rgb(0.11, 0.42, 0.87),
-                    Button::Secondary => Color::from_rgb(0.055, 0.21, 0.435),
-                    Button::Disabled => Color::from_rgb(0.5, 0.5, 0.5),
+                    Button::Secondary => Color::from_rgb(0.5, 0.5, 0.5),
                 })),
                 border_radius: 12.0,
                 shadow_offset: Vector::new(1.0, 1.0),

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -70,13 +70,15 @@ impl Sandbox for Tour {
 
         controls = controls.push(Space::with_width(Length::Fill));
 
-        if steps.can_continue() {
-            controls = controls.push(
-                button(next_button, "Next")
-                    .on_press(Message::NextPressed)
-                    .style(style::Button::Primary),
-            );
-        }
+        let mut button = button(next_button, "Next");
+        button = if steps.can_continue() {
+            button
+                .style(style::Button::Primary)
+                .on_press(Message::NextPressed)
+        } else {
+            button.style(style::Button::Disabled)
+        };
+        controls = controls.push(button);
 
         let content: Element<_> = Column::new()
             .max_width(540)
@@ -790,6 +792,7 @@ mod style {
     pub enum Button {
         Primary,
         Secondary,
+        Disabled,
     }
 
     impl button::StyleSheet for Button {
@@ -797,7 +800,8 @@ mod style {
             button::Style {
                 background: Some(Background::Color(match self {
                     Button::Primary => Color::from_rgb(0.11, 0.42, 0.87),
-                    Button::Secondary => Color::from_rgb(0.5, 0.5, 0.5),
+                    Button::Secondary => Color::from_rgb(0.055, 0.21, 0.435),
+                    Button::Disabled => Color::from_rgb(0.5, 0.5, 0.5),
                 })),
                 border_radius: 12.0,
                 shadow_offset: Vector::new(1.0, 1.0),

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -30,7 +30,8 @@ use std::hash::Hash;
 ///     .on_press(Message::ButtonPressed);
 /// ```
 ///
-/// Buttons can be disabled by not having an on_press.
+/// If a [`Button::on_press`] handler is not set, the resulting [`Button`] will
+/// be disabled:
 ///
 /// ```
 /// # use iced_native::{button, Text};
@@ -38,13 +39,18 @@ use std::hash::Hash;
 /// # type Button<'a, Message> =
 /// #     iced_native::Button<'a, Message, iced_native::renderer::Null>;
 /// #
-/// # #[derive(Clone)]
-/// # enum Message {
-/// #     ButtonPressed,
-/// # }
-/// #
-/// let mut state = button::State::new();
-/// let disabled_button = Button::<Message>::new(&mut state, Text::new("I'm disabled!"));
+/// #[derive(Clone)]
+/// enum Message {
+///     ButtonPressed,
+/// }
+///
+/// fn disabled_button(state: &mut button::State) -> Button<'_, Message> {
+///     Button::new(state, Text::new("I'm disabled!"))
+/// }
+///
+/// fn enabled_button(state: &mut button::State) -> Button<'_, Message> {
+///     disabled_button(state).on_press(Message::ButtonPressed)
+/// }
 /// ```
 #[allow(missing_debug_implementations)]
 pub struct Button<'a, Message, Renderer: self::Renderer> {

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -29,6 +29,13 @@ use std::hash::Hash;
 /// let button = Button::new(&mut state, Text::new("Press me!"))
 ///     .on_press(Message::ButtonPressed);
 /// ```
+///
+/// Buttons can be disabled by not having an on_press.
+///
+/// ```
+/// let mut state = button::State::new();
+/// let disabled_button = Button::new(&mut state, Text::new("I'm disabled!"));
+/// ```
 #[allow(missing_debug_implementations)]
 pub struct Button<'a, Message, Renderer: self::Renderer> {
     state: &'a mut State,
@@ -97,6 +104,7 @@ where
     }
 
     /// Sets the message that will be produced when the [`Button`] is pressed.
+    /// If on_press isn't set, button will be disabled.
     pub fn on_press(mut self, msg: Message) -> Self {
         self.on_press = Some(msg);
         self

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -33,8 +33,18 @@ use std::hash::Hash;
 /// Buttons can be disabled by not having an on_press.
 ///
 /// ```
+/// # use iced_native::{button, Text};
+/// #
+/// # type Button<'a, Message> =
+/// #     iced_native::Button<'a, Message, iced_native::renderer::Null>;
+/// #
+/// # #[derive(Clone)]
+/// # enum Message {
+/// #     ButtonPressed,
+/// # }
+/// #
 /// let mut state = button::State::new();
-/// let disabled_button = Button::new(&mut state, Text::new("I'm disabled!"));
+/// let disabled_button = Button::<Message>::new(&mut state, Text::new("I'm disabled!"));
 /// ```
 #[allow(missing_debug_implementations)]
 pub struct Button<'a, Message, Renderer: self::Renderer> {

--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -21,19 +21,25 @@ use dodrio::bumpalo;
 ///     .on_press(Message::ButtonPressed);
 /// ```
 ///
-/// Buttons can be disabled by not having an on_press.
+/// If a [`Button::on_press`] handler is not set, the resulting [`Button`] will
+/// be disabled:
 ///
 /// ```
 /// # use iced_web::{button, Button, Text};
 /// #
-/// # enum Message {
-/// #     ButtonPressed,
-/// # }
-/// #
-/// let mut state = button::State::new();
-/// let disabled_button = Button::<Message>::new(&mut state, Text::new("I'm disabled!"));
+/// #[derive(Clone)]
+/// enum Message {
+///     ButtonPressed,
+/// }
+///
+/// fn disabled_button(state: &mut button::State) -> Button<'_, Message> {
+///     Button::new(state, Text::new("I'm disabled!"))
+/// }
+///
+/// fn enabled_button(state: &mut button::State) -> Button<'_, Message> {
+///     disabled_button(state).on_press(Message::ButtonPressed)
+/// }
 /// ```
-
 #[allow(missing_debug_implementations)]
 pub struct Button<'a, Message> {
     content: Element<'a, Message>,

--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -24,8 +24,14 @@ use dodrio::bumpalo;
 /// Buttons can be disabled by not having an on_press.
 ///
 /// ```
+/// # use iced_web::{button, Button, Text};
+/// #
+/// # enum Message {
+/// #     ButtonPressed,
+/// # }
+/// #
 /// let mut state = button::State::new();
-/// let disabled_button = Button::new(&mut state, Text::new("I'm disabled!"));
+/// let disabled_button = Button::<Message>::new(&mut state, Text::new("I'm disabled!"));
 /// ```
 
 #[allow(missing_debug_implementations)]

--- a/web/src/widget/button.rs
+++ b/web/src/widget/button.rs
@@ -20,6 +20,14 @@ use dodrio::bumpalo;
 /// let button = Button::new(&mut state, Text::new("Press me!"))
 ///     .on_press(Message::ButtonPressed);
 /// ```
+///
+/// Buttons can be disabled by not having an on_press.
+///
+/// ```
+/// let mut state = button::State::new();
+/// let disabled_button = Button::new(&mut state, Text::new("I'm disabled!"));
+/// ```
+
 #[allow(missing_debug_implementations)]
 pub struct Button<'a, Message> {
     content: Element<'a, Message>,
@@ -90,6 +98,7 @@ impl<'a, Message> Button<'a, Message> {
     }
 
     /// Sets the message that will be produced when the [`Button`] is pressed.
+    /// If on_press isn't set, button will be disabled.
     pub fn on_press(mut self, msg: Message) -> Self {
         self.on_press = Some(msg);
         self
@@ -153,6 +162,8 @@ where
             node = node.on("click", move |_root, _vdom, _event| {
                 event_bus.publish(on_press.clone());
             });
+        } else {
+            node = node.attr("disabled", "");
         }
 
         node.finish()


### PR DESCRIPTION
This PR:
* Adds doc comment for disabled button
* Makes disabled button behavior consistent in iced_web

I also added a new style to the tour, because disabled buttons were indistinguishable from normal buttons and changed the Secondary style color, to make plain gray available for Disabled.