### PR TITLE
Pane Grid Title Bar Overlay

### DIFF
--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -193,18 +193,18 @@ where
         &mut self,
         layout: Layout<'_>,
     ) -> Option<overlay::Element<'_, Message, Renderer>> {
-        let body_layout = if self.title_bar.is_some() {
+        if let Some(title_bar) = self.title_bar.as_mut() {
             let mut children = layout.children();
+            let title_bar_layout = children.next().unwrap();
 
-            // Overlays only allowed in the pane body, for now at least.
-            let _title_bar_layout = children.next();
+            if let Some(overlay) = title_bar.overlay(title_bar_layout) {
+                return Some(overlay);
+            }
 
-            children.next()?
+            self.body.overlay(children.next()?)
         } else {
-            layout
-        };
-
-        self.body.overlay(body_layout)
+            self.body.overlay(layout)
+        }
     }
 }
 

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -195,13 +195,12 @@ where
     ) -> Option<overlay::Element<'_, Message, Renderer>> {
         if let Some(title_bar) = self.title_bar.as_mut() {
             let mut children = layout.children();
-            let title_bar_layout = children.next().unwrap();
+            let title_bar_layout = children.next()?;
 
-            if let Some(overlay) = title_bar.overlay(title_bar_layout) {
-                return Some(overlay);
+            match title_bar.overlay(title_bar_layout) {
+                Some(overlay) => Some(overlay),
+                None => self.body.overlay(children.next()?),
             }
-
-            self.body.overlay(children.next()?)
         } else {
             self.body.overlay(layout)
         }

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -1,6 +1,7 @@
 use crate::container;
 use crate::event::{self, Event};
 use crate::layout;
+use crate::overlay;
 use crate::pane_grid;
 use crate::{
     Clipboard, Element, Hasher, Layout, Padding, Point, Rectangle, Size,
@@ -241,5 +242,12 @@ where
         );
 
         control_status.merge(title_status)
+    }
+
+    pub(crate) fn overlay(
+        &mut self,
+        layout: Layout<'_>,
+    ) -> Option<overlay::Element<'_, Message, Renderer>> {
+        self.content.overlay(layout)
     }
 }


### PR DESCRIPTION
If the title bar content produces an overlay, give it precedence over the pane body's overlay.