### PR TITLE
Lighter dual axis scrollable

### DIFF
--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -211,8 +211,8 @@ impl Sandbox for Example {
                  geometry for your widget.",
             ));
 
-        let scrollable = Scrollable::new(&mut self.scroll)
-            .push(Container::new(content).width(Length::Fill).center_x());
+        let scrollable = Scrollable::new(&mut self.scroll,
+            Container::new(content).width(Length::Fill).center_x());
 
         Container::new(scrollable)
             .width(Length::Fill)

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -277,17 +277,15 @@ impl Content {
             ));
         }
 
-        let content = Scrollable::new(scroll)
-            .width(Length::Fill)
-            .spacing(10)
-            .align_items(Align::Center)
-            .push(controls);
+        let content = Scrollable::new(scroll, controls.align_items(Align::Center))
+            .width(Length::Fill);
 
         Container::new(content)
             .width(Length::Fill)
             .height(Length::Fill)
             .padding(5)
             .center_y()
+            .center_x()
             .into()
     }
 }

--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -1,7 +1,4 @@
-use iced::{
-    pick_list, scrollable, Align, Container, Element, Length, PickList,
-    Sandbox, Scrollable, Settings, Space, Text,
-};
+use iced::{Align ,Text ,Space ,Settings ,Scrollable ,Sandbox ,PickList ,Length ,Element ,Container ,Column ,pick_list, scrollable};
 
 pub fn main() -> iced::Result {
     Example::run(Settings::default())
@@ -46,15 +43,14 @@ impl Sandbox for Example {
             Message::LanguageSelected,
         );
 
-        let mut content = Scrollable::new(&mut self.scroll)
+        let content = Scrollable::new(&mut self.scroll, Column::new()
             .width(Length::Fill)
             .align_items(Align::Center)
             .spacing(10)
             .push(Space::with_height(Length::Units(600)))
             .push(Text::new("Which is your favorite language?"))
-            .push(pick_list);
-
-        content = content.push(Space::with_height(Length::Units(600)));
+            .push(pick_list)
+            .push(Space::with_height(Length::Units(600))));
 
         Container::new(content)
             .width(Length::Fill)

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -92,13 +92,15 @@ impl Sandbox for Styling {
         let progress_bar =
             ProgressBar::new(0.0..=100.0, self.slider_value).style(self.theme);
 
-        let scrollable = Scrollable::new(&mut self.scroll)
+        let scrollable = Scrollable::new(&mut self.scroll,
+                Column::new()
+                .push(Text::new("Scroll me!"))
+                .push(Space::with_height(Length::Units(800)))
+                .push(Text::new("You did it!")))
             .width(Length::Fill)
             .height(Length::Units(100))
-            .style(self.theme)
-            .push(Text::new("Scroll me!"))
-            .push(Space::with_height(Length::Units(800)))
-            .push(Text::new("You did it!"));
+            .style(self.theme);
+
 
         let checkbox = Checkbox::new(
             self.toggle_value,

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -196,12 +196,12 @@ impl Application for Todos {
                     .push(controls)
                     .push(tasks);
 
-                Scrollable::new(scroll)
+                Scrollable::new(scroll,
+                    Container::new(content)
+                    .width(Length::Fill)
+                    .center_x()
                     .padding(40)
-                    .push(
-                        Container::new(content).width(Length::Fill).center_x(),
-                    )
-                    .into()
+                    ).into()
             }
         }
     }

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -92,8 +92,8 @@ impl Sandbox for Tour {
             content
         };
 
-        let scrollable = Scrollable::new(scroll)
-            .push(Container::new(content).width(Length::Fill).center_x());
+        let scrollable = Scrollable::new(scroll,
+            Container::new(content).width(Length::Fill).center_x());
 
         Container::new(scrollable)
             .height(Length::Fill)

--- a/native/src/layout/flex.rs
+++ b/native/src/layout/flex.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// The main axis of a flex layout.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Axis {
     /// The horizontal axis
     Horizontal,

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -144,7 +144,7 @@ where
         } = menu;
 
         let container =
-            Container::new(Scrollable::new(&mut state.scrollable).push(List {
+            Container::new(Scrollable::new(&mut state.scrollable, List {
                 options,
                 hovered_option,
                 last_selection,

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -1,6 +1,6 @@
 use crate::{
     button, checkbox, column, container, pane_grid, progress_bar, radio, row,
-    scrollable, slider, text, text_input, Color, Element, Font,
+    scrollable, slider, text, text_input, layout::flex::Axis, Color, Element, Font,
     HorizontalAlignment, Layout, Point, Rectangle, Renderer, Size,
     VerticalAlignment,
 };
@@ -92,6 +92,7 @@ impl scrollable::Renderer for Null {
         _scrollbar_width: u16,
         _scrollbar_margin: u16,
         _scroller_width: u16,
+        _axis: Axis,
     ) -> Option<scrollable::Scrollbar> {
         None
     }

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -279,7 +279,6 @@ where
                         }
                     }
 
-                    return event::Status::Captured;
                 }
                 Event::Touch(event) => {
                     match event {

--- a/wgpu/src/widget/scrollable.rs
+++ b/wgpu/src/widget/scrollable.rs
@@ -3,6 +3,7 @@ use crate::Renderer;
 
 pub use iced_graphics::scrollable::{Scrollbar, Scroller, StyleSheet};
 pub use iced_native::scrollable::State;
+pub use iced_native::layout::flex::Axis;
 
 /// A widget that can vertically display an infinite amount of content
 /// with a scrollbar.


### PR DESCRIPTION
After some discussions, here is a new version of the existing Scrollable widget.
 * This widget becomes much simpler: it exists to wrap a widget that needs a scrollbar.
 * This widget becomes more *flex*ible: it can be configured to be a horizontal or a vertical Scrollable using the .axis(...) method. For horizontal: `.axis(Axis::Horizontal)` and for vertical: `.axis(Axis::Vertical)`.
 * This widget has a default axis: vertical. Large content is usually displayed vertically (web pages for instance) so the default axis is `Axis::Vertical` to save you from having to press more keys.

Additional info:
* `spacing` `padding` `align_item` `push` are gone: wrap the contents in `Container` and `Column/Row` widgets to obtain the desired properties.
 * `width: Length`, `height: Length`, `max_width: u32`, and `max_height: u32` remain. 
 * `style()` setter remains as well.
 * `scrollable` and `scroller` properties: their *thickness* is called `width`, regardless of orientation.  
 

Any feedback is very welcome :) 
For instance, should scrollbar/scroller thickness be called something else than `width` (since `width` is usually a horizontal measurement but `scrollbar/scroller` width can be vertical when they are sideway? 