### PR TITLE
reproduce svg unbounded memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
     "examples/todos",
     "examples/tour",
     "examples/tooltip",
+    "examples/repro",
 ]
 
 [dependencies]

--- a/examples/repro/Cargo.toml
+++ b/examples/repro/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "repro"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["svg", "canvas"] }

--- a/examples/repro/src/main.rs
+++ b/examples/repro/src/main.rs
@@ -1,0 +1,164 @@
+use iced::{
+    button, canvas, Align, Button, Column, Length, Row, Sandbox, Settings,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    Foo,
+}
+
+pub fn main() -> iced::Result {
+    Repro::run(Settings::default())
+}
+
+#[derive(Default)]
+struct Canvas {
+    #[allow(unused)]
+    inner: canvas::Cache,
+}
+
+impl canvas::Program<Message> for Canvas {
+    fn draw(
+        &self,
+        _bounds: iced::Rectangle,
+        _cursor: canvas::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        vec![]
+    }
+}
+
+struct Repro {
+    one: iced::Svg,
+    one_state: button::State,
+    two: iced::Svg,
+    two_state: button::State,
+    three: iced::Svg,
+    canvas: Canvas,
+}
+
+pub(crate) mod style {
+    use iced::{button, container, Background, Color};
+
+    pub struct TextContainer;
+
+    impl container::StyleSheet for TextContainer {
+        fn style(&self) -> container::Style {
+            container::Style {
+                background: Some(Background::Color(Color::WHITE)),
+                text_color: Some(Color::BLACK),
+                border_radius: 16.0,
+                border_width: 4.0,
+                ..container::Style::default()
+            }
+        }
+    }
+
+    pub struct ButtonStyle;
+
+    impl button::StyleSheet for ButtonStyle {
+        fn active(&self) -> button::Style {
+            button::Style {
+                background: None,
+                border_radius: 1.0,
+                text_color: Color::WHITE,
+                ..button::Style::default()
+            }
+        }
+    }
+}
+
+impl Sandbox for Repro {
+    type Message = Message;
+
+    fn new() -> Self {
+        Repro {
+            one: iced::Svg::from_path(format!(
+                "{}/src/one.svg",
+                env!("CARGO_MANIFEST_DIR")
+            )),
+            one_state: Default::default(),
+            two: iced::Svg::from_path(format!(
+                "{}/src/two.svg",
+                env!("CARGO_MANIFEST_DIR")
+            )),
+            two_state: Default::default(),
+            three: iced::Svg::from_path(format!(
+                "{}/src/three.svg",
+                env!("CARGO_MANIFEST_DIR")
+            )),
+            canvas: Canvas::default(),
+        }
+    }
+
+    fn title(&self) -> String {
+        String::from("Repro - Iced")
+    }
+
+    fn update(&mut self, _message: Message) {}
+    fn view(&mut self) -> iced::Element<Message> {
+        const ICON_SIZE: u16 = 64;
+        let ui = Column::new()
+            .push(
+                Row::new()
+                    .height(Length::Shrink)
+                    .push(
+                        Column::new()
+                            .width(Length::FillPortion(2))
+                            .align_items(Align::Start)
+                            .push(
+                                Row::new().padding(10).spacing(10).push(
+                                    Button::new(
+                                        &mut self.one_state,
+                                        self.one
+                                            .clone()
+                                            .width(Length::Units(ICON_SIZE))
+                                            .height(Length::Units(ICON_SIZE)),
+                                    )
+                                    .height(Length::Shrink)
+                                    .width(Length::Shrink)
+                                    .style(style::ButtonStyle)
+                                    .on_press(Message::Foo),
+                                ),
+                            ),
+                    )
+                    .push(
+                        Column::new()
+                            .width(Length::FillPortion(2))
+                            .align_items(Align::End)
+                            .push(
+                                Row::new()
+                                    .padding(10)
+                                    .spacing(10)
+                                    .push(
+                                        Button::new(
+                                            &mut self.two_state,
+                                            self.two
+                                                .clone()
+                                                .width(Length::Units(ICON_SIZE))
+                                                .height(Length::Units(
+                                                    ICON_SIZE,
+                                                )),
+                                        )
+                                        .height(Length::Shrink)
+                                        .width(Length::Shrink)
+                                        .style(style::ButtonStyle)
+                                        .on_press(Message::Foo),
+                                    )
+                                    .push(
+                                        self.three
+                                            .clone()
+                                            .width(Length::Units(ICON_SIZE))
+                                            .height(Length::Units(ICON_SIZE)),
+                                    ),
+                            ),
+                    ),
+            )
+            .push(
+                canvas::Canvas::new(&mut self.canvas)
+                    .width(Length::Fill)
+                    .height(Length::Fill),
+            );
+        let content: iced::Element<_> = ui.into();
+        content.explain(iced::Color::WHITE)
+    }
+}

--- a/examples/repro/src/one.svg
+++ b/examples/repro/src/one.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="one.svg"
+   xml:space="preserve"
+   style="enable-background:new 0 0 241.7 275.1;"
+   viewBox="0 0 241.7 275.1"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata842"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs840" /><sodipodi:namedview
+   inkscape:current-layer="Layer_1"
+   inkscape:window-maximized="0"
+   inkscape:window-y="25"
+   inkscape:window-x="0"
+   inkscape:cy="137.55"
+   inkscape:cx="120.85"
+   inkscape:zoom="1.741185"
+   showgrid="false"
+   id="namedview838"
+   inkscape:window-height="585"
+   inkscape:window-width="1236"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0"
+   guidetolerance="10"
+   gridtolerance="10"
+   objecttolerance="10"
+   borderopacity="1"
+   inkscape:document-rotation="0"
+   bordercolor="#666666"
+   pagecolor="#ffffff" />
+<style
+   id="style833"
+   type="text/css">
+	.st0{fill:#E717FF;stroke:#8E13E5;stroke-width:3;stroke-miterlimit:10;}
+</style>
+
+<rect
+   y="40.776829"
+   x="26.993111"
+   height="200.4382"
+   width="190.67474"
+   id="rect849"
+   style="fill:#ff0000;fill-opacity:0.51417" /></svg>

--- a/examples/repro/src/three.svg
+++ b/examples/repro/src/three.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="three.svg"
+   xml:space="preserve"
+   style="enable-background:new 0 0 224.9 180.5;"
+   viewBox="0 0 224.9 180.5"
+   y="0px"
+   x="0px"
+   id="Layer_1"
+   version="1.1"><metadata
+   id="metadata1491"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs1489" /><sodipodi:namedview
+   inkscape:current-layer="Layer_1"
+   inkscape:window-maximized="0"
+   inkscape:window-y="25"
+   inkscape:window-x="0"
+   inkscape:cy="90.25"
+   inkscape:cx="99.602031"
+   inkscape:zoom="1.5069252"
+   showgrid="false"
+   id="namedview1487"
+   inkscape:window-height="565"
+   inkscape:window-width="1111"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0"
+   guidetolerance="10"
+   gridtolerance="10"
+   objecttolerance="10"
+   borderopacity="1"
+   inkscape:document-rotation="0"
+   bordercolor="#666666"
+   pagecolor="#ffffff" />
+<style
+   id="style1448"
+   type="text/css">
+	.st0{fill:#8E13E5;}
+	.st1{fill:#E717FF;}
+</style>
+
+
+
+
+<rect
+   y="0"
+   x="-0.66360295"
+   height="180.5"
+   width="226.95221"
+   id="rect2054"
+   style="fill:#ff00ff;fill-opacity:0.51417" /></svg>

--- a/examples/repro/src/two.svg
+++ b/examples/repro/src/two.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="two.svg"
+   version="1.1"
+   viewBox="0 0 226.1 176.02"
+   data-name="Layer 1"
+   id="Layer_1">
+  <metadata
+     id="metadata883">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs881" />
+  <sodipodi:namedview
+     inkscape:current-layer="Layer_1"
+     inkscape:window-maximized="0"
+     inkscape:window-y="25"
+     inkscape:window-x="0"
+     inkscape:cy="88.010002"
+     inkscape:cx="109.47196"
+     inkscape:zoom="1.5452789"
+     showgrid="false"
+     id="namedview879"
+     inkscape:window-height="585"
+     inkscape:window-width="1158"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     inkscape:document-rotation="0"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <rect
+     y="0.64713216"
+     x="-5.6098486e-08"
+     height="177.9614"
+     width="227.14346"
+     id="rect1446"
+     style="fill:#00ff00;fill-opacity:0.51417" />
+</svg>

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -309,6 +309,7 @@ impl Pipeline {
         target: &wgpu::TextureView,
         _scale: f32,
     ) {
+        println!("=== Drawing {} images", images.len());
         let instances: &mut Vec<Instance> = &mut Vec::new();
 
         #[cfg(feature = "image_rs")]
@@ -463,6 +464,7 @@ impl Pipeline {
 
             i += Instance::MAX;
         }
+        println!("=== Done");
     }
 
     pub fn trim_cache(&mut self) {

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -78,6 +78,7 @@ impl Cache {
             (scale * width).round() as u32,
             (scale * height).round() as u32,
         );
+        println!("Upload {} {}x{}", id, width, height);
 
         // TODO: Optimize!
         // We currently rerasterize the SVG when its size changes. This is slow
@@ -122,6 +123,7 @@ impl Cache {
                     device,
                     encoder,
                 )?;
+                println!("  Allocating {} {}x{}", id, width, height);
 
                 let _ = self.svg_hits.insert(id);
                 let _ = self.rasterized_hits.insert((id, width, height));

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -252,9 +252,9 @@ async fn run_instance<A, E, C>(
     while let Some(event) = receiver.next().await {
         match event {
             event::Event::MainEventsCleared => {
-                if events.is_empty() && messages.is_empty() {
-                    continue;
-                }
+                // if events.is_empty() && messages.is_empty() {
+                //     continue;
+                // }
 
                 debug.event_processing_started();
 


### PR DESCRIPTION
i have made repro for svg memory usage. on macos moving mouse shows unbounded memory allocation with the behavior of leak i say in #841

i only see this on macos and ios, i think dpi is involved. thank you
