### PR TITLE
Update `wgpu` to `0.9`

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -26,8 +26,8 @@ qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
 
 [dependencies]
-wgpu = "0.8"
-wgpu_glyph = "0.12"
+wgpu = "0.9"
+wgpu_glyph = "0.13"
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -165,33 +165,13 @@ impl Pipeline {
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<Instance>() as u64,
                             step_mode: wgpu::InputStepMode::Instance,
-                            attributes: &[
-                                wgpu::VertexAttribute {
-                                    shader_location: 1,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 0,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 2,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 4 * 2,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 3,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 4 * 4,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 4,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 4 * 6,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 5,
-                                    format: wgpu::VertexFormat::Sint32,
-                                    offset: 4 * 8,
-                                },
-                            ],
+                            attributes: &wgpu::vertex_attr_array!(
+                                1 => Float32x2,
+                                2 => Float32x2,
+                                3 => Float32x2,
+                                4 => Float32x2,
+                                5 => Sint32,
+                            ),
                         },
                     ],
                 },

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -87,38 +87,14 @@ impl Pipeline {
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<layer::Quad>() as u64,
                             step_mode: wgpu::InputStepMode::Instance,
-                            attributes: &[
-                                wgpu::VertexAttribute {
-                                    shader_location: 1,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 0,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 2,
-                                    format: wgpu::VertexFormat::Float32x2,
-                                    offset: 4 * 2,
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 3,
-                                    format: wgpu::VertexFormat::Float32x4,
-                                    offset: 4 * (2 + 2),
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 4,
-                                    format: wgpu::VertexFormat::Float32x4,
-                                    offset: 4 * (2 + 2 + 4),
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 5,
-                                    format: wgpu::VertexFormat::Float32,
-                                    offset: 4 * (2 + 2 + 4 + 4),
-                                },
-                                wgpu::VertexAttribute {
-                                    shader_location: 6,
-                                    format: wgpu::VertexFormat::Float32,
-                                    offset: 4 * (2 + 2 + 4 + 4 + 1),
-                                },
-                            ],
+                            attributes: &wgpu::vertex_attr_array!(
+                                1 => Float32x2,
+                                2 => Float32x2,
+                                3 => Float32x4,
+                                4 => Float32x4,
+                                5 => Float32,
+                                6 => Float32,
+                            ),
                         },
                     ],
                 },

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -150,20 +150,12 @@ impl Pipeline {
                     buffers: &[wgpu::VertexBufferLayout {
                         array_stride: mem::size_of::<Vertex2D>() as u64,
                         step_mode: wgpu::InputStepMode::Vertex,
-                        attributes: &[
+                        attributes: &wgpu::vertex_attr_array!(
                             // Position
-                            wgpu::VertexAttribute {
-                                shader_location: 0,
-                                format: wgpu::VertexFormat::Float32x2,
-                                offset: 0,
-                            },
+                            0 => Float32x2,
                             // Color
-                            wgpu::VertexAttribute {
-                                shader_location: 1,
-                                format: wgpu::VertexFormat::Float32x4,
-                                offset: 4 * 2,
-                            },
-                        ],
+                            1 => Float32x4,
+                        ),
                     }],
                 },
                 fragment: Some(wgpu::FragmentState {


### PR DESCRIPTION
- Update wgpu to 0.9 (no changes required) Blocked by:  hecrj/wgpu_glyph#70
- While at it, I replaced manually defined vertex attributes with wgpu built-in macro (if there was any reason for those to be manually defined then I can just drop the commit, just let me know)