### PR TITLE
Enable receiving URLs on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,6 @@ iced_core = { version = "0.4", path = "core" }
 iced_futures = { version = "0.3", path = "futures" }
 thiserror = "1.0"
 
-[patch.crates-io]
-winit = { git="https://github.com/iced-rs/winit", rev="152eda9b2d995dd0f5b886a53bddac7c75738b47" }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.3", path = "winit" }
 iced_glutin = { version = "0.2", path = "glutin", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,12 +84,16 @@ members = [
     "examples/todos",
     "examples/tour",
     "examples/tooltip",
+    "examples/url_handler",
 ]
 
 [dependencies]
 iced_core = { version = "0.4", path = "core" }
 iced_futures = { version = "0.3", path = "futures" }
 thiserror = "1.0"
+
+[patch.crates-io]
+winit = { git="https://github.com/cryptowatch/winit", rev="f9180f3b3c0f4fb8fd8c65bd0adf641cd6b32dd0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.3", path = "winit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ iced_futures = { version = "0.3", path = "futures" }
 thiserror = "1.0"
 
 [patch.crates-io]
-winit = { git="https://github.com/cryptowatch/winit", rev="f9180f3b3c0f4fb8fd8c65bd0adf641cd6b32dd0" }
+winit = { git="https://github.com/iced-rs/winit", rev="152eda9b2d995dd0f5b886a53bddac7c75738b47" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced_winit = { version = "0.3", path = "winit" }

--- a/examples/url_handler/Cargo.toml
+++ b/examples/url_handler/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "url_handler"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+iced = { path = "../.." }
+iced_native = { path = "../../native" }
+syslog="4.0"
+log="0.4"

--- a/examples/url_handler/Cargo.toml
+++ b/examples/url_handler/Cargo.toml
@@ -8,5 +8,3 @@ publish = false
 [dependencies]
 iced = { path = "../.." }
 iced_native = { path = "../../native" }
-syslog="4.0"
-log="0.4"

--- a/examples/url_handler/src/main.rs
+++ b/examples/url_handler/src/main.rs
@@ -1,0 +1,67 @@
+use iced::{
+    executor, Application, Command, Clipboard,
+    Container, Element, Length, Settings, Subscription, Text,
+};
+use iced_native::Event;
+
+pub fn main() -> iced::Result {
+    App::run(Settings::default())
+}
+
+#[derive(Debug, Default)]
+struct App {
+    url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    EventOccurred(iced_native::Event),
+}
+
+impl Application for App {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (App, Command<Message>) {
+        (App::default(), Command::none())
+    }
+
+    fn title(&self) -> String {
+        String::from("Url - Iced")
+    }
+
+    fn update(
+        &mut self,
+        message: Message,
+        _clipboard: &mut Clipboard,
+    ) -> Command<Message> {
+        match message {
+            Message::EventOccurred(event) => {
+                if let Event::UrlReceived(url) = event{
+                    self.url = Some(url);
+                }
+            }
+        };
+
+        Command::none()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        iced_native::subscription::events().map(Message::EventOccurred)
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        let content = match &self.url{
+            Some(url) => Text::new(format!("{}", url)),
+            None => Text::new("No URL received yet!")
+        };
+
+        Container::new(content.size(48))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
+    }
+}

--- a/examples/url_handler/src/main.rs
+++ b/examples/url_handler/src/main.rs
@@ -1,8 +1,11 @@
 use iced::{
-    executor, Application, Command, Clipboard,
-    Container, Element, Length, Settings, Subscription, Text,
+    executor, Application, Clipboard, Command, Container, Element, Length,
+    Settings, Subscription, Text,
 };
-use iced_native::Event;
+use iced_native::{
+    event::{MacOS, PlatformSpecific},
+    Event,
+};
 
 pub fn main() -> iced::Result {
     App::run(Settings::default())
@@ -38,7 +41,10 @@ impl Application for App {
     ) -> Command<Message> {
         match message {
             Message::EventOccurred(event) => {
-                if let Event::UrlReceived(url) = event{
+                if let Event::PlatformSpecific(PlatformSpecific::MacOS(
+                    MacOS::ReceivedUrl(url),
+                )) = event
+                {
                     self.url = Some(url);
                 }
             }
@@ -52,9 +58,9 @@ impl Application for App {
     }
 
     fn view(&mut self) -> Element<Message> {
-        let content = match &self.url{
+        let content = match &self.url {
             Some(url) => Text::new(format!("{}", url)),
-            None => Text::new("No URL received yet!")
+            None => Text::new("No URL received yet!"),
         };
 
         Container::new(content.size(48))

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -13,8 +13,10 @@ categories = ["gui"]
 [features]
 debug = ["iced_winit/debug"]
 
-[dependencies]
-glutin = "0.27"
+[dependencies.glutin]
+version = "0.27"
+git = "https://github.com/iced-rs/glutin"
+rev = "be6793b5b3defc9452cd1c896cd315ed7442d546"
 
 [dependencies.iced_native]
 version = "0.4"

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -237,8 +237,9 @@ async fn run_instance<A, E, C>(
 
                 context.window().request_redraw();
             }
-            event::Event::ReceivedUrl(url) => {
-                events.push(iced_native::Event::UrlReceived(url));
+            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))) => {
+                use iced_native::event;
+                events.push(iced_native::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))));
             }
             event::Event::UserEvent(message) => {
                 messages.push(message);

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -237,6 +237,9 @@ async fn run_instance<A, E, C>(
 
                 context.window().request_redraw();
             }
+            event::Event::ReceivedUrl(url) => {
+                events.push(iced_native::Event::UrlReceived(url));
+            }
             event::Event::UserEvent(message) => {
                 messages.push(message);
             }

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -237,9 +237,15 @@ async fn run_instance<A, E, C>(
 
                 context.window().request_redraw();
             }
-            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))) => {
+            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(
+                event::MacOS::ReceivedUrl(url),
+            )) => {
                 use iced_native::event;
-                events.push(iced_native::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))));
+                events.push(iced_native::Event::PlatformSpecific(
+                    event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(
+                        url,
+                    )),
+                ));
             }
             event::Event::UserEvent(message) => {
                 messages.push(message);

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -23,6 +23,10 @@ pub enum Event {
 
     /// A touch event
     Touch(touch::Event),
+    
+    // TODO: System(system::Event)?
+    /// A url was received.
+    UrlReceived(String),
 }
 
 /// The status of an [`Event`] after being processed.

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -23,10 +23,27 @@ pub enum Event {
 
     /// A touch event
     Touch(touch::Event),
-    
-    // TODO: System(system::Event)?
-    /// A url was received.
-    UrlReceived(String),
+
+    /// A platform specific event
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// A platform specific event
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlatformSpecific {
+    /// A MacOS specific event
+    MacOS(MacOS),
+}
+
+/// Describes an event specific to MacOS
+#[derive(Debug, Clone, PartialEq)]
+pub enum MacOS {
+    /// Triggered when the app receives an URL from the system
+    ///
+    /// _**Note:** For this event to be triggered, the executable needs to be properly [bundled]!_
+    ///
+    /// [bundled]: https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW19
+    ReceivedUrl(String),
 }
 
 /// The status of an [`Event`] after being processed.

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -14,10 +14,14 @@ categories = ["gui"]
 debug = ["iced_native/debug"]
 
 [dependencies]
-winit = "0.25"
 window_clipboard = "0.2"
 log = "0.4"
 thiserror = "1.0"
+
+[dependencies.winit]
+version = "0.25"
+git = "https://github.com/iced-rs/winit"
+rev = "9c358959ed99736566d50a511b03d2fed3aac2ae"
 
 [dependencies.iced_native]
 version = "0.4"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -310,9 +310,15 @@ async fn run_instance<A, E, C>(
 
                 window.request_redraw();
             }
-            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))) => {
+            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(
+                event::MacOS::ReceivedUrl(url),
+            )) => {
                 use iced_native::event;
-                events.push(iced_native::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))));
+                events.push(iced_native::Event::PlatformSpecific(
+                    event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(
+                        url,
+                    )),
+                ));
             }
             event::Event::UserEvent(message) => {
                 messages.push(message);

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -310,8 +310,9 @@ async fn run_instance<A, E, C>(
 
                 window.request_redraw();
             }
-            event::Event::ReceivedUrl(url) => {
-                events.push(iced_native::Event::UrlReceived(url));
+            event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))) => {
+                use iced_native::event;
+                events.push(iced_native::Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))));
             }
             event::Event::UserEvent(message) => {
                 messages.push(message);

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -310,6 +310,9 @@ async fn run_instance<A, E, C>(
 
                 window.request_redraw();
             }
+            event::Event::ReceivedUrl(url) => {
+                events.push(iced_native::Event::UrlReceived(url));
+            }
             event::Event::UserEvent(message) => {
                 messages.push(message);
             }


### PR DESCRIPTION
This PR uses the newly created `ReceivedUrl` to allow receiving URLs from the system on MacOS.  For this to work the executable needs to be properly bundled (as stated on the documentation of the event). It also adds a simple example showcasing the event.

Note: This PR makes use of the new organization repositories ([iced-rs/winit](https://github.com/iced-rs/winit) and [iced-rs/glutin](https://github.com/iced-rs/glutin)).

Depends on the merging of https://github.com/iced-rs/winit/pull/1.