### PR TITLE
Added `select_all` method to `TextInput`.

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -265,8 +265,10 @@ impl Task {
                 self.completed = completed;
             }
             TaskMessage::Edit => {
+                let mut text_input = text_input::State::focused();
+                text_input.select_all();
                 self.state = TaskState::Editing {
-                    text_input: text_input::State::focused(),
+                    text_input,
                     delete_button: button::State::new(),
                 };
             }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -267,6 +267,7 @@ impl Task {
             TaskMessage::Edit => {
                 let mut text_input = text_input::State::focused();
                 text_input.select_all();
+
                 self.state = TaskState::Editing {
                     text_input,
                     delete_button: button::State::new(),

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -792,6 +792,11 @@ impl State {
     pub fn move_cursor_to(&mut self, position: usize) {
         self.cursor.move_to(position);
     }
+
+    /// Selects all the content of the [`TextInput`].
+    pub fn select_all(&mut self) {
+        self.cursor.select_range(0, usize::MAX);
+    }
 }
 
 // TODO: Reduce allocations

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -232,4 +232,9 @@ impl State {
         // TODO
         Self::default()
     }
+
+    /// Selects all the content of the [`TextInput`].
+    pub fn select_all(&mut self) {
+        // TODO
+    }
 }


### PR DESCRIPTION
Hi, and thank you for creating iced.

I was tinkering with the `todos` example and I wanted to pre-select the text when you clicked the edit button.

But when I tried to update the example I noticed that the public methods from `TextInput` only allowed to move the cursor, so I added a `select_all` method and updated the `todos` example to achieve the desired outcome.