### PR TITLE
Overwrite `overlay` method in Widget implementation for Button

### DIFF
--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -246,7 +246,7 @@ where
         &mut self,
         layout: Layout<'_>,
     ) -> Option<overlay::Element<'_, Message, Renderer>> {
-        self.content.overlay(layout)
+        self.content.overlay(layout.children().next().unwrap())
     }
 }
 

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -2,6 +2,7 @@
 //!
 //! A [`Button`] has some local [`State`].
 use crate::event::{self, Event};
+use crate::overlay;
 use crate::layout;
 use crate::mouse;
 use crate::touch;
@@ -239,6 +240,13 @@ where
 
         self.width.hash(state);
         self.content.hash_layout(state);
+    }
+
+    fn overlay(
+        &mut self,
+        layout: Layout<'_>,
+    ) -> Option<overlay::Element<'_, Message, Renderer>> {
+        self.content.overlay(layout)
     }
 }
 

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -2,9 +2,9 @@
 //!
 //! A [`Button`] has some local [`State`].
 use crate::event::{self, Event};
-use crate::overlay;
 use crate::layout;
 use crate::mouse;
+use crate::overlay;
 use crate::touch;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Widget,


### PR DESCRIPTION
This solved #763 for me. 
I hope it's ok for Buttons to have an overlay.

Closes #763.