### PR TITLE
Add `Icon::from_dynamic_image` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ iced_winit = { version = "0.3", path = "winit" }
 iced_glutin = { version = "0.2", path = "glutin", optional = true }
 iced_wgpu = { version = "0.4", path = "wgpu", optional = true }
 iced_glow = { version = "0.2", path = "glow", optional = true}
+image_rs = { package = "image", version = "0.23.14" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iced_web = { version = "0.4", path = "web" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,13 +90,13 @@ members = [
 iced_core = { version = "0.4", path = "core" }
 iced_futures = { version = "0.3", path = "futures" }
 thiserror = "1.0"
+image_rs = { package = "image", version = "0.23.14" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.3", path = "winit" }
 iced_glutin = { version = "0.2", path = "glutin", optional = true }
 iced_wgpu = { version = "0.4", path = "wgpu", optional = true }
 iced_glow = { version = "0.2", path = "glow", optional = true}
-image_rs = { package = "image", version = "0.23.14" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iced_web = { version = "0.4", path = "web" }

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -2,6 +2,8 @@
 use std::fmt;
 use std::io;
 
+use image_rs::{DynamicImage, GenericImageView};
+
 /// The icon of a window.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone)]
@@ -13,6 +15,26 @@ pub struct Icon(iced_winit::winit::window::Icon);
 pub struct Icon;
 
 impl Icon {
+    /// Creates an icon from dynamic image.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_dynamic_image(dynamic_image: DynamicImage) -> Result<Self, Error> {
+        let width = dynamic_image.width();
+        let height = dynamic_image.height();
+        let rgba = dynamic_image.into_rgba8().into_raw();
+
+        let raw =
+            iced_winit::winit::window::Icon::from_rgba(rgba, width, height)?;
+
+        Ok(Icon(raw))
+    }
+
+    /// Creates an icon from dynamic image.
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_dynamic_image(_dynamic_image: DynamicImage) -> Result<Self, Error> {
+        Ok(Icon)
+    }
+
+
     /// Creates an icon from 32bpp RGBA data.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_rgba(


### PR DESCRIPTION
I find it strange that user of the library need to use the `from_rgba` function (I think it's too low-level for its purpose). So I decided to add the `Icon::from_dynamic_image` function, which is uses the `image` crate.

Also, maybe integrate the `image` crate :wink:? This will reuse already written code and help to improve the library.
Of course, there are downsides:
- need for additional dependency, which will slow compile time of the app
- later will probably need to deprecate the `image` feature