### PR TITLE
pick_list: fix layouting not respecting fonts

### DIFF
--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -163,7 +163,7 @@ where
                         let (width, _) = renderer.measure(
                             &label,
                             text_size,
-                            Renderer::Font::default(),
+                            self.font,
                             Size::new(f32::INFINITY, f32::INFINITY),
                         );
 


### PR DESCRIPTION
pick_list layouting always uses default font when calculating width, resulting in overlaps when using differently spaced fonts.

Fixes #879 