### PR TITLE
Update `winit` and `glutin`

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 debug = ["iced_winit/debug"]
 
 [dependencies]
-glutin = "0.25"
+glutin = "0.26"
 
 [dependencies.iced_native]
 version = "0.3"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["gui"]
 debug = ["iced_native/debug"]
 
 [dependencies]
-winit = "0.23"
+winit = "0.24"
 window_clipboard = "0.1"
 log = "0.4"
 thiserror = "1.0"

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -170,7 +170,9 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
         winit::event::MouseButton::Left => mouse::Button::Left,
         winit::event::MouseButton::Right => mouse::Button::Right,
         winit::event::MouseButton::Middle => mouse::Button::Middle,
-        winit::event::MouseButton::Other(other) => mouse::Button::Other(other),
+        winit::event::MouseButton::Other(other) => {
+            mouse::Button::Other(other as u8)
+        }
     }
 }
 


### PR DESCRIPTION
Updates `winit` and `glutin` to the latest releases.

We avoid a breaking change in `mouse::Button::Other` for the time being.