### PR TITLE
feat: add window as third param to update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "examples/progress_bar",
     "examples/qr_code",
     "examples/scrollable",
+    "examples/use_window",
     "examples/solar_system",
     "examples/stopwatch",
     "examples/styling",

--- a/examples/use_window/Cargo.toml
+++ b/examples/use_window/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "use_window"
+version = "0.1.0"
+authors = ["TimUntersberger <timuntersberger2@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+iced = { path = "../.." }

--- a/examples/use_window/README.md
+++ b/examples/use_window/README.md
@@ -1,0 +1,18 @@
+## Counter
+
+The classic counter example explained in the [`README`](../../README.md).
+
+The __[`main`]__ file contains all the code of the example.
+
+<div align="center">
+  <a href="https://gfycat.com/fairdeadcatbird">
+    <img src="https://thumbs.gfycat.com/FairDeadCatbird-small.gif">
+  </a>
+</div>
+
+You can run it with `cargo run`:
+```
+cargo run --package counter
+```
+
+[`main`]: src/main.rs

--- a/examples/use_window/src/main.rs
+++ b/examples/use_window/src/main.rs
@@ -1,0 +1,92 @@
+use iced::{button, text_input, executor, Align, Button, Column, Element, Application, Settings, Text, Window, Clipboard, TextInput, Command, runtime};
+
+pub fn main() -> iced::Result {
+    App::run(Settings::default())
+}
+
+#[derive(Default)]
+struct App {
+    height: String,
+    width: String,
+    x: String,
+    y: String,
+    height_input: text_input::State,
+    width_input: text_input::State,
+    x_input: text_input::State,
+    y_input: text_input::State,
+    resize_button: button::State,
+    move_button: button::State
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    ResizePressed,
+    MovePressed,
+    HeightChanged(String),
+    WidthChanged(String),
+    XChanged(String),
+    YChanged(String),
+}
+
+impl Application for App {
+    type Message = Message;
+    type Executor = executor::Default;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
+        (Self::default(), Command::none())
+    }
+
+    fn title(&self) -> String {
+        String::from("Use Window - Iced")
+    }
+
+    fn update(&mut self, message: Message, _: &mut Clipboard, window: &Window) -> Command<Self::Message> {
+        match message {
+            Message::ResizePressed => {
+                window.set_inner_size(runtime::winit::dpi::LogicalSize::new(
+                    self.width.parse::<u32>().unwrap(), 
+                    self.height.parse::<u32>().unwrap()
+                ));
+            },
+            Message::MovePressed => {
+                window.set_outer_position(runtime::winit::dpi::LogicalPosition::new(
+                    self.x.parse::<i32>().unwrap(), 
+                    self.y.parse::<i32>().unwrap()
+                ));
+            },
+            Message::HeightChanged(height) => {
+                self.height = height;
+            },
+            Message::WidthChanged(width) => {
+                self.width = width;
+            }
+            Message::XChanged(x) => {
+                self.x = x;
+            },
+            Message::YChanged(y) => {
+                self.y = y;
+            }
+        }
+        Command::none()
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        Column::new()
+            .padding(20)
+            .align_items(Align::Center)
+            .push(TextInput::new(&mut self.width_input, "Width...", &self.width, Message::WidthChanged))
+            .push(TextInput::new(&mut self.height_input, "Height...", &self.height, Message::HeightChanged))
+            .push(
+                Button::new(&mut self.resize_button, Text::new("Resize"))
+                    .on_press(Message::ResizePressed),
+            )
+            .push(TextInput::new(&mut self.x_input, "X...", &self.x, Message::XChanged))
+            .push(TextInput::new(&mut self.y_input, "Y...", &self.y, Message::YChanged))
+            .push(
+                Button::new(&mut self.move_button, Text::new("Move"))
+                    .on_press(Message::MovePressed),
+            )
+            .into()
+    }
+}

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -16,6 +16,7 @@ pub use iced_native::*;
 
 pub mod application;
 
+pub use glutin::window::Window;
 pub use iced_winit::settings;
 pub use iced_winit::{Clipboard, Error, Mode};
 

--- a/native/src/program.rs
+++ b/native/src/program.rs
@@ -6,7 +6,7 @@ mod state;
 pub use state::State;
 
 /// The core of a user interface application following The Elm Architecture.
-pub trait Program: Sized {
+pub trait Program<W>: Sized {
     /// The graphics backend to use to draw the [`Program`].
     type Renderer: Renderer;
 
@@ -28,6 +28,7 @@ pub trait Program: Sized {
         &mut self,
         message: Self::Message,
         clipboard: &mut Self::Clipboard,
+        window: &W
     ) -> Command<Self::Message>;
 
     /// Returns the widgets to display in the [`Program`].

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -5,9 +5,9 @@ use crate::{
 /// The execution state of a [`Program`]. It leverages caching, event
 /// processing, and rendering primitive storage.
 #[allow(missing_debug_implementations)]
-pub struct State<P>
+pub struct State<P, W>
 where
-    P: Program + 'static,
+    P: Program<W> + 'static,
 {
     program: P,
     cache: Option<Cache>,
@@ -16,9 +16,9 @@ where
     queued_messages: Vec<P::Message>,
 }
 
-impl<P> State<P>
+impl<P, W> State<P, W>
 where
-    P: Program + 'static,
+    P: Program<W> + 'static
 {
     /// Creates a new [`State`] with the provided [`Program`], initializing its
     /// primitive with the given logical bounds and renderer.
@@ -92,6 +92,7 @@ where
         cursor_position: Point,
         renderer: &mut P::Renderer,
         clipboard: &mut P::Clipboard,
+        window: W,
         debug: &mut Debug,
     ) -> Option<Command<P::Message>> {
         let mut user_interface = build_user_interface(
@@ -135,7 +136,7 @@ where
                     debug.log_message(&message);
 
                     debug.update_started();
-                    let command = self.program.update(message, clipboard);
+                    let command = self.program.update(message, clipboard, &window);
                     debug.update_finished();
 
                     command
@@ -160,7 +161,7 @@ where
     }
 }
 
-fn build_user_interface<'a, P: Program>(
+fn build_user_interface<'a, W, P: Program<W>>(
     program: &'a mut P,
     cache: Cache,
     renderer: &mut P::Renderer,

--- a/src/application.rs
+++ b/src/application.rs
@@ -133,6 +133,7 @@ pub trait Application: Sized {
         &mut self,
         message: Self::Message,
         clipboard: &mut Clipboard,
+        window: &crate::Window,
     ) -> Command<Self::Message>;
 
     /// Returns the event [`Subscription`] for the current state of the
@@ -235,7 +236,7 @@ pub trait Application: Sized {
 struct Instance<A: Application>(A);
 
 #[cfg(not(target_arch = "wasm32"))]
-impl<A> iced_winit::Program for Instance<A>
+impl<A> iced_winit::Program<crate::Window> for Instance<A>
 where
     A: Application,
 {
@@ -247,8 +248,9 @@ where
         &mut self,
         message: Self::Message,
         clipboard: &mut iced_winit::Clipboard,
+        window: &crate::Window
     ) -> Command<Self::Message> {
-        self.0.update(message, clipboard)
+        self.0.update(message, clipboard, window)
     }
 
     fn view(&mut self) -> Element<'_, Self::Message> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,23 +215,23 @@ pub mod time;
     not(feature = "glow"),
     feature = "wgpu"
 ))]
-use iced_winit as runtime;
+pub use iced_winit as runtime;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
-use iced_glutin as runtime;
+pub use iced_glutin as runtime;
 
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(feature = "glow"),
     feature = "wgpu"
 ))]
-use iced_wgpu as renderer;
+pub use iced_wgpu as renderer;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glow"))]
-use iced_glow as renderer;
+pub use iced_glow as renderer;
 
 #[cfg(target_arch = "wasm32")]
-use iced_web as runtime;
+pub use iced_web as runtime;
 
 #[doc(no_inline)]
 pub use widget::*;
@@ -247,5 +247,5 @@ pub use settings::Settings;
 pub use runtime::{
     futures, Align, Background, Clipboard, Color, Command, Font,
     HorizontalAlignment, Length, Point, Rectangle, Size, Subscription, Vector,
-    VerticalAlignment,
+    VerticalAlignment, Window
 };

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Application, Clipboard, Color, Command, Element, Error, Settings,
+    Application, Clipboard, Color, Command, Element, Error, Settings, Window,
     Subscription,
 };
 
@@ -166,6 +166,7 @@ where
         &mut self,
         message: T::Message,
         _clipboard: &mut Clipboard,
+        _window: &Window
     ) -> Command<T::Message> {
         T::update(self, message);
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -67,6 +67,8 @@ pub mod css;
 pub mod subscription;
 pub mod widget;
 
+pub type Window = ();
+
 pub use bus::Bus;
 pub use clipboard::Clipboard;
 pub use css::Css;

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -29,7 +29,7 @@ use std::mem::ManuallyDrop;
 ///
 /// When using an [`Application`] with the `debug` feature enabled, a debug view
 /// can be toggled by pressing `F12`.
-pub trait Application: Program<Clipboard = Clipboard> {
+pub trait Application: Program<crate::Window, Clipboard = Clipboard> {
     /// The data needed to initialize your [`Application`].
     type Flags;
 
@@ -283,6 +283,7 @@ async fn run_instance<A, E, C>(
                         &mut debug,
                         &mut clipboard,
                         &mut messages,
+                        &window
                     );
 
                     // Update window
@@ -459,12 +460,13 @@ pub fn update<A: Application, E: Executor>(
     debug: &mut Debug,
     clipboard: &mut A::Clipboard,
     messages: &mut Vec<A::Message>,
+    window: &crate::Window
 ) {
     for message in messages.drain(..) {
         debug.log_message(&message);
 
         debug.update_started();
-        let command = runtime.enter(|| application.update(message, clipboard));
+        let command = runtime.enter(|| application.update(message, clipboard, window));
         debug.update_finished();
 
         runtime.spawn(command);

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -33,6 +33,7 @@ mod error;
 mod mode;
 mod proxy;
 
+pub use winit::window::Window;
 pub use application::Application;
 pub use clipboard::Clipboard;
 pub use error::Error;


### PR DESCRIPTION
This PR tries to tackle a common problem where you want to modify the window at runtime.

My proposed solution is to add a third param to the update function of an application which is the "Window" of each platform.

* winit => winit::window::Window
* glutin => glutin::window::Window
* web => ()

I also add an example under examples/use_window which shows how you could resize/move the application at runtime.

One problem which I haven't fixed yet is that when resizing the window using winit for example the application only rerenders after some time and moving the window before this rerender happens causes a `Next Frame: Outdated` from the Compositor.

I don't really know how to fix this, because I am not too familiar with the codebase, so I would like some guidance on this.

If we would have to manually recreate the swap chain after resizing the window for instant rerendering I'd suggest we should create a wrapper Window struct which does this automatically and just delegates too platform-specific Window implementations.

Closes #767, Closes #644, Closes #493