### PR TITLE
Some Scrolling tweaks

### DIFF
--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -244,6 +244,48 @@ where
                 } else {
                     event_status
                 }
+            },
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if layout.bounds().contains(cursor_position) && *self.is_open == false {
+                    let negative: bool;
+                    match delta {
+                        mouse::ScrollDelta::Lines { y, .. } => {
+                            negative = y.is_sign_negative();
+                        }
+                        mouse::ScrollDelta::Pixels { y, .. } => {
+                            negative = y.is_sign_negative();
+                        }
+                    };
+                    if negative {
+                        if let Some(selected) = self.selected.as_ref() {
+                            let i = self.options.iter().position(|option| option == selected).unwrap() + 1;
+                            if i < self.options.len() {
+                                messages.push((self.on_selected)
+                                    (self.options[i].clone()));
+                            }
+                        } else {
+                            messages.push((self.on_selected)
+                            (self.options[0].clone()))
+                        }
+                    } else {
+                        if let Some(selected) = self.selected.as_ref() {
+                            let i = self.options.iter().position(|option| option == selected).unwrap();
+                            if i != 0 {
+                                messages.push((self.on_selected)
+                                    (self.options[i - 1].clone()));
+                            }
+
+                        } else {
+                            messages.push((self.on_selected)
+                            (self.options[self.options.len() -1].clone()))
+                        }
+                    }
+
+                    
+                    return event::Status::Captured;
+                } else {
+                    return event::Status::Ignored;
+                }
             }
             _ => event::Status::Ignored,
         }


### PR DESCRIPTION
While all of the changes work well, I am quite new to Rust, and I imagine that many changes will have to be made for the code quality to meet the rest of the Iced code base.

3 things in this pull request:
1. Adding scroll to `pick_list`s
    I think that this functionality for pick_lists should be expected. Just allows for selecting from a `pick_list` by scrolling over a closed `pick_list`. Though I am not confident with my code quality. It works reliably, but code is a mess. Please let me know how to improve it.

2. Adding `on_scroll` functions to `text_input`
    I added `on_scroll_up` and `on_scroll_down` to `Text_Input`s. I am not confident on implementation nor code quality on this one. I needed it on my project specifically for `Text_Input`s that the user enters integers, and then scroll for tweaks if wanted (think a timer input that allows to typing in the time as well as scrolling to the time). These functions could also be useful for other widgets (`on_scroll_left` could be useful for a slider for example). Though I am open to any code implementation ideas.

3. Adding convenience functions for `scrollable`s
    Simple functions just for convenience, rather than having to play with `Rectangles` and content, just one function call to scroll to the bottom. (I use this on a GUI that creates new elements in a list above the create button. The create button is always at the bottom of a `Scrollable` thus scrolling to the bottom after pressing the create button is convenient).