### PR TITLE
Open the todos example via double-click on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.14
       run: cargo build --verbose --release --package todos
+    - name: Open binary via double-click
+      run: chmod +x target/release/todos
     - name: Archive todos binary
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
This PR allows to open the `todos` example produced by the `build` action via double-click on MacOS

Thanks in advance for your review! :)