### PR TITLE
WIP allow svg render in canvas

### DIFF
--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -215,6 +215,14 @@ impl Frame {
         });
     }
 
+    /// Fill svg
+    pub fn fill_svg(&mut self, svg: super::super::Svg, bounds: Rectangle) {
+        self.primitives.push(Primitive::Svg {
+            handle: svg.handle,
+            bounds,
+        });
+    }
+
     /// Stores the current transform of the [`Frame`] and executes the given
     /// drawing operations, restoring the transform afterwards.
     ///

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -57,6 +57,11 @@ where
         &self.program
     }
 
+    /// Returns a reference to the [`Program`] of the [`State`].
+    pub fn program_mut(&mut self) -> &mut P {
+        &mut self.program
+    }
+
     /// Returns a reference to the current rendering primitive of the [`State`].
     pub fn primitive(&self) -> &<P::Renderer as Renderer>::Output {
         &self.primitive

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -16,7 +16,8 @@ use std::{
 /// specially when they are complex.
 #[derive(Debug, Clone)]
 pub struct Svg {
-    handle: Handle,
+    /// The svg handle
+    pub handle: Handle,
     width: Length,
     height: Length,
 }


### PR DESCRIPTION
@hecrj for #880 i have made simple PR to see how svg can render to canvas. It works for my purpose!

For example, i can do:

```rust
self.cache.draw(bounds.size(), |frame| {
  frame.fill_svg(self.svg, bounds);
});
```

and this works!!!

however, some things:
1. I am not sure if it is good how i pass svg primitive in the `fill_svg` method
2. private handle exposed in PR, but not sure best way to expose
3. there appears to be some kind of gpu memory leak, as it is very slow and render time goes up and up (i do not invalidate cache in my example, and show that fill svg only called once, so i'm not sure what is going on, hopefully you can advise)

thank you!!

I would very like to see svg rendering in canvas, very cool, hope we can fix this and get it in iced sometime