### PR TITLE
Enable qr_code feature on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,4 +102,4 @@ iced_web = { version = "0.4", path = "web" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
-features = ["image", "svg", "canvas"]
+features = ["image", "svg", "canvas", "qr_code"]


### PR DESCRIPTION
The `QRCode` widget does not currently appear in the document. https://docs.rs/iced/0.3.0/iced/widget/index.html