### PR TITLE
Generic Element Content in Pane Grid TitleBar

### DIFF
--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -1,7 +1,7 @@
 use iced::{
     button, executor, keyboard, pane_grid, scrollable, Align, Application,
-    Button, Column, Command, Container, Element, HorizontalAlignment, Length,
-    PaneGrid, Scrollable, Settings, Subscription, Text,
+    Button, Color, Column, Command, Container, Element, HorizontalAlignment,
+    Length, PaneGrid, Row, Scrollable, Settings, Subscription, Text,
 };
 use iced_native::{event, subscription, Event};
 
@@ -141,10 +141,21 @@ impl Application for Example {
         let pane_grid = PaneGrid::new(&mut self.panes, |pane, content| {
             let is_focused = focus == Some(pane);
 
-            let title_bar =
-                pane_grid::TitleBar::new(format!("Pane {}", content.id))
-                    .padding(10)
-                    .style(style::TitleBar { is_focused });
+            let title = Row::with_children(vec![
+                Text::new("Pane").into(),
+                Text::new(content.id.to_string())
+                    .color(if is_focused {
+                        PANE_ID_COLOR_FOCUSED
+                    } else {
+                        PANE_ID_COLOR_UNFOCUSED
+                    })
+                    .into(),
+            ])
+            .spacing(5);
+
+            let title_bar = pane_grid::TitleBar::new(title)
+                .padding(10)
+                .style(style::TitleBar { is_focused });
 
             pane_grid::Content::new(content.view(pane, total_panes))
                 .title_bar(title_bar)
@@ -164,6 +175,17 @@ impl Application for Example {
             .into()
     }
 }
+
+const PANE_ID_COLOR_UNFOCUSED: Color = Color::from_rgb(
+    0xFF as f32 / 255.0,
+    0xC7 as f32 / 255.0,
+    0xC7 as f32 / 255.0,
+);
+const PANE_ID_COLOR_FOCUSED: Color = Color::from_rgb(
+    0xFF as f32 / 255.0,
+    0x47 as f32 / 255.0,
+    0x47 as f32 / 255.0,
+);
 
 fn handle_hotkey(key_code: keyboard::KeyCode) -> Option<Message> {
     use keyboard::KeyCode;

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -12,11 +12,7 @@ use crate::defaults;
 use crate::{Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::pane_grid;
-use iced_native::text;
-use iced_native::{
-    Element, HorizontalAlignment, Layout, Point, Rectangle, Vector,
-    VerticalAlignment,
-};
+use iced_native::{Element, Layout, Point, Rectangle, Vector};
 
 pub use iced_native::pane_grid::{
     Axis, Configuration, Content, Direction, DragEvent, Pane, ResizeEvent,
@@ -188,14 +184,12 @@ where
         defaults: &Self::Defaults,
         bounds: Rectangle,
         style_sheet: &Self::Style,
-        title: &str,
-        title_size: u16,
-        title_font: Self::Font,
-        title_bounds: Rectangle,
+        content: (&Element<'_, Message, Self>, Layout<'_>),
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
     ) -> Self::Output {
         let style = style_sheet.style();
+        let (title_content, title_layout) = content;
 
         let defaults = Self::Defaults {
             text: defaults::Text {
@@ -205,16 +199,12 @@ where
 
         let background = crate::widget::container::background(bounds, &style);
 
-        let (title_primitive, _) = text::Renderer::draw(
+        let (title_primitive, title_interaction) = title_content.draw(
             self,
             &defaults,
-            title_bounds,
-            title,
-            title_size,
-            title_font,
-            None,
-            HorizontalAlignment::Left,
-            VerticalAlignment::Top,
+            title_layout,
+            cursor_position,
+            &bounds,
         );
 
         if let Some((controls, controls_layout)) = controls {
@@ -234,7 +224,7 @@ where
                         controls_primitive,
                     ],
                 },
-                controls_interaction,
+                controls_interaction.max(title_interaction),
             )
         } else {
             (
@@ -245,7 +235,7 @@ where
                 } else {
                     title_primitive
                 },
-                mouse::Interaction::default(),
+                title_interaction,
             )
         }
     }

--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -7,9 +7,8 @@
 //! drag and drop, and hotkey support.
 //!
 //! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.2/examples/pane_grid
-use crate::backend::{self, Backend};
 use crate::defaults;
-use crate::{Primitive, Renderer};
+use crate::{Backend, Primitive, Renderer};
 use iced_native::mouse;
 use iced_native::pane_grid;
 use iced_native::{Element, Layout, Point, Rectangle, Vector};
@@ -30,7 +29,7 @@ pub type PaneGrid<'a, Message, Backend> =
 
 impl<B> pane_grid::Renderer for Renderer<B>
 where
-    B: Backend + backend::Text,
+    B: Backend,
 {
     fn draw<Message>(
         &mut self,

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -276,10 +276,7 @@ impl pane_grid::Renderer for Null {
         _defaults: &Self::Defaults,
         _bounds: Rectangle,
         _style: &Self::Style,
-        _title: &str,
-        _title_size: u16,
-        _title_font: Self::Font,
-        _title_bounds: Rectangle,
+        _content: (&Element<'_, Message, Self>, Layout<'_>),
         _controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         _cursor_position: Point,
     ) {

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -586,18 +586,15 @@ pub trait Renderer:
     /// It receives:
     /// - the bounds, style of the [`TitleBar`]
     /// - the style of the [`TitleBar`]
-    /// - the title of the [`TitleBar`] with its size, font, and bounds
-    /// - the controls of the [`TitleBar`] with their [`Layout`+, if any
+    /// - the content of the [`TitleBar`] with its layout
+    /// - the controls of the [`TitleBar`] with their [`Layout`], if any
     /// - the cursor position
     fn draw_title_bar<Message>(
         &mut self,
         defaults: &Self::Defaults,
         bounds: Rectangle,
         style: &Self::Style,
-        title: &str,
-        title_size: u16,
-        title_font: Self::Font,
-        title_bounds: Rectangle,
+        content: (&Element<'_, Message, Self>, Layout<'_>),
         controls: Option<(&Element<'_, Message, Self>, Layout<'_>)>,
         cursor_position: Point,
     ) -> Self::Output;

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -33,7 +33,6 @@ use crate::layout;
 use crate::mouse;
 use crate::overlay;
 use crate::row;
-use crate::text;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
     Widget,
@@ -543,9 +542,7 @@ where
 /// able to use a [`PaneGrid`] in your user interface.
 ///
 /// [renderer]: crate::renderer
-pub trait Renderer:
-    crate::Renderer + container::Renderer + text::Renderer + Sized
-{
+pub trait Renderer: crate::Renderer + container::Renderer + Sized {
     /// Draws a [`PaneGrid`].
     ///
     /// It receives:

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -1,41 +1,36 @@
 use crate::event::{self, Event};
 use crate::layout;
 use crate::pane_grid;
-use crate::{Clipboard, Element, Hasher, Layout, Point, Rectangle, Size};
+use crate::{Clipboard, Element, Hasher, Layout, Point, Size};
 
 /// The title bar of a [`Pane`].
 ///
 /// [`Pane`]: crate::widget::pane_grid::Pane
 #[allow(missing_debug_implementations)]
 pub struct TitleBar<'a, Message, Renderer: pane_grid::Renderer> {
-    title: String,
-    title_size: Option<u16>,
+    content: Element<'a, Message, Renderer>,
     controls: Option<Element<'a, Message, Renderer>>,
     padding: u16,
     always_show_controls: bool,
     style: Renderer::Style,
 }
 
-impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
+impl<'a, Message, Renderer: 'a> TitleBar<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {
-    /// Creates a new [`TitleBar`] with the given title.
-    pub fn new(title: impl Into<String>) -> Self {
+    /// Creates a new [`TitleBar`] with the given content.
+    pub fn new<E>(content: E) -> Self
+    where
+        E: Into<Element<'a, Message, Renderer>>,
+    {
         Self {
-            title: title.into(),
-            title_size: None,
+            content: content.into(),
             controls: None,
             padding: 0,
             always_show_controls: false,
             style: Renderer::Style::default(),
         }
-    }
-
-    /// Sets the size of the title of the [`TitleBar`].
-    pub fn title_size(mut self, size: u16) -> Self {
-        self.title_size = Some(size);
-        self
     }
 
     /// Sets the controls of the [`TitleBar`].
@@ -91,48 +86,29 @@ where
         let mut children = layout.children();
         let padded = children.next().unwrap();
 
-        if let Some(controls) = &self.controls {
-            let mut children = padded.children();
-            let title_layout = children.next().unwrap();
+        let mut children = padded.children();
+        let title_layout = children.next().unwrap();
+
+        let controls = if let Some(controls) = &self.controls {
             let controls_layout = children.next().unwrap();
 
-            let (title_bounds, controls) =
-                if show_controls || self.always_show_controls {
-                    (title_layout.bounds(), Some((controls, controls_layout)))
-                } else {
-                    (
-                        Rectangle {
-                            width: padded.bounds().width,
-                            ..title_layout.bounds()
-                        },
-                        None,
-                    )
-                };
-
-            renderer.draw_title_bar(
-                defaults,
-                layout.bounds(),
-                &self.style,
-                &self.title,
-                self.title_size.unwrap_or(renderer.default_size()),
-                Renderer::Font::default(),
-                title_bounds,
-                controls,
-                cursor_position,
-            )
+            if show_controls || self.always_show_controls {
+                Some((controls, controls_layout))
+            } else {
+                None
+            }
         } else {
-            renderer.draw_title_bar::<()>(
-                defaults,
-                layout.bounds(),
-                &self.style,
-                &self.title,
-                self.title_size.unwrap_or(renderer.default_size()),
-                Renderer::Font::default(),
-                padded.bounds(),
-                None,
-                cursor_position,
-            )
-        }
+            None
+        };
+
+        renderer.draw_title_bar(
+            defaults,
+            layout.bounds(),
+            &self.style,
+            (&self.content, title_layout),
+            controls,
+            cursor_position,
+        )
     }
 
     /// Returns whether the mouse cursor is over the pick area of the
@@ -165,8 +141,7 @@ where
     pub(crate) fn hash_layout(&self, hasher: &mut Hasher) {
         use std::hash::Hash;
 
-        self.title.hash(hasher);
-        self.title_size.hash(hasher);
+        self.content.hash_layout(hasher);
         self.padding.hash(hasher);
     }
 
@@ -179,15 +154,10 @@ where
         let limits = limits.pad(padding);
         let max_size = limits.max();
 
-        let title_size = self.title_size.unwrap_or(renderer.default_size());
-        let title_font = Renderer::Font::default();
-
-        let (title_width, title_height) = renderer.measure(
-            &self.title,
-            title_size,
-            title_font,
-            Size::new(f32::INFINITY, max_size.height),
-        );
+        let title_layout = self
+            .content
+            .layout(renderer, &layout::Limits::new(Size::ZERO, max_size));
+        let title_size = title_layout.size();
 
         let mut node = if let Some(controls) = &self.controls {
             let mut controls_layout = controls
@@ -196,16 +166,8 @@ where
             let controls_size = controls_layout.size();
             let space_before_controls = max_size.width - controls_size.width;
 
-            let mut title_layout = layout::Node::new(Size::new(
-                title_width.min(space_before_controls),
-                title_height,
-            ));
-
-            let title_size = title_layout.size();
             let height = title_size.height.max(controls_size.height);
 
-            title_layout
-                .move_to(Point::new(0.0, (height - title_size.height) / 2.0));
             controls_layout.move_to(Point::new(space_before_controls, 0.0));
 
             layout::Node::with_children(
@@ -213,7 +175,10 @@ where
                 vec![title_layout, controls_layout],
             )
         } else {
-            layout::Node::new(Size::new(max_size.width, title_height))
+            layout::Node::with_children(
+                Size::new(max_size.width, title_size.height),
+                vec![title_layout],
+            )
         };
 
         node.move_to(Point::new(padding, padding));

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -15,7 +15,7 @@ pub struct TitleBar<'a, Message, Renderer: pane_grid::Renderer> {
     style: Renderer::Style,
 }
 
-impl<'a, Message, Renderer: 'a> TitleBar<'a, Message, Renderer>
+impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
 where
     Renderer: pane_grid::Renderer,
 {


### PR DESCRIPTION
Makes the `TitleBar` more flexible by replacing the basic string + size with a generic `Element`.

Not quite sure if I've connected all the dots, especially regarding events/interactions on the elements within the title content.

Upgraded the example program to have a colored Pane ID, showing off a `Row` containing two `Text` elements.

![Screen Shot 2020-12-10 at 1 47 13 PM](https://user-images.githubusercontent.com/1562417/101821959-49388380-3aee-11eb-90e6-1181c7a9d82e.png)
