### PR TITLE
PaneGrid Events in Title Bar Area

### DIFF
--- a/graphics/src/widget/pane_grid.rs
+++ b/graphics/src/widget/pane_grid.rs
@@ -218,10 +218,10 @@ where
                         body_primitive,
                     ],
                 },
-                if is_over_pick_area {
-                    mouse::Interaction::Grab
-                } else if title_bar_interaction > body_interaction {
+                if title_bar_interaction > body_interaction {
                     title_bar_interaction
+                } else if is_over_pick_area {
+                    mouse::Interaction::Grab
                 } else {
                     body_interaction
                 },


### PR DESCRIPTION
This work adds event handling from within the title area of the `TitleBar`, in addition to the existing functionality of the controls area. It might be useful to pane grid users to be able to have buttons on both sides of the title bar.

The `pane_grid` example app is updated to:
- Have a Close button in the pane controls area
- Have a Pin/Unpin button in the title area that prevents that pane from being closed

https://user-images.githubusercontent.com/1562417/119413773-f45f8280-bcb3-11eb-9aa1-1beac83b33cc.mov

