### PR TITLE
Fix implementation of `Widget::overlay` for `pane_grid::TitleBar`

### DIFF
--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -249,10 +249,10 @@ where
         layout: Layout<'_>,
     ) -> Option<overlay::Element<'_, Message, Renderer>> {
         let mut children = layout.children();
-        let padded = children.next().unwrap();
+        let padded = children.next()?;
 
         let mut children = padded.children();
-        let title_layout = children.next().unwrap();
+        let title_layout = children.next()?;
 
         let Self {
             content, controls, ..
@@ -260,7 +260,7 @@ where
 
         content.overlay(title_layout).or_else(move || {
             controls.as_mut().and_then(|controls| {
-                let controls_layout = children.next().unwrap();
+                let controls_layout = children.next()?;
 
                 controls.overlay(controls_layout)
             })

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -248,6 +248,22 @@ where
         &mut self,
         layout: Layout<'_>,
     ) -> Option<overlay::Element<'_, Message, Renderer>> {
-        self.content.overlay(layout)
+        let mut children = layout.children();
+        let padded = children.next().unwrap();
+
+        let mut children = padded.children();
+        let title_layout = children.next().unwrap();
+
+        let Self {
+            content, controls, ..
+        } = self;
+
+        content.overlay(title_layout).or_else(move || {
+            controls.as_mut().and_then(|controls| {
+                let controls_layout = children.next().unwrap();
+
+                controls.overlay(controls_layout)
+            })
+        })
     }
 }


### PR DESCRIPTION
The previous implementation was naively providing the original `Layout` and, therefore,  not being consistent with the `layout` implementation.