### PR TITLE
Update to wgpu 0.8

### DIFF
--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -20,8 +20,8 @@ impl Scene {
     ) -> wgpu::RenderPass<'a> {
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: None,
-            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-                attachment: target,
+            color_attachments: &[wgpu::RenderPassColorAttachment {
+                view: target,
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Clear({
@@ -75,15 +75,17 @@ fn build_pipeline(device: &wgpu::Device) -> wgpu::RenderPipeline {
                 entry_point: "main",
                 targets: &[wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    color_blend: wgpu::BlendState::REPLACE,
-                    alpha_blend: wgpu::BlendState::REPLACE,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent::REPLACE,
+                        alpha: wgpu::BlendComponent::REPLACE,
+                    }),
                     write_mask: wgpu::ColorWrite::ALL,
                 }],
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
                 front_face: wgpu::FrontFace::Ccw,
-                cull_mode: wgpu::CullMode::None,
+                cull_mode: None,
                 ..Default::default()
             },
             depth_stencil: None,

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -26,8 +26,8 @@ qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
 
 [dependencies]
-wgpu = "0.7"
-wgpu_glyph = "0.11"
+wgpu = "0.8"
+wgpu_glyph = "0.12"
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -97,11 +97,13 @@ impl Pipeline {
                 entries: &[
                     wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer {
-                            buffer: &uniforms_buffer,
-                            offset: 0,
-                            size: None,
-                        },
+                        resource: wgpu::BindingResource::Buffer(
+                            wgpu::BufferBinding {
+                                buffer: &uniforms_buffer,
+                                offset: 0,
+                                size: None,
+                            },
+                        ),
                     },
                     wgpu::BindGroupEntry {
                         binding: 1,
@@ -155,7 +157,7 @@ impl Pipeline {
                             step_mode: wgpu::InputStepMode::Vertex,
                             attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
-                                format: wgpu::VertexFormat::Float2,
+                                format: wgpu::VertexFormat::Float32x2,
                                 offset: 0,
                             }],
                         },
@@ -165,27 +167,27 @@ impl Pipeline {
                             attributes: &[
                                 wgpu::VertexAttribute {
                                     shader_location: 1,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 0,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 2,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 4 * 2,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 3,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 4 * 4,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 4,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 4 * 6,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 5,
-                                    format: wgpu::VertexFormat::Uint,
+                                    format: wgpu::VertexFormat::Uint32,
                                     offset: 4 * 8,
                                 },
                             ],
@@ -197,23 +199,25 @@ impl Pipeline {
                     entry_point: "main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        color_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
+                        blend: Some(wgpu::BlendState {
+                            color: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::SrcAlpha,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                            alpha: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::One,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                        }),
                         write_mask: wgpu::ColorWrite::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
                     topology: wgpu::PrimitiveTopology::TriangleList,
                     front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
+                    cull_mode: None,
                     ..Default::default()
                 },
                 depth_stencil: None,
@@ -423,16 +427,14 @@ impl Pipeline {
             let mut render_pass =
                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("iced_wgpu::image render pass"),
-                    color_attachments: &[
-                        wgpu::RenderPassColorAttachmentDescriptor {
-                            attachment: target,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Load,
-                                store: true,
-                            },
+                    color_attachments: &[wgpu::RenderPassColorAttachment {
+                        view: target,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: true,
                         },
-                    ],
+                    }],
                     depth_stencil_attachment: None,
                 });
 

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -24,7 +24,7 @@ impl Atlas {
         let extent = wgpu::Extent3d {
             width: SIZE,
             height: SIZE,
-            depth: 1,
+            depth_or_array_layers: 1,
         };
 
         let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -294,19 +294,19 @@ impl Atlas {
         let extent = wgpu::Extent3d {
             width,
             height,
-            depth: 1,
+            depth_or_array_layers: 1,
         };
 
         encoder.copy_buffer_to_texture(
-            wgpu::BufferCopyView {
+            wgpu::ImageCopyBuffer {
                 buffer,
-                layout: wgpu::TextureDataLayout {
+                layout: wgpu::ImageDataLayout {
                     offset: offset as u64,
-                    bytes_per_row: 4 * image_width + padding,
-                    rows_per_image: image_height,
+                    bytes_per_row: Some(std::num::NonZeroU32::new(4 * image_width + padding).unwrap()),
+                    rows_per_image: Some(std::num::NonZeroU32::new(image_height).unwrap()),
                 },
             },
-            wgpu::TextureCopyView {
+            wgpu::ImageCopyTexture {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
@@ -334,7 +334,7 @@ impl Atlas {
             size: wgpu::Extent3d {
                 width: SIZE,
                 height: SIZE,
-                depth: self.layers.len() as u32,
+                depth_or_array_layers: self.layers.len() as u32,
             },
             mip_level_count: 1,
             sample_count: 1,
@@ -355,7 +355,7 @@ impl Atlas {
             }
 
             encoder.copy_texture_to_texture(
-                wgpu::TextureCopyView {
+                wgpu::ImageCopyTexture {
                     texture: &self.texture,
                     mip_level: 0,
                     origin: wgpu::Origin3d {
@@ -364,7 +364,7 @@ impl Atlas {
                         z: i as u32,
                     },
                 },
-                wgpu::TextureCopyView {
+                wgpu::ImageCopyTexture {
                     texture: &new_texture,
                     mip_level: 0,
                     origin: wgpu::Origin3d {
@@ -376,7 +376,7 @@ impl Atlas {
                 wgpu::Extent3d {
                     width: SIZE,
                     height: SIZE,
-                    depth: 1,
+                    depth_or_array_layers: 1,
                 },
             );
         }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -35,6 +35,7 @@ pub mod window;
 mod backend;
 mod quad;
 mod text;
+mod util;
 
 pub use iced_graphics::{
     Antialiasing, Color, Defaults, Error, Primitive, Viewport,

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -1,4 +1,4 @@
-use crate::Transformation;
+use crate::{util::align_size, Transformation};
 use iced_graphics::layer;
 use iced_native::Rectangle;
 
@@ -28,7 +28,7 @@ impl Pipeline {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         min_binding_size: wgpu::BufferSize::new(
-                            mem::size_of::<Uniforms>() as u64,
+                            Uniforms::ALIGNED_SIZE,
                         ),
                     },
                     count: None,
@@ -37,7 +37,7 @@ impl Pipeline {
 
         let constants_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::quad uniforms buffer"),
-            size: mem::size_of::<Uniforms>() as u64,
+            size: Uniforms::ALIGNED_SIZE,
             usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
             mapped_at_creation: false,
         });
@@ -47,11 +47,11 @@ impl Pipeline {
             layout: &constant_layout,
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
-                resource: wgpu::BindingResource::Buffer {
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
                     buffer: &constants_buffer,
                     offset: 0,
                     size: None,
-                },
+                }),
             }],
         });
 
@@ -83,7 +83,7 @@ impl Pipeline {
                             step_mode: wgpu::InputStepMode::Vertex,
                             attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
-                                format: wgpu::VertexFormat::Float2,
+                                format: wgpu::VertexFormat::Float32x2,
                                 offset: 0,
                             }],
                         },
@@ -93,32 +93,32 @@ impl Pipeline {
                             attributes: &[
                                 wgpu::VertexAttribute {
                                     shader_location: 1,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 0,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 2,
-                                    format: wgpu::VertexFormat::Float2,
+                                    format: wgpu::VertexFormat::Float32x2,
                                     offset: 4 * 2,
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 3,
-                                    format: wgpu::VertexFormat::Float4,
+                                    format: wgpu::VertexFormat::Float32x4,
                                     offset: 4 * (2 + 2),
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 4,
-                                    format: wgpu::VertexFormat::Float4,
+                                    format: wgpu::VertexFormat::Float32x4,
                                     offset: 4 * (2 + 2 + 4),
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 5,
-                                    format: wgpu::VertexFormat::Float,
+                                    format: wgpu::VertexFormat::Float32,
                                     offset: 4 * (2 + 2 + 4 + 4),
                                 },
                                 wgpu::VertexAttribute {
                                     shader_location: 6,
-                                    format: wgpu::VertexFormat::Float,
+                                    format: wgpu::VertexFormat::Float32,
                                     offset: 4 * (2 + 2 + 4 + 4 + 1),
                                 },
                             ],
@@ -130,23 +130,25 @@ impl Pipeline {
                     entry_point: "main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        color_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
+                        blend: Some(wgpu::BlendState {
+                            color: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::SrcAlpha,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                            alpha: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::One,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                        }),
                         write_mask: wgpu::ColorWrite::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
                     topology: wgpu::PrimitiveTopology::TriangleList,
                     front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
+                    cull_mode: None,
                     ..Default::default()
                 },
                 depth_stencil: None,
@@ -237,16 +239,14 @@ impl Pipeline {
                 let mut render_pass =
                     encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                         label: Some("iced_wgpu::quad render pass"),
-                        color_attachments: &[
-                            wgpu::RenderPassColorAttachmentDescriptor {
-                                attachment: target,
-                                resolve_target: None,
-                                ops: wgpu::Operations {
-                                    load: wgpu::LoadOp::Load,
-                                    store: true,
-                                },
+                        color_attachments: &[wgpu::RenderPassColorAttachment {
+                            view: target,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: true,
                             },
-                        ],
+                        }],
                         depth_stencil_attachment: None,
                     });
 
@@ -312,6 +312,12 @@ struct Uniforms {
 }
 
 impl Uniforms {
+    const ALIGNED_SIZE: u64 = Self::aligned_size() as u64;
+
+    const fn aligned_size() -> u64 {
+        align_size(mem::size_of::<Self>() as u64, mem::size_of::<[f32; 16]>() as u64)
+    }
+
     fn new(transformation: Transformation, scale: f32) -> Uniforms {
         Self {
             transform: *transformation.as_ref(),

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -20,9 +20,9 @@ impl Blit {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Linear,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
 
@@ -96,23 +96,25 @@ impl Blit {
                     entry_point: "main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        color_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha_blend: wgpu::BlendState {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
+                        blend: Some(wgpu::BlendState {
+                            color: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::SrcAlpha,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                            alpha: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::One,
+                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                        }),
                         write_mask: wgpu::ColorWrite::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
                     topology: wgpu::PrimitiveTopology::TriangleList,
                     front_face: wgpu::FrontFace::Cw,
-                    cull_mode: wgpu::CullMode::None,
+                    cull_mode: None,
                     ..Default::default()
                 },
                 depth_stencil: None,
@@ -178,8 +180,8 @@ impl Blit {
             encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("iced_wgpu::triangle::msaa render pass"),
                 color_attachments: &[
-                    wgpu::RenderPassColorAttachmentDescriptor {
-                        attachment: target,
+                    wgpu::RenderPassColorAttachment {
+                        view: target,
                         resolve_target: None,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Load,
@@ -222,7 +224,7 @@ impl Targets {
         let extent = wgpu::Extent3d {
             width,
             height,
-            depth: 1,
+            depth_or_array_layers: 1,
         };
 
         let attachment = device.create_texture(&wgpu::TextureDescriptor {

--- a/wgpu/src/util.rs
+++ b/wgpu/src/util.rs
@@ -1,0 +1,4 @@
+// webgpu requires that a struct be aligned to a multiple of its largest member
+pub const fn align_size(size: u64, alignment: u64) -> u64 {
+    ((size + alignment - 1) / alignment) * alignment
+}

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -146,8 +146,8 @@ impl iced_graphics::window::Compositor for Compositor {
 
         let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("iced_wgpu::window::Compositor render pass"),
-            color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
-                attachment: &frame.output.view,
+            color_attachments: &[wgpu::RenderPassColorAttachment {
+                view: &frame.output.view,
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Clear({


### PR DESCRIPTION
Most of these are simple changes due to upstream refactorings, but there are two exceptions:

### 1. Alignment of structs based on largest field size in `wgpu/src/quad.rs` and `wgpu/src/triangle.rs`

Error I get in e.g. `integration` with wgpu 0.8 without the alignment changes:

```
Caused by:
    In Device::create_render_pipeline
      note: label = `iced_wgpu::quad pipeline`
    error matching VERTEX shader requirements against the pipeline
    shader global ResourceBinding { group: 0, binding: 0 } is not available in the layout pipeline layout
    buffer structure size 80, added to one element of an unbound array, if it's the last field, ended up greater than the given `min_binding_size`
```

The upstream source of these changes is `naga` https://github.com/gfx-rs/naga/pull/663 and the web gpu spec itself (which now requires this alignment, see https://gpuweb.github.io/gpuweb/wgsl/#structure-layout-rules).

In `triangle.rs` I rely on the fact that the structure is already aligned and simply perform a no-op alignment (so if someone else comes along to change the padding it's clearer that they need to consider the alignment). If you'd like something done different done here let me now. See https://github.com/hecrj/iced/compare/master...mvilim:wgpu-0.8?expand=1#diff-e1f0045458bcc8906b9880928a65c95b5a5d49dbdb59058f9b4973e528808bfbR436

### 2. Consistent bind group and sampler filtering in `wgpu/src/triangle/msaa.rs`

In the wgpu 0.7 update (#725), the filtering was disabled in the bind group `filtering: false` but left as `Linear` in the sampler. That combination causes me to receive this error with wgpu 0.8:

```
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
      note: label = `iced_wgpu::triangle::msaa uniforms bind group`
    sampler binding 0 expects filtering = false, but given a sampler with filtering = true
```

I wasn't sure why this change was made in the 0.7 update (`filtering: true` works for me in wgpu 0.7.0 but perhaps a transitive version has changed), so I erred on the side of caution and simply changed the sampler to match with `Nearest`. If you would rather just change `filtering` back to `true`, let me know (it works for me in wgpu 0.8 as well).

See https://github.com/hecrj/iced/compare/master...mvilim:wgpu-0.8?expand=1#diff-e25ec11fdbfd4ad5ba3acbaf97caabc9cf532e735e50076912edbc5966815c76R23

I have verified that all the examples work for me:

- [x] bezier_tool
- [x] clock
- [x] color_palette
- [x] counter
- [x] custom_widget
- [x] download_progress
- [x] events
- [x] game_of_life
- [x] geometry
- [x] integration
- [x] pane_grid
- [x] pick_list
- [x] pokedex
- [x] progress_bar
- [x] qr_code
- [x] scrollable
- [x] solar_system
- [x] stopwatch
- [x] styling
- [x] svg
- [x] todos
- [x] tour
