### PR TITLE
Use ceil on svg dimensions, fix svg memory usage ref #841

### DIFF
--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -75,8 +75,8 @@ impl Cache {
         let id = handle.id();
 
         let (width, height) = (
-            (scale * width).round() as u32,
-            (scale * height).round() as u32,
+            (scale * width).ceil() as u32,
+            (scale * height).ceil() as u32,
         );
 
         // TODO: Optimize!
@@ -122,6 +122,7 @@ impl Cache {
                     device,
                     encoder,
                 )?;
+                log::debug!("allocating {} {}x{}", id, width, height);
 
                 let _ = self.svg_hits.insert(id);
                 let _ = self.rasterized_hits.insert((id, width, height));


### PR DESCRIPTION
Calls ceil() on dimension bounds as this appears fix svg memory
unbounded usage because no longer cache miss.

The height and width return from resvg seem to always be ceiling
of float dimensions, so we try to match.