### PR TITLE
Set IME's window position on TextInput

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -20,6 +20,7 @@ pub fn main() {
     // Initialize winit
     let event_loop = EventLoop::new();
     let window = winit::window::Window::new(&event_loop).unwrap();
+    let window = std::sync::Arc::new(window);
 
     let physical_size = window.inner_size();
     let mut viewport = Viewport::with_physical_size(
@@ -28,11 +29,11 @@ pub fn main() {
     );
     let mut cursor_position = PhysicalPosition::new(-1.0, -1.0);
     let mut modifiers = ModifiersState::default();
-    let mut clipboard = Clipboard::connect(&window);
+    let mut clipboard = Clipboard::connect(window.clone());
 
     // Initialize wgpu
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
-    let surface = unsafe { instance.create_surface(&window) };
+    let surface = unsafe { instance.create_surface(window.as_ref()) };
 
     let (mut device, queue) = futures::executor::block_on(async {
         let adapter = instance

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -136,10 +136,10 @@ async fn run_instance<A, E, C>(
     use glutin::event;
     use iced_winit::futures::stream::StreamExt;
 
+    let clipboard = Clipboard::new(context.window());
+
     let mut state = application::State::new(&application, context.window());
     let mut viewport_version = state.viewport_version();
-    let mut clipboard =
-        Clipboard::new(context.window(), state.viewport().clone());
     let mut user_interface =
         ManuallyDrop::new(application::build_user_interface(
             &mut application,
@@ -242,10 +242,6 @@ async fn run_instance<A, E, C>(
                     ));
 
                     compositor.resize_viewport(physical_size);
-
-                    if let Some(clipboard) = clipboard.as_mut() {
-                        clipboard.2 = state.viewport().clone();
-                    }
 
                     viewport_version = current_viewport_version;
                 }

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -136,10 +136,10 @@ async fn run_instance<A, E, C>(
     use glutin::event;
     use iced_winit::futures::stream::StreamExt;
 
-    let clipboard = Clipboard::new(context.window());
-
     let mut state = application::State::new(&application, context.window());
     let mut viewport_version = state.viewport_version();
+    let mut clipboard =
+        Clipboard::new(context.window(), state.viewport().clone());
     let mut user_interface =
         ManuallyDrop::new(application::build_user_interface(
             &mut application,
@@ -242,6 +242,10 @@ async fn run_instance<A, E, C>(
                     ));
 
                     compositor.resize_viewport(physical_size);
+
+                    if let Some(clipboard) = clipboard.as_mut() {
+                        clipboard.2 = state.viewport().clone();
+                    }
 
                     viewport_version = current_viewport_version;
                 }

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -3,4 +3,7 @@
 pub trait Clipboard {
     /// Returns the current content of the [`Clipboard`] as text.
     fn content(&self) -> Option<String>;
+
+    /// Set Input Method window's position.
+    fn set_input_method_position(&self, position: iced_core::Point);
 }

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -4,6 +4,6 @@ pub trait Clipboard {
     /// Returns the current content of the [`Clipboard`] as text.
     fn content(&self) -> Option<String>;
 
-    /// Set Input Method window's position.
-    fn set_input_method_position(&self, position: iced_core::Point);
+    /// Set IME window's position.
+    fn set_ime_position(&self, position: iced_core::Point);
 }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -590,7 +590,7 @@ where
                     self.size.unwrap_or(renderer.default_size()),
                     self.font,
                 );
-                clipboard.set_input_method_position(Point::new(
+                clipboard.set_ime_position(Point::new(
                     (text_layout.bounds().x + text_value_width).min(
                         text_layout.bounds().x + text_layout.bounds().width,
                     ),

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -15,7 +15,6 @@ debug = ["iced_native/debug"]
 
 [dependencies]
 winit = "0.24"
-raw-window-handle = "0.3.3"
 window_clipboard = "0.1"
 log = "0.4"
 thiserror = "1.0"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -15,9 +15,14 @@ debug = ["iced_native/debug"]
 
 [dependencies]
 winit = "0.24"
+raw-window-handle = "0.3.3"
 window_clipboard = "0.1"
 log = "0.4"
 thiserror = "1.0"
+
+[dependencies.iced_core]
+version = "0.3"
+path = "../core"
 
 [dependencies.iced_native]
 version = "0.3"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -194,9 +194,9 @@ async fn run_instance<A, E, C>(
     use winit::event;
 
     let surface = compositor.create_surface(&window);
-    let clipboard = Clipboard::new(&window);
 
     let mut state = State::new(&application, &window);
+    let mut clipboard = Clipboard::new(&window, state.viewport().clone());
     let mut viewport_version = state.viewport_version();
     let mut swap_chain = {
         let physical_size = state.physical_size();
@@ -307,6 +307,10 @@ async fn run_instance<A, E, C>(
                         physical_size.width,
                         physical_size.height,
                     );
+
+                    if let Some(clipboard) = clipboard.as_mut() {
+                        clipboard.2 = state.viewport().clone();
+                    }
 
                     viewport_version = current_viewport_version;
                 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -193,8 +193,9 @@ async fn run_instance<A, E, C>(
     use iced_futures::futures::stream::StreamExt;
     use winit::event;
 
-    let surface = compositor.create_surface(&window);
-    let mut clipboard = Clipboard::connect(&window);
+    let window = std::sync::Arc::new(window);
+    let surface = compositor.create_surface(window.as_ref());
+    let mut clipboard = Clipboard::connect(window.clone());
 
     let mut state = State::new(&application, &window);
     let mut viewport_version = state.viewport_version();

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -194,9 +194,9 @@ async fn run_instance<A, E, C>(
     use winit::event;
 
     let surface = compositor.create_surface(&window);
+    let clipboard = Clipboard::new(&window);
 
     let mut state = State::new(&application, &window);
-    let mut clipboard = Clipboard::new(&window, state.viewport().clone());
     let mut viewport_version = state.viewport_version();
     let mut swap_chain = {
         let physical_size = state.physical_size();
@@ -307,10 +307,6 @@ async fn run_instance<A, E, C>(
                         physical_size.width,
                         physical_size.height,
                     );
-
-                    if let Some(clipboard) = clipboard.as_mut() {
-                        clipboard.2 = state.viewport().clone();
-                    }
 
                     viewport_version = current_viewport_version;
                 }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -46,7 +46,7 @@ impl Clipboard {
     }
 }
 
-impl<'a> iced_native::Clipboard for Clipboard {
+impl iced_native::Clipboard for Clipboard {
     fn read(&self) -> Option<String> {
         self.read()
     }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -56,6 +56,10 @@ impl iced_native::Clipboard for Clipboard {
                         &mut composition_form as _,
                     )
                 };
+
+                let _ = unsafe {
+                    winapi::um::imm::ImmReleaseContext(handle.hwnd as _, himc)
+                };
             }
         }
     }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -1,66 +1,28 @@
-use raw_window_handle::HasRawWindowHandle;
-
 /// A buffer for short-term storage and transfer within and between
 /// applications.
 #[allow(missing_debug_implementations)]
-pub struct Clipboard(
+pub struct Clipboard<'a>(
     window_clipboard::Clipboard,
-    raw_window_handle::RawWindowHandle,
-    pub crate::Viewport,
+    &'a winit::window::Window,
 );
 
-impl Clipboard {
+impl<'a> Clipboard<'a> {
     /// Creates a new [`Clipboard`] for the given window.
-    pub fn new(
-        window: &winit::window::Window,
-        viewport: crate::Viewport,
-    ) -> Option<Clipboard> {
+    pub fn new(window: &'a winit::window::Window) -> Option<Clipboard<'a>> {
         window_clipboard::Clipboard::new(window)
-            .map(|clipboard| {
-                Clipboard(clipboard, window.raw_window_handle(), viewport)
-            })
+            .map(|clipboard| Clipboard(clipboard, window))
             .ok()
     }
 }
 
-impl iced_native::Clipboard for Clipboard {
+impl<'a> iced_native::Clipboard for Clipboard<'a> {
     fn content(&self) -> Option<String> {
         self.0.read().ok()
     }
 
-    fn set_input_method_position(&self, position: iced_core::Point) {
-        #[cfg(target_os = "windows")]
-        {
-            if let raw_window_handle::RawWindowHandle::Windows(handle) = self.1
-            {
-                let himc =
-                    unsafe { winapi::um::imm::ImmGetContext(handle.hwnd as _) };
-
-                let mut composition_form = winapi::um::imm::COMPOSITIONFORM {
-                    dwStyle: winapi::um::imm::CFS_POINT,
-                    ptCurrentPos: winapi::shared::windef::POINT {
-                        x: (position.x * self.2.scale_factor() as f32) as _,
-                        y: (position.y * self.2.scale_factor() as f32) as _,
-                    },
-                    rcArea: winapi::shared::windef::RECT {
-                        left: 0,
-                        top: 0,
-                        right: 0,
-                        bottom: 0,
-                    },
-                };
-
-                let _ = unsafe {
-                    winapi::um::imm::ImmSetCompositionWindow(
-                        himc,
-                        &mut composition_form as _,
-                    )
-                };
-
-                let _ = unsafe {
-                    winapi::um::imm::ImmReleaseContext(handle.hwnd as _, himc)
-                };
-            }
-        }
+    fn set_ime_position(&self, position: iced_core::Point) {
+        self.1.set_ime_position(winit::dpi::LogicalPosition::new(
+            position.x, position.y,
+        ));
     }
 }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -1,17 +1,62 @@
+use raw_window_handle::HasRawWindowHandle;
+
 /// A buffer for short-term storage and transfer within and between
 /// applications.
 #[allow(missing_debug_implementations)]
-pub struct Clipboard(window_clipboard::Clipboard);
+pub struct Clipboard(
+    window_clipboard::Clipboard,
+    raw_window_handle::RawWindowHandle,
+    pub crate::Viewport,
+);
 
 impl Clipboard {
     /// Creates a new [`Clipboard`] for the given window.
-    pub fn new(window: &winit::window::Window) -> Option<Clipboard> {
-        window_clipboard::Clipboard::new(window).map(Clipboard).ok()
+    pub fn new(
+        window: &winit::window::Window,
+        viewport: crate::Viewport,
+    ) -> Option<Clipboard> {
+        window_clipboard::Clipboard::new(window)
+            .map(|clipboard| {
+                Clipboard(clipboard, window.raw_window_handle(), viewport)
+            })
+            .ok()
     }
 }
 
 impl iced_native::Clipboard for Clipboard {
     fn content(&self) -> Option<String> {
         self.0.read().ok()
+    }
+
+    fn set_input_method_position(&self, position: iced_core::Point) {
+        #[cfg(target_os = "windows")]
+        {
+            if let raw_window_handle::RawWindowHandle::Windows(handle) = self.1
+            {
+                let himc =
+                    unsafe { winapi::um::imm::ImmGetContext(handle.hwnd as _) };
+
+                let mut composition_form = winapi::um::imm::COMPOSITIONFORM {
+                    dwStyle: winapi::um::imm::CFS_POINT,
+                    ptCurrentPos: winapi::shared::windef::POINT {
+                        x: (position.x * self.2.scale_factor() as f32) as _,
+                        y: (position.y * self.2.scale_factor() as f32) as _,
+                    },
+                    rcArea: winapi::shared::windef::RECT {
+                        left: 0,
+                        top: 0,
+                        right: 0,
+                        bottom: 0,
+                    },
+                };
+
+                let _ = unsafe {
+                    winapi::um::imm::ImmSetCompositionWindow(
+                        himc,
+                        &mut composition_form as _,
+                    )
+                };
+            }
+        }
     }
 }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 /// A buffer for short-term storage and transfer within and between
 /// applications.
 #[allow(missing_debug_implementations)]
-pub struct Clipboard<'a> {
+pub struct Clipboard {
     state: State,
-    window: &'a winit::window::Window,
+    window: Arc<winit::window::Window>,
 }
 
 enum State {
@@ -11,10 +13,10 @@ enum State {
     Unavailable,
 }
 
-impl<'a> Clipboard<'a> {
+impl Clipboard {
     /// Creates a new [`Clipboard`] for the given window.
-    pub fn connect(window: &'a winit::window::Window) -> Clipboard<'a> {
-        let state = window_clipboard::Clipboard::connect(window)
+    pub fn connect(window: Arc<winit::window::Window>) -> Clipboard {
+        let state = window_clipboard::Clipboard::connect(window.as_ref())
             .ok()
             .map(State::Connected)
             .unwrap_or(State::Unavailable);
@@ -44,7 +46,7 @@ impl<'a> Clipboard<'a> {
     }
 }
 
-impl<'a> iced_native::Clipboard for Clipboard<'a> {
+impl<'a> iced_native::Clipboard for Clipboard {
     fn read(&self) -> Option<String> {
         self.read()
     }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -17,7 +17,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
 
 #[doc(no_inline)]

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -17,7 +17,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unused_results)]
-// #![forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
 
 #[doc(no_inline)]


### PR DESCRIPTION
# Before
![before](https://user-images.githubusercontent.com/1667746/103873211-d0d7d900-5112-11eb-89f7-d0bf21130675.gif)

# After
![after](https://user-images.githubusercontent.com/1667746/103873217-d2a19c80-5112-11eb-9674-389bd53dc2da.gif)

I've created a very early implementation for setting IME's window position on TextInput ~~which works only on Windows~~.
Currently, I extended the `Clipboard` struct also handles the Input Method to avoid large diff. And set IME's window position in the `on_event` method.

## TODO

- [ ] Rename `Clipboard` and make also have responsibility of Input Method, or Separate struct and pass `Clipboard` and `InputMethod` to `on_event` arguments. Do you think which is better?
- [x] ~~Separate codes related to Input Method to another crate, like `window_clipboard `.~~ I've found that `winit` has the method for this situation.
- [x] Support MacOS
- [x] Support Linux