### PR TITLE
wgpu: Use the preferred texture format of the surface

### DIFF
--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -46,7 +46,7 @@ pub fn main() {
         (
             adapter
                 .get_swap_chain_preferred_format(&surface)
-                .expect("Preffered format"),
+                .expect("Get preferred format"),
             adapter
                 .request_device(
                     &wgpu::DeviceDescriptor {

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -30,23 +30,24 @@ pub struct Backend {
 
 impl Backend {
     /// Creates a new [`Backend`].
-    pub fn new(device: &wgpu::Device, settings: Settings) -> Self {
+    pub fn new(
+        device: &wgpu::Device,
+        settings: Settings,
+        format: wgpu::TextureFormat,
+    ) -> Self {
         let text_pipeline = text::Pipeline::new(
             device,
-            settings.format,
+            format,
             settings.default_font,
             settings.text_multithreading,
         );
 
-        let quad_pipeline = quad::Pipeline::new(device, settings.format);
-        let triangle_pipeline = triangle::Pipeline::new(
-            device,
-            settings.format,
-            settings.antialiasing,
-        );
+        let quad_pipeline = quad::Pipeline::new(device, format);
+        let triangle_pipeline =
+            triangle::Pipeline::new(device, format, settings.antialiasing);
 
         #[cfg(any(feature = "image_rs", feature = "svg"))]
-        let image_pipeline = image::Pipeline::new(device, settings.format);
+        let image_pipeline = image::Pipeline::new(device, format);
 
         Self {
             quad_pipeline,

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -6,11 +6,6 @@ pub use crate::Antialiasing;
 /// [`Backend`]: crate::Backend
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Settings {
-    /// The output format of the [`Backend`].
-    ///
-    /// [`Backend`]: crate::Backend
-    pub format: wgpu::TextureFormat,
-
     /// The present mode of the [`Backend`].
     ///
     /// [`Backend`]: crate::Backend
@@ -68,7 +63,6 @@ impl Settings {
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
             present_mode: wgpu::PresentMode::Mailbox,
             internal_backend: wgpu::BackendBit::PRIMARY,
             default_font: None,


### PR DESCRIPTION
Use the preferred texture format of the surface instead of `Bgra8UnormSrgb`.

Related to: #891