### PR TITLE
feat(web): Support in-memory image data

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -20,7 +20,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 url = "2.0"
 num-traits = "0.2"
-js-sys = "0.3"
+base64 = "0.13"
 
 [dependencies.iced_core]
 version = "0.3"
@@ -45,6 +45,4 @@ features = [
     "EventTarget",
     "InputEvent",
     "KeyboardEvent",
-    "Url",
-    "Blob",
 ]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -46,4 +46,5 @@ features = [
     "InputEvent",
     "KeyboardEvent",
     "Url",
+    "Blob",
 ]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -20,6 +20,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 url = "2.0"
 num-traits = "0.2"
+js-sys = "0.3"
 
 [dependencies.iced_core]
 version = "0.3"
@@ -44,4 +45,5 @@ features = [
     "EventTarget",
     "InputEvent",
     "KeyboardEvent",
+    "Url",
 ]


### PR DESCRIPTION
I had to create two methods which basically do the same thing, `from_memory` and `from_slice`, because `from_memory` takes ownership of the bytes to be compatible with `iced_native`.

Also, `Data` is incompatible, because if I stored the bytes in `Data` and created a new object URL every render, it would have caused a memory leak because bumpalo doesn't call destructors and there'd be no way to call URL.revokeObjectUrl on it. It's also more efficient this way.