### PR TITLE
Update to wgpu 0.7

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -36,7 +36,7 @@ pub fn main() {
     let (mut device, queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::Default,
+                power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: Some(&surface),
             })
             .await
@@ -45,9 +45,9 @@ pub fn main() {
         adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
+                    label: None,
                     features: wgpu::Features::empty(),
                     limits: wgpu::Limits::default(),
-                    shader_validation: false,
                 },
                 None,
             )
@@ -63,7 +63,7 @@ pub fn main() {
         device.create_swap_chain(
             &surface,
             &wgpu::SwapChainDescriptor {
-                usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                 format: format,
                 width: size.width,
                 height: size.height,
@@ -157,7 +157,7 @@ pub fn main() {
                     swap_chain = device.create_swap_chain(
                         &surface,
                         &wgpu::SwapChainDescriptor {
-                            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                             format: format,
                             width: size.width,
                             height: size.height,

--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -19,6 +19,7 @@ impl Scene {
         background_color: Color,
     ) -> wgpu::RenderPass<'a> {
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: target,
                 resolve_target: None,
@@ -48,10 +49,10 @@ impl Scene {
 
 fn build_pipeline(device: &wgpu::Device) -> wgpu::RenderPipeline {
     let vs_module =
-        device.create_shader_module(wgpu::include_spirv!("shader/vert.spv"));
+        device.create_shader_module(&wgpu::include_spirv!("shader/vert.spv"));
 
     let fs_module =
-        device.create_shader_module(wgpu::include_spirv!("shader/frag.spv"));
+        device.create_shader_module(&wgpu::include_spirv!("shader/frag.spv"));
 
     let pipeline_layout =
         device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -64,34 +65,33 @@ fn build_pipeline(device: &wgpu::Device) -> wgpu::RenderPipeline {
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: None,
             layout: Some(&pipeline_layout),
-            vertex_stage: wgpu::ProgrammableStageDescriptor {
+            vertex: wgpu::VertexState {
                 module: &vs_module,
                 entry_point: "main",
+                buffers: &[],
             },
-            fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
+            fragment: Some(wgpu::FragmentState {
                 module: &fs_module,
                 entry_point: "main",
+                targets: &[wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    color_blend: wgpu::BlendState::REPLACE,
+                    alpha_blend: wgpu::BlendState::REPLACE,
+                    write_mask: wgpu::ColorWrite::ALL,
+                }],
             }),
-            rasterization_state: Some(wgpu::RasterizationStateDescriptor {
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
                 front_face: wgpu::FrontFace::Ccw,
                 cull_mode: wgpu::CullMode::None,
                 ..Default::default()
-            }),
-            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-            color_states: &[wgpu::ColorStateDescriptor {
-                format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                color_blend: wgpu::BlendDescriptor::REPLACE,
-                alpha_blend: wgpu::BlendDescriptor::REPLACE,
-                write_mask: wgpu::ColorWrite::ALL,
-            }],
-            depth_stencil_state: None,
-            vertex_state: wgpu::VertexStateDescriptor {
-                index_format: wgpu::IndexFormat::Uint16,
-                vertex_buffers: &[],
             },
-            sample_count: 1,
-            sample_mask: !0,
-            alpha_to_coverage_enabled: false,
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
         });
 
     pipeline

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -14,8 +14,8 @@ qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
 
 [dependencies]
-wgpu = "0.7.0"
-wgpu_glyph = {git="https://github.com/hecrj/wgpu_glyph.git"}
+wgpu = "0.7"
+wgpu_glyph = "0.11"
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -14,8 +14,8 @@ qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
 
 [dependencies]
-wgpu = "0.6"
-wgpu_glyph = "0.10"
+wgpu = "0.7.0"
+wgpu_glyph = {git="https://github.com/hecrj/wgpu_glyph.git"}
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -422,7 +422,7 @@ impl Pipeline {
 
             let mut render_pass =
                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("iced_wgpu::image Render Pass"),
+                    label: Some("iced_wgpu::image render pass"),
                     color_attachments: &[
                         wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: target,

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -76,7 +76,7 @@ impl Pipeline {
                         visibility: wgpu::ShaderStage::FRAGMENT,
                         ty: wgpu::BindingType::Sampler {
                             comparison: false,
-                            filtering: false,
+                            filtering: true,
                         },
                         count: None,
                     },
@@ -118,7 +118,7 @@ impl Pipeline {
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float {
-                            filterable: false,
+                            filterable: true,
                         },
                         view_dimension: wgpu::TextureViewDimension::D2Array,
                         multisampled: false,

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -120,7 +120,7 @@ impl Pipeline {
                         sample_type: wgpu::TextureSampleType::Float {
                             filterable: false,
                         },
-                        view_dimension: wgpu::TextureViewDimension::D2,
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
                         multisampled: false,
                     },
                     count: None,

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -62,8 +62,9 @@ impl Pipeline {
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
                         visibility: wgpu::ShaderStage::VERTEX,
-                        ty: wgpu::BindingType::UniformBuffer {
-                            dynamic: false,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
                             min_binding_size: wgpu::BufferSize::new(
                                 mem::size_of::<Uniforms>() as u64,
                             ),
@@ -73,7 +74,10 @@ impl Pipeline {
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
                         visibility: wgpu::ShaderStage::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler { comparison: false },
+                        ty: wgpu::BindingType::Sampler {
+                            comparison: false,
+                            filtering: false,
+                        },
                         count: None,
                     },
                 ],
@@ -93,9 +97,11 @@ impl Pipeline {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(
-                            uniforms_buffer.slice(..),
-                        ),
+                        resource: wgpu::BindingResource::Buffer {
+                            buffer: &uniforms_buffer,
+                            offset: 0,
+                            size: None,
+                        },
                     },
                     wgpu::BindGroupEntry {
                         binding: 1,
@@ -110,9 +116,11 @@ impl Pipeline {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
-                        dimension: wgpu::TextureViewDimension::D2,
-                        component_type: wgpu::TextureComponentType::Float,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float {
+                            filterable: false,
+                        },
+                        view_dimension: wgpu::TextureViewDimension::D2,
                         multisampled: false,
                     },
                     count: None,
@@ -126,11 +134,11 @@ impl Pipeline {
                 bind_group_layouts: &[&constant_layout, &texture_layout],
             });
 
-        let vs_module = device.create_shader_module(wgpu::include_spirv!(
+        let vs_module = device.create_shader_module(&wgpu::include_spirv!(
             "shader/image.vert.spv"
         ));
 
-        let fs_module = device.create_shader_module(wgpu::include_spirv!(
+        let fs_module = device.create_shader_module(&wgpu::include_spirv!(
             "shader/image.frag.spv"
         ));
 
@@ -138,72 +146,44 @@ impl Pipeline {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("iced_wgpu::image pipeline"),
                 layout: Some(&layout),
-                vertex_stage: wgpu::ProgrammableStageDescriptor {
+                vertex: wgpu::VertexState {
                     module: &vs_module,
                     entry_point: "main",
-                },
-                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                    module: &fs_module,
-                    entry_point: "main",
-                }),
-                rasterization_state: Some(wgpu::RasterizationStateDescriptor {
-                    front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
-                    ..Default::default()
-                }),
-                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-                color_states: &[wgpu::ColorStateDescriptor {
-                    format,
-                    color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    alpha_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::One,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    write_mask: wgpu::ColorWrite::ALL,
-                }],
-                depth_stencil_state: None,
-                vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
-                    vertex_buffers: &[
-                        wgpu::VertexBufferDescriptor {
-                            stride: mem::size_of::<Vertex>() as u64,
+                    buffers: &[
+                        wgpu::VertexBufferLayout {
+                            array_stride: mem::size_of::<Vertex>() as u64,
                             step_mode: wgpu::InputStepMode::Vertex,
-                            attributes: &[wgpu::VertexAttributeDescriptor {
+                            attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
                                 format: wgpu::VertexFormat::Float2,
                                 offset: 0,
                             }],
                         },
-                        wgpu::VertexBufferDescriptor {
-                            stride: mem::size_of::<Instance>() as u64,
+                        wgpu::VertexBufferLayout {
+                            array_stride: mem::size_of::<Instance>() as u64,
                             step_mode: wgpu::InputStepMode::Instance,
                             attributes: &[
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 1,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 0,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 2,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 4 * 2,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 3,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 4 * 4,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 4,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 4 * 6,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 5,
                                     format: wgpu::VertexFormat::Uint,
                                     offset: 4 * 8,
@@ -212,9 +192,36 @@ impl Pipeline {
                         },
                     ],
                 },
-                sample_count: 1,
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
+                fragment: Some(wgpu::FragmentState {
+                    module: &fs_module,
+                    entry_point: "main",
+                    targets: &[wgpu::ColorTargetState {
+                        format,
+                        color_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        write_mask: wgpu::ColorWrite::ALL,
+                    }],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    front_face: wgpu::FrontFace::Cw,
+                    cull_mode: wgpu::CullMode::None,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
             });
 
         let vertices =
@@ -415,6 +422,7 @@ impl Pipeline {
 
             let mut render_pass =
                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("iced_wgpu::image Render Pass"),
                     color_attachments: &[
                         wgpu::RenderPassColorAttachmentDescriptor {
                             attachment: target,
@@ -431,7 +439,10 @@ impl Pipeline {
             render_pass.set_pipeline(&self.pipeline);
             render_pass.set_bind_group(0, &self.constants, &[]);
             render_pass.set_bind_group(1, &self.texture, &[]);
-            render_pass.set_index_buffer(self.indices.slice(..));
+            render_pass.set_index_buffer(
+                self.indices.slice(..),
+                wgpu::IndexFormat::Uint16,
+            );
             render_pass.set_vertex_buffer(0, self.vertices.slice(..));
             render_pass.set_vertex_buffer(1, self.instances.slice(..));
 

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -130,13 +130,13 @@ impl Pipeline {
                     entry_point: "main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        alpha_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::One,
+                        color_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
                             dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                             operation: wgpu::BlendOperation::Add,
                         },
-                        color_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                        alpha_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::One,
                             dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                             operation: wgpu::BlendOperation::Add,
                         },

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -24,8 +24,9 @@ impl Pipeline {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer {
-                        dynamic: false,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
                         min_binding_size: wgpu::BufferSize::new(
                             mem::size_of::<Uniforms>() as u64,
                         ),
@@ -46,9 +47,11 @@ impl Pipeline {
             layout: &constant_layout,
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
-                resource: wgpu::BindingResource::Buffer(
-                    constants_buffer.slice(..),
-                ),
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &constants_buffer,
+                    offset: 0,
+                    size: None,
+                },
             }],
         });
 
@@ -59,87 +62,61 @@ impl Pipeline {
                 bind_group_layouts: &[&constant_layout],
             });
 
-        let vs_module = device
-            .create_shader_module(wgpu::include_spirv!("shader/quad.vert.spv"));
+        let vs_module = device.create_shader_module(&wgpu::include_spirv!(
+            "shader/quad.vert.spv"
+        ));
 
-        let fs_module = device
-            .create_shader_module(wgpu::include_spirv!("shader/quad.frag.spv"));
+        let fs_module = device.create_shader_module(&wgpu::include_spirv!(
+            "shader/quad.frag.spv"
+        ));
 
         let pipeline =
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("iced_wgpu::quad pipeline"),
                 layout: Some(&layout),
-                vertex_stage: wgpu::ProgrammableStageDescriptor {
+                vertex: wgpu::VertexState {
                     module: &vs_module,
                     entry_point: "main",
-                },
-                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                    module: &fs_module,
-                    entry_point: "main",
-                }),
-                rasterization_state: Some(wgpu::RasterizationStateDescriptor {
-                    front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
-                    ..Default::default()
-                }),
-                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-                color_states: &[wgpu::ColorStateDescriptor {
-                    format,
-                    color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    alpha_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::One,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    write_mask: wgpu::ColorWrite::ALL,
-                }],
-                depth_stencil_state: None,
-                vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
-                    vertex_buffers: &[
-                        wgpu::VertexBufferDescriptor {
-                            stride: mem::size_of::<Vertex>() as u64,
+                    buffers: &[
+                        wgpu::VertexBufferLayout {
+                            array_stride: mem::size_of::<Vertex>() as u64,
                             step_mode: wgpu::InputStepMode::Vertex,
-                            attributes: &[wgpu::VertexAttributeDescriptor {
+                            attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
                                 format: wgpu::VertexFormat::Float2,
                                 offset: 0,
                             }],
                         },
-                        wgpu::VertexBufferDescriptor {
-                            stride: mem::size_of::<layer::Quad>() as u64,
+                        wgpu::VertexBufferLayout {
+                            array_stride: mem::size_of::<layer::Quad>() as u64,
                             step_mode: wgpu::InputStepMode::Instance,
                             attributes: &[
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 1,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 0,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 2,
                                     format: wgpu::VertexFormat::Float2,
                                     offset: 4 * 2,
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 3,
                                     format: wgpu::VertexFormat::Float4,
                                     offset: 4 * (2 + 2),
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 4,
                                     format: wgpu::VertexFormat::Float4,
                                     offset: 4 * (2 + 2 + 4),
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 5,
                                     format: wgpu::VertexFormat::Float,
                                     offset: 4 * (2 + 2 + 4 + 4),
                                 },
-                                wgpu::VertexAttributeDescriptor {
+                                wgpu::VertexAttribute {
                                     shader_location: 6,
                                     format: wgpu::VertexFormat::Float,
                                     offset: 4 * (2 + 2 + 4 + 4 + 1),
@@ -148,9 +125,36 @@ impl Pipeline {
                         },
                     ],
                 },
-                sample_count: 1,
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
+                fragment: Some(wgpu::FragmentState {
+                    module: &fs_module,
+                    entry_point: "main",
+                    targets: &[wgpu::ColorTargetState {
+                        format,
+                        alpha_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        color_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        write_mask: wgpu::ColorWrite::ALL,
+                    }],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    front_face: wgpu::FrontFace::Cw,
+                    cull_mode: wgpu::CullMode::None,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
             });
 
         let vertices =
@@ -232,6 +236,7 @@ impl Pipeline {
             {
                 let mut render_pass =
                     encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("iced_wgpu::quad render pass"),
                         color_attachments: &[
                             wgpu::RenderPassColorAttachmentDescriptor {
                                 attachment: target,
@@ -247,7 +252,10 @@ impl Pipeline {
 
                 render_pass.set_pipeline(&self.pipeline);
                 render_pass.set_bind_group(0, &self.constants, &[]);
-                render_pass.set_index_buffer(self.indices.slice(..));
+                render_pass.set_index_buffer(
+                    self.indices.slice(..),
+                    wgpu::IndexFormat::Uint16,
+                );
                 render_pass.set_vertex_buffer(0, self.vertices.slice(..));
                 render_pass.set_vertex_buffer(1, self.instances.slice(..));
                 render_pass.set_scissor_rect(

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -258,12 +258,13 @@ impl Pipeline {
                 );
                 render_pass.set_vertex_buffer(0, self.vertices.slice(..));
                 render_pass.set_vertex_buffer(1, self.instances.slice(..));
+
                 render_pass.set_scissor_rect(
                     bounds.x,
                     bounds.y,
                     bounds.width,
                     // TODO: Address anti-aliasing adjustments properly
-                    bounds.height + 1,
+                    bounds.height,
                 );
 
                 render_pass.draw_indexed(

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -362,7 +362,7 @@ impl Pipeline {
 
             let mut render_pass =
                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("iced_wgpu::triangle Render Pass"),
+                    label: Some("iced_wgpu::triangle render pass"),
                     color_attachments: &[
                         wgpu::RenderPassColorAttachmentDescriptor {
                             attachment,

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -86,8 +86,9 @@ impl Pipeline {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer {
-                        dynamic: true,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
                         min_binding_size: wgpu::BufferSize::new(
                             mem::size_of::<Uniforms>() as u64,
                         ),
@@ -109,11 +110,13 @@ impl Pipeline {
                 layout: &constants_layout,
                 entries: &[wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: wgpu::BindingResource::Buffer(
-                        constants_buffer
-                            .raw
-                            .slice(0..std::mem::size_of::<Uniforms>() as u64),
-                    ),
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &constants_buffer.raw,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(
+                            std::mem::size_of::<Uniforms>() as u64,
+                        ),
+                    },
                 }],
             });
 
@@ -124,11 +127,11 @@ impl Pipeline {
                 bind_group_layouts: &[&constants_layout],
             });
 
-        let vs_module = device.create_shader_module(wgpu::include_spirv!(
+        let vs_module = device.create_shader_module(&wgpu::include_spirv!(
             "shader/triangle.vert.spv"
         ));
 
-        let fs_module = device.create_shader_module(wgpu::include_spirv!(
+        let fs_module = device.create_shader_module(&wgpu::include_spirv!(
             "shader/triangle.frag.spv"
         ));
 
@@ -136,49 +139,21 @@ impl Pipeline {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("iced_wgpu::triangle pipeline"),
                 layout: Some(&layout),
-                vertex_stage: wgpu::ProgrammableStageDescriptor {
+                vertex: wgpu::VertexState {
                     module: &vs_module,
                     entry_point: "main",
-                },
-                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
-                    module: &fs_module,
-                    entry_point: "main",
-                }),
-                rasterization_state: Some(wgpu::RasterizationStateDescriptor {
-                    front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
-                    ..Default::default()
-                }),
-                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-                color_states: &[wgpu::ColorStateDescriptor {
-                    format,
-                    color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    alpha_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::One,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    write_mask: wgpu::ColorWrite::ALL,
-                }],
-                depth_stencil_state: None,
-                vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint32,
-                    vertex_buffers: &[wgpu::VertexBufferDescriptor {
-                        stride: mem::size_of::<Vertex2D>() as u64,
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: mem::size_of::<Vertex2D>() as u64,
                         step_mode: wgpu::InputStepMode::Vertex,
                         attributes: &[
                             // Position
-                            wgpu::VertexAttributeDescriptor {
+                            wgpu::VertexAttribute {
                                 shader_location: 0,
                                 format: wgpu::VertexFormat::Float2,
                                 offset: 0,
                             },
                             // Color
-                            wgpu::VertexAttributeDescriptor {
+                            wgpu::VertexAttribute {
                                 shader_location: 1,
                                 format: wgpu::VertexFormat::Float4,
                                 offset: 4 * 2,
@@ -186,11 +161,38 @@ impl Pipeline {
                         ],
                     }],
                 },
-                sample_count: u32::from(
-                    antialiasing.map(|a| a.sample_count()).unwrap_or(1),
-                ),
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
+                fragment: Some(wgpu::FragmentState {
+                    module: &fs_module,
+                    entry_point: "main",
+                    targets: &[wgpu::ColorTargetState {
+                        format,
+                        color_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        write_mask: wgpu::ColorWrite::ALL,
+                    }],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    front_face: wgpu::FrontFace::Cw,
+                    cull_mode: wgpu::CullMode::None,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: u32::from(
+                        antialiasing.map(|a| a.sample_count()).unwrap_or(1),
+                    ),
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
             });
 
         Pipeline {
@@ -252,11 +254,15 @@ impl Pipeline {
                     layout: &self.constants_layout,
                     entries: &[wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(
-                            self.uniforms_buffer.raw.slice(
-                                0..std::mem::size_of::<Uniforms>() as u64,
-                            ),
-                        ),
+                        resource: wgpu::BindingResource::Buffer {
+                            buffer: &self.uniforms_buffer.raw,
+                            offset: 0,
+                            size: wgpu::BufferSize::new(std::mem::size_of::<
+                                Uniforms,
+                            >(
+                            )
+                                as u64),
+                        },
                     }],
                 });
         }
@@ -356,6 +362,7 @@ impl Pipeline {
 
             let mut render_pass =
                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("iced_wgpu::triangle Render Pass"),
                     color_attachments: &[
                         wgpu::RenderPassColorAttachmentDescriptor {
                             attachment,
@@ -390,6 +397,7 @@ impl Pipeline {
                     self.index_buffer
                         .raw
                         .slice(index_offset * mem::size_of::<u32>() as u64..),
+                    wgpu::IndexFormat::Uint32,
                 );
 
                 render_pass.set_vertex_buffer(

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -116,7 +116,6 @@ impl Blit {
                     ..Default::default()
                 },
                 depth_stencil: None,
-
                 multisample: wgpu::MultisampleState {
                     count: 1,
                     mask: !0,

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -32,7 +32,10 @@ impl Blit {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler { comparison: false },
+                    ty: wgpu::BindingType::Sampler {
+                        comparison: false,
+                        filtering: true,
+                    },
                     count: None,
                 }],
             });
@@ -53,9 +56,11 @@ impl Blit {
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStage::FRAGMENT,
-                    ty: wgpu::BindingType::SampledTexture {
-                        dimension: wgpu::TextureViewDimension::D2,
-                        component_type: wgpu::TextureComponentType::Float,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float {
+                            filterable: true,
+                        },
+                        view_dimension: wgpu::TextureViewDimension::D2,
                         multisampled: false,
                     },
                     count: None,
@@ -69,11 +74,11 @@ impl Blit {
                 bind_group_layouts: &[&constant_layout, &texture_layout],
             });
 
-        let vs_module = device.create_shader_module(wgpu::include_spirv!(
+        let vs_module = device.create_shader_module(&wgpu::include_spirv!(
             "../shader/blit.vert.spv"
         ));
 
-        let fs_module = device.create_shader_module(wgpu::include_spirv!(
+        let fs_module = device.create_shader_module(&wgpu::include_spirv!(
             "../shader/blit.frag.spv"
         ));
 
@@ -81,42 +86,42 @@ impl Blit {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("iced_wgpu::triangle::msaa pipeline"),
                 layout: Some(&layout),
-                vertex_stage: wgpu::ProgrammableStageDescriptor {
+                vertex: wgpu::VertexState {
                     module: &vs_module,
                     entry_point: "main",
+                    buffers: &[],
                 },
-                fragment_stage: Some(wgpu::ProgrammableStageDescriptor {
+                fragment: Some(wgpu::FragmentState {
                     module: &fs_module,
                     entry_point: "main",
+                    targets: &[wgpu::ColorTargetState {
+                        format,
+                        color_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha_blend: wgpu::BlendState {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        write_mask: wgpu::ColorWrite::ALL,
+                    }],
                 }),
-                rasterization_state: Some(wgpu::RasterizationStateDescriptor {
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
                     front_face: wgpu::FrontFace::Cw,
                     cull_mode: wgpu::CullMode::None,
                     ..Default::default()
-                }),
-                primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-                color_states: &[wgpu::ColorStateDescriptor {
-                    format,
-                    color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    alpha_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::One,
-                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                        operation: wgpu::BlendOperation::Add,
-                    },
-                    write_mask: wgpu::ColorWrite::ALL,
-                }],
-                depth_stencil_state: None,
-                vertex_state: wgpu::VertexStateDescriptor {
-                    index_format: wgpu::IndexFormat::Uint16,
-                    vertex_buffers: &[],
                 },
-                sample_count: 1,
-                sample_mask: !0,
-                alpha_to_coverage_enabled: false,
+                depth_stencil: None,
+
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
             });
 
         Blit {
@@ -172,6 +177,7 @@ impl Blit {
     ) {
         let mut render_pass =
             encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("iced_wgpu::triangle::msaa Render Pass"),
                 color_attachments: &[
                     wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: target,
@@ -227,7 +233,7 @@ impl Targets {
             sample_count,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         });
 
         let resolve = device.create_texture(&wgpu::TextureDescriptor {
@@ -237,7 +243,7 @@ impl Targets {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT
+            usage: wgpu::TextureUsage::RENDER_ATTACHMENT
                 | wgpu::TextureUsage::SAMPLED,
         });
 

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -177,7 +177,7 @@ impl Blit {
     ) {
         let mut render_pass =
             encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("iced_wgpu::triangle::msaa Render Pass"),
+                label: Some("iced_wgpu::triangle::msaa render pass"),
                 color_attachments: &[
                     wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: target,

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -34,7 +34,7 @@ impl Blit {
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Sampler {
                         comparison: false,
-                        filtering: true,
+                        filtering: false,
                     },
                     count: None,
                 }],
@@ -58,7 +58,7 @@ impl Blit {
                     visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float {
-                            filterable: true,
+                            filterable: false,
                         },
                         view_dimension: wgpu::TextureViewDimension::D2,
                         multisampled: false,

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -39,7 +39,7 @@ impl Compositor {
             .request_device(
                 &wgpu::DeviceDescriptor {
                     label: Some(
-                        "iced_wgpu::window::Compositor Device Descriptor",
+                        "iced_wgpu::window::compositor device descriptor",
                     ),
                     features: wgpu::Features::empty(),
                     limits: wgpu::Limits {
@@ -132,7 +132,7 @@ impl iced_graphics::window::Compositor for Compositor {
         );
 
         let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("iced_wgpu::window::Compositor Render Pass"),
+            label: Some("iced_wgpu::window::Compositor render pass"),
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.output.view,
                 resolve_target: None,

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -27,7 +27,7 @@ impl Compositor {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: if settings.antialiasing.is_none() {
-                    wgpu::PowerPreference::default()
+                    wgpu::PowerPreference::LowPower
                 } else {
                     wgpu::PowerPreference::HighPerformance
                 },

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -27,7 +27,7 @@ impl Compositor {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: if settings.antialiasing.is_none() {
-                    wgpu::PowerPreference::Default
+                    wgpu::PowerPreference::default()
                 } else {
                     wgpu::PowerPreference::HighPerformance
                 },
@@ -38,12 +38,14 @@ impl Compositor {
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {
+                    label: Some(
+                        "iced_wgpu::window::Compositor Device Descriptor",
+                    ),
                     features: wgpu::Features::empty(),
                     limits: wgpu::Limits {
                         max_bind_groups: 2,
                         ..wgpu::Limits::default()
                     },
-                    shader_validation: false,
                 },
                 None,
             )
@@ -103,7 +105,7 @@ impl iced_graphics::window::Compositor for Compositor {
         self.device.create_swap_chain(
             surface,
             &wgpu::SwapChainDescriptor {
-                usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                 format: self.settings.format,
                 present_mode: self.settings.present_mode,
                 width,
@@ -130,6 +132,7 @@ impl iced_graphics::window::Compositor for Compositor {
         );
 
         let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("iced_wgpu::window::Compositor Render Pass"),
             color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                 attachment: &frame.output.view,
                 resolve_target: None,


### PR DESCRIPTION
Notes:
- `wgpu::PowerPreference::Default` no longer exists, maybe there is another way to replicate its behavior.
- Not sure if `filtering sampler` should be used. (so it is not used)
- Anti-aliasig fix had to be removed because of wgpu ScissorRect validation error [link](https://github.com/hecrj/iced/pull/725/commits/bd6b8304bd940c5519fdf705698974994d5d1ca1)

What is working:
- [x] bezier_tool
- [x] clock
- [x] color_palette
- [x] counter
- [x] custom_widget
- [x] download_progress
- [x] events
- [x] game_of_life
- [x] geometry
- [x] integration
- [x] pane_grid
- [x] pick_list
- [x] pokedex
- [x] progress_bar
- [x] qr_code
- [x] scrollable
- [x] solar_system
- [x] stopwatch
- [x] styling
- [x] svg
- [x] todos
- [x] tour

Closes #723.