### PR TITLE
Update `resvg` and `font-kit`

### DIFF
--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -44,7 +44,7 @@ version = "0.12"
 optional = true
 
 [dependencies.font-kit]
-version = "0.8"
+version = "0.10"
 optional = true
 
 [package.metadata.docs.rs]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT AND OFL-1.1"
 repository = "https://github.com/hecrj/iced"
 
 [features]
-svg = ["resvg"]
+svg = ["resvg", "usvg"]
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
@@ -40,8 +40,11 @@ version = "0.23"
 optional = true
 
 [dependencies.resvg]
-version = "0.9"
-features = ["raqote-backend"]
+version = "0.12"
+optional = true
+
+[dependencies.usvg]
+version = "0.12"
 optional = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Follow-up to #573.

Thanks to @myfreeweb for most of the changes! I have been able to perform the RGBA to BGRA conversion without relying on `image`, although it may not be as efficient.

Closes #466.