### PR TITLE
Allow disabling drag and drop on windows

### DIFF
--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -100,6 +100,8 @@ impl Window {
             if let Some(parent) = self.platform_specific.parent {
                 window_builder = window_builder.with_parent_window(parent);
             }
+            window_builder = window_builder
+                .with_drag_and_drop(self.platform_specific.drag_and_drop);
         }
 
         window_builder

--- a/winit/src/settings/windows.rs
+++ b/winit/src/settings/windows.rs
@@ -4,9 +4,10 @@
 /// The platform specific window settings of an application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlatformSpecific {
-    /// Parent Window
+    /// Parent window
     pub parent: Option<winapi::shared::windef::HWND>,
-    /// Drap and Drop support
+
+    /// Drag and drop support
     pub drag_and_drop: bool,
 }
 

--- a/winit/src/settings/windows.rs
+++ b/winit/src/settings/windows.rs
@@ -2,8 +2,19 @@
 //! Platform specific settings for Windows.
 
 /// The platform specific window settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlatformSpecific {
     /// Parent Window
     pub parent: Option<winapi::shared::windef::HWND>,
+    /// Drap and Drop support
+    pub drag_and_drop: bool,
+}
+
+impl Default for PlatformSpecific {
+    fn default() -> Self {
+        Self {
+            parent: None,
+            drag_and_drop: true,
+        }
+    }
 }


### PR DESCRIPTION
I am using `rodio` and so `cpal` in an `iced` application, that has the unfortunate effect of not working at all because of an interraction between `cpal` and `winit` (see  RustAudio/cpal#504). There is a fix available in `winit` by disabling drag and drop: rust-windowing/winit#1524, this PR adds this switch to `iced`. 
I don't know much about iced internals, so I don't know if this change breaks anything