### PR TITLE
Add window::Event::Moved

### DIFF
--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -3,6 +3,14 @@ use std::path::PathBuf;
 /// A window-related event.
 #[derive(PartialEq, Clone, Debug)]
 pub enum Event {
+    /// A window was moved.
+    Moved {
+        /// The new logical x location of the window
+        x: i32,
+        /// The new logical y location of the window
+        y: i32,
+    },
+
     /// A window was resized.
     Resized {
         /// The new width of the window (in units)

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -130,6 +130,12 @@ pub fn window_event(
         WindowEvent::Touch(touch) => {
             Some(Event::Touch(touch_event(*touch, scale_factor)))
         }
+        WindowEvent::Moved(position) => {
+            let winit::dpi::LogicalPosition { x, y } =
+                position.to_logical(scale_factor);
+
+            Some(Event::Window(window::Event::Moved { x, y }))
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
Creates a new `window::Event` when the window is moved. These coordinates can be persisted and used with the new window settings `Position::Specific` to restore an application to it's previous location.