### PR TITLE
fix: allow titlebar overlays to close when dragging pane

### DIFF
--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -452,24 +452,20 @@ where
             _ => {}
         }
 
-        if self.state.picked_pane().is_none() {
-            self.elements
-                .iter_mut()
-                .zip(layout.children())
-                .map(|((_, pane), layout)| {
-                    pane.on_event(
-                        event.clone(),
-                        layout,
-                        cursor_position,
-                        renderer,
-                        clipboard,
-                        messages,
-                    )
-                })
-                .fold(event_status, event::Status::merge)
-        } else {
-            event::Status::Captured
-        }
+        self.elements
+            .iter_mut()
+            .zip(layout.children())
+            .map(|((_, pane), layout)| {
+                pane.on_event(
+                    event.clone(),
+                    layout,
+                    cursor_position,
+                    renderer,
+                    clipboard,
+                    messages,
+                )
+            })
+            .fold(event_status, event::Status::merge)
     }
 
     fn draw(

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -452,17 +452,26 @@ where
             _ => {}
         }
 
+        let picked_pane = self.state.picked_pane().map(|(pane, _)| pane);
+
         self.elements
             .iter_mut()
             .zip(layout.children())
-            .map(|((_, pane), layout)| {
-                pane.on_event(
+            .map(|((pane, content), layout)| {
+                let is_picked = if let Some(picked_pane) = picked_pane {
+                    picked_pane == *pane
+                } else {
+                    false
+                };
+
+                content.on_event(
                     event.clone(),
                     layout,
                     cursor_position,
                     renderer,
                     clipboard,
                     messages,
+                    is_picked,
                 )
             })
             .fold(event_status, event::Status::merge)

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -458,11 +458,7 @@ where
             .iter_mut()
             .zip(layout.children())
             .map(|((pane, content), layout)| {
-                let is_picked = if let Some(picked_pane) = picked_pane {
-                    picked_pane == *pane
-                } else {
-                    false
-                };
+                let is_picked = picked_pane == Some(*pane);
 
                 content.on_event(
                     event.clone(),

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -149,6 +149,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         messages: &mut Vec<Message>,
+        is_picked: bool,
     ) -> event::Status {
         let mut event_status = event::Status::Ignored;
 
@@ -169,14 +170,18 @@ where
             layout
         };
 
-        let body_status = self.body.on_event(
-            event,
-            body_layout,
-            cursor_position,
-            renderer,
-            clipboard,
-            messages,
-        );
+        let body_status = if is_picked {
+            event::Status::Ignored
+        } else {
+            self.body.on_event(
+                event,
+                body_layout,
+                cursor_position,
+                renderer,
+                clipboard,
+                messages,
+            )
+        };
 
         event_status.merge(body_status)
     }


### PR DESCRIPTION
Currently, if you have a widget that produces an overlay in the `TitleBar` and you try to drag that pane, the overlay won't close (due to the button press outside the overlay bounds not getting processed by the overlay) and will "hang" in place while the pane is dragged.

This fixes the `pane_grid` widget by allowing `TitleBar` content to process events when "dragging" the pane.

When a pane is being dragged, only the `TitleBar` will get to process events, not the pane body.