### PR TITLE
Update tokio to v1.0

### DIFF
--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["canvas", "tokio", "debug"] }
-tokio = { version = "0.3", features = ["sync"] }
+tokio = { version = "1.0", features = ["sync"] }
 itertools = "0.9"
 rustc-hash = "1.1"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -26,9 +26,10 @@ optional = true
 features = ["rt-core", "rt-threaded", "time", "stream"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.tokio]
-version = "0.3"
+package = "tokio"
+version = "1.0"
 optional = true
-features = ["rt-multi-thread", "time", "stream"]
+features = ["rt", "rt-multi-thread", "time"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.async-std]
 version = "1.0"

--- a/futures/src/time.rs
+++ b/futures/src/time.rs
@@ -81,6 +81,6 @@ where
             tokio::time::interval_at(start, self.0)
         };
 
-        stream.map(|_| std::time::Instant::now()).boxed()
+        stream.map(tokio::time::Instant::into_std).boxed()
     }
 }

--- a/futures/src/time.rs
+++ b/futures/src/time.rs
@@ -67,8 +67,20 @@ where
 
         let start = tokio::time::Instant::now() + self.0;
 
-        tokio::time::interval_at(start, self.0)
-            .map(|_| std::time::Instant::now())
-            .boxed()
+        let stream = {
+            #[cfg(feature = "tokio")]
+            {
+                futures::stream::unfold(
+                    tokio::time::interval_at(start, self.0),
+                    |mut interval| async move {
+                        Some((interval.tick().await, interval))
+                    },
+                )
+            }
+            #[cfg(feature = "tokio_old")]
+            tokio::time::interval_at(start, self.0)
+        };
+
+        stream.map(|_| std::time::Instant::now()).boxed()
     }
 }


### PR DESCRIPTION
https://docs.rs/tokio/1.0.0/tokio/stream/index.html is why `async-stream` is included, so that we can turn `Interval` ticks to a `impl Stream`.