### PR TITLE
impl Clone and Copy for all Style types in iced_style

### DIFF
--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -2,7 +2,7 @@
 use iced_core::{Background, Color, Vector};
 
 /// The appearance of a button.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Style {
     pub shadow_offset: Vector,
     pub background: Option<Background>,

--- a/style/src/checkbox.rs
+++ b/style/src/checkbox.rs
@@ -2,7 +2,7 @@
 use iced_core::{Background, Color};
 
 /// The appearance of a checkbox.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Style {
     pub background: Background,
     pub checkmark_color: Color,

--- a/style/src/progress_bar.rs
+++ b/style/src/progress_bar.rs
@@ -2,7 +2,7 @@
 use iced_core::{Background, Color};
 
 /// The appearance of a progress bar.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Style {
     pub background: Background,
     pub bar: Background,

--- a/style/src/radio.rs
+++ b/style/src/radio.rs
@@ -2,7 +2,7 @@
 use iced_core::{Background, Color};
 
 /// The appearance of a radio button.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Style {
     pub background: Background,
     pub dot_color: Color,


### PR DESCRIPTION
Many of the `Style` types in `iced_style` implement these traits, which is useful. It would be nice if the rest of the `Style` types in `iced_style` also have implementations of these traits.