### PR TITLE
text_input: Do not capture Tab/Up/Down keys

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -549,6 +549,11 @@ where
                         self.state.keyboard_modifiers =
                             keyboard::Modifiers::default();
                     }
+                    keyboard::KeyCode::Tab
+                    | keyboard::KeyCode::Up
+                    | keyboard::KeyCode::Down => {
+                        return event::Status::Ignored;
+                    }
                     _ => {}
                 }
 
@@ -560,6 +565,11 @@ where
                 match key_code {
                     keyboard::KeyCode::V => {
                         self.state.is_pasting = None;
+                    }
+                    keyboard::KeyCode::Tab
+                    | keyboard::KeyCode::Up
+                    | keyboard::KeyCode::Down => {
+                        return event::Status::Ignored;
                     }
                     _ => {}
                 }


### PR DESCRIPTION
Fixes #651

This PR has been updated based on the conversation in #651 to ignore three keys that are never part of the text input's characters, and are commonly used for widget navigation.

This is in lieu of an exhaustive mapping of virtual key codes which will never be part of a sequence which results in a character, as I could not find such a canonical mapping.