### PR TITLE
Add WGPU_BACKEND environment variable

### DIFF
--- a/glow/src/settings.rs
+++ b/glow/src/settings.rs
@@ -29,3 +29,12 @@ impl Default for Settings {
         }
     }
 }
+
+impl Settings {
+    /// Creates new [`Settings`] using environment configuration.
+    ///
+    /// Currently, this is equivalent to calling [`Settings::default`].
+    pub fn from_env() -> Self {
+        Self::default()
+    }
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -206,7 +206,7 @@ pub trait Application: Sized {
                 } else {
                     None
                 },
-                ..crate::renderer::Settings::default()
+                ..crate::renderer::Settings::from_env()
             };
 
             Ok(crate::runtime::application::run::<

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -16,6 +16,9 @@ pub struct Settings {
     /// [`Backend`]: crate::Backend
     pub present_mode: wgpu::PresentMode,
 
+    /// The internal graphics backend to use.
+    pub internal_backend: wgpu::BackendBit,
+
     /// The bytes of the font that will be used by default.
     ///
     /// If `None` is provided, a default system font will be chosen.
@@ -30,14 +33,52 @@ pub struct Settings {
     pub antialiasing: Option<Antialiasing>,
 }
 
+impl Settings {
+    /// Creates new [`Settings`] using environment configuration.
+    ///
+    /// Specifically:
+    ///
+    /// - The `internal_backend` can be configured using the `WGPU_BACKEND`
+    /// environment variable. If the variable is not set, the primary backend
+    /// will be used. The following values are allowed:
+    ///     - `vulkan`
+    ///     - `metal`
+    ///     - `dx12`
+    ///     - `dx11`
+    ///     - `gl`
+    ///     - `webgpu`
+    pub fn from_env() -> Self {
+        Settings {
+            internal_backend: backend_from_env()
+                .unwrap_or(wgpu::BackendBit::PRIMARY),
+            ..Self::default()
+        }
+    }
+}
+
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
             format: wgpu::TextureFormat::Bgra8UnormSrgb,
             present_mode: wgpu::PresentMode::Mailbox,
+            internal_backend: wgpu::BackendBit::PRIMARY,
             default_font: None,
             default_text_size: 20,
             antialiasing: None,
         }
     }
+}
+
+fn backend_from_env() -> Option<wgpu::BackendBit> {
+    std::env::var("WGPU_BACKEND").ok().map(|backend| {
+        match backend.to_lowercase().as_str() {
+            "vulkan" => wgpu::BackendBit::VULKAN,
+            "metal" => wgpu::BackendBit::METAL,
+            "dx12" => wgpu::BackendBit::DX12,
+            "dx11" => wgpu::BackendBit::DX11,
+            "gl" => wgpu::BackendBit::GL,
+            "webgpu" => wgpu::BackendBit::BROWSER_WEBGPU,
+            other => panic!("Unknown backend: {}", other),
+        }
+    })
 }

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -15,35 +15,6 @@ pub struct Compositor {
     local_pool: futures::executor::LocalPool,
 }
 
-#[derive(Clone)]
-pub enum WgpuBackend {
-    Auto,
-    Vulkan,
-    Metal,
-    Dx12,
-    Dx11,
-    Gl,
-    BrowserWgpu,
-}
-
-impl WgpuBackend {
-    fn from_env() -> Self {
-        if let Ok(backend) = std::env::var("WGPU_BACKEND") {
-            match backend.to_lowercase().as_str() {
-                "vulkan" => WgpuBackend::Vulkan,
-                "metal" => WgpuBackend::Metal,
-                "dx12" => WgpuBackend::Dx12,
-                "dx11" => WgpuBackend::Dx11,
-                "gl" => WgpuBackend::Gl,
-                "webgpu" => WgpuBackend::BrowserWgpu,
-                other => panic!("Unknown backend: {}", other),
-            }
-        } else {
-            WgpuBackend::Auto
-        }
-    }
-}
-
 impl Compositor {
     const CHUNK_SIZE: u64 = 10 * 1024;
 
@@ -51,17 +22,7 @@ impl Compositor {
     ///
     /// Returns `None` if no compatible graphics adapter could be found.
     pub async fn request(settings: Settings) -> Option<Self> {
-        let backend = match WgpuBackend::from_env() {
-            WgpuBackend::Auto => wgpu::BackendBit::PRIMARY,
-            WgpuBackend::Vulkan => wgpu::BackendBit::VULKAN,
-            WgpuBackend::Metal => wgpu::BackendBit::METAL,
-            WgpuBackend::Dx12 => wgpu::BackendBit::DX12,
-            WgpuBackend::Dx11 => wgpu::BackendBit::DX11,
-            WgpuBackend::Gl => wgpu::BackendBit::GL,
-            WgpuBackend::BrowserWgpu => wgpu::BackendBit::BROWSER_WEBGPU,
-        };
-
-        let instance = wgpu::Instance::new(backend);
+        let instance = wgpu::Instance::new(settings.internal_backend);
 
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {


### PR DESCRIPTION
Fixes #787. Related to #207.
Inspired by Bevy’s source code.
You can explicitly specify the render backend when you run your app by setting the WGPU_BACKEND environment variable. If this environment variable does not exist, the default is the wgpu::BackendBit::PRIMARY.

If you use cargo with version 1.52 or later, you can easily set your environment variables.

First create a folder called `.cargo` in your project directory, then create a `config.toml` file in the `.cargo` folder:
before:
```shell
.
├── Cargo.lock
├── Cargo.toml
└── src
    └── main.rs
```
after: 
```shell
.
├── Cargo.lock
├── .cargo
│   └── config.toml
├── Cargo.toml
└── src
    └── main.rs
```
`.cargo/config.toml`:
```toml
[env]
WGPU_BACKEND = "dx12"
```
Specific configuration method can be seen [here](https://github.com/rust-lang/cargo/pull/8839#issuecomment-725678657).