### PR TITLE
Add a primary backend that can be set

### DIFF
--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -78,6 +78,7 @@ fn backend_from_env() -> Option<wgpu::BackendBit> {
             "dx11" => wgpu::BackendBit::DX11,
             "gl" => wgpu::BackendBit::GL,
             "webgpu" => wgpu::BackendBit::BROWSER_WEBGPU,
+            "primary" => wgpu::BackendBit::PRIMARY,
             other => panic!("Unknown backend: {}", other),
         }
     })

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -47,6 +47,7 @@ impl Settings {
     ///     - `dx11`
     ///     - `gl`
     ///     - `webgpu`
+    ///     - `primary`
     pub fn from_env() -> Self {
         Settings {
             internal_backend: backend_from_env()


### PR DESCRIPTION
I’ve found that some machines don’t have some backend ( For example, win10, but there is no DX12 ) , and that setting it to a fixed backend can cause problems, so it makes sense to add the option to support fallback within the configurable backend.

Setting an environment variable does make me feel good during development, but the need to set such an environment variable later on when loading the application to the user makes things weird.

I now use dotenv to help me set up environment variables so that I don’t have to deal with the environment variables inside the user system, but it still requires some cumbersome setup.

Therefore, while submitting this PR, I also hope that someone can think about whether there is a more elegant way to deal with this issue. 

The current idea of ​​optional backend is only somewhat useful under the windows platform, because wgpu is currently only supported by vulkan and metal on linux and mac, so this issue is not very important.