### PR TITLE
WIP: Upgrade Tokio to 1.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ glow_default_system_font = ["iced_glow/default_system_font"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug"]
 # Enables `tokio` as the `executor::Default` on native platforms
-tokio = ["iced_futures/tokio"]
+tokio = ["iced_futures/tokio", "iced_futures/tokio-stream"]
 # Enables old `tokio` (0.2) as the `executor::Default` on native platforms
 tokio_old = ["iced_futures/tokio_old"]
 # Enables `async-std` as the `executor::Default` on native platforms

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["canvas", "tokio", "debug"] }
-tokio = { version = "0.3", features = ["sync"] }
+tokio = { version = "1.0", features = ["sync"] }
 itertools = "0.9"
 rustc-hash = "1.1"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -26,9 +26,13 @@ optional = true
 features = ["rt-core", "rt-threaded", "time", "stream"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.tokio]
-version = "0.3"
+version = "1.0"
 optional = true
-features = ["rt-multi-thread", "time", "stream"]
+features = ["rt-multi-thread", "time"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.tokio-stream]
+version = "0.1"
+optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.async-std]
 version = "1.0"


### PR DESCRIPTION
This PR is just indicate I'm trying upgrade the tokio to 1.0 version, It's NOT ready for MERGE.

Currently blocked by tokio lack of `Stream` trait
