### PR TITLE
Added exiting event hook for application

### DIFF
--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -88,4 +88,8 @@ impl Application for Events {
             .center_y()
             .into()
     }
+
+    fn exiting(&self) {
+        println!("Exiting...")
+    }
 }

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -310,4 +310,6 @@ async fn run_instance<A, E, C>(
 
     // Manually drop the user interface
     drop(ManuallyDrop::into_inner(user_interface));
+
+    application.exiting();
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -292,7 +292,7 @@ where
         self.0.scale_factor()
     }
 
-    fn exiting(&self){
+    fn exiting(&self) {
         self.0.exiting()
     }
 }
@@ -332,7 +332,7 @@ where
         self.0.view()
     }
 
-    fn exiting(&self){
+    fn exiting(&self) {
         self.0.exiting()
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -87,6 +87,10 @@ use crate::{
 ///     fn view(&mut self) -> Element<Self::Message> {
 ///         Text::new("Hello, world!").into()
 ///     }
+///
+///     fn exiting(&self) {
+///         println!("Cleaning up custom resources...")
+///     }
 /// }
 /// ```
 pub trait Application: Sized {
@@ -223,6 +227,9 @@ pub trait Application: Sized {
             Ok(())
         }
     }
+
+    /// Triggered when application is exiting.
+    fn exiting(&self) {}
 }
 
 struct Instance<A: Application>(A);
@@ -284,6 +291,10 @@ where
     fn scale_factor(&self) -> f64 {
         self.0.scale_factor()
     }
+
+    fn exiting(&self){
+        self.0.exiting()
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -319,5 +330,9 @@ where
 
     fn view(&mut self) -> Element<'_, Self::Message> {
         self.0.view()
+    }
+
+    fn exiting(&self){
+        self.0.exiting()
     }
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -91,6 +91,9 @@ pub trait Application: Program<Clipboard = Clipboard> {
     fn scale_factor(&self) -> f64 {
         1.0
     }
+
+    /// Triggered when application is exiting.
+    fn exiting(&self) {}
 }
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
@@ -378,6 +381,8 @@ async fn run_instance<A, E, C>(
 
     // Manually drop the user interface
     drop(ManuallyDrop::into_inner(user_interface));
+
+    application.exiting();
 }
 
 /// Returns true if the provided event should cause an [`Application`] to


### PR DESCRIPTION
I found my self needing to clean up other resources before the application is really able to exit, at the moment there is nowhere I could put the clean up logic and the application just hangs when exiting, hence this `exiting()` hook.

(Sorry about the force push that polluted the previous PR.)