### PR TITLE
Fix glow and multiple windows usage

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -146,7 +146,7 @@ async fn run_instance<A, E, C>(
     mut runtime: Runtime<E, Proxy<A::Message>, A::Message>,
     mut debug: Debug,
     mut receiver: mpsc::UnboundedReceiver<glutin::event::Event<'_, A::Message>>,
-    context: glutin::ContextWrapper<glutin::PossiblyCurrent, Window>,
+    mut context: glutin::ContextWrapper<glutin::PossiblyCurrent, Window>,
     exit_on_close_request: bool,
 ) where
     A: Application + 'static,
@@ -255,6 +255,16 @@ async fn run_instance<A, E, C>(
             }
             event::Event::RedrawRequested(_) => {
                 debug.render_started();
+
+                #[allow(unsafe_code)]
+                unsafe {
+                    if !context.is_current() {
+                        context = context
+                            .make_current()
+                            .expect("Make OpenGL context current");
+                    }
+                }
+
                 let current_viewport_version = state.viewport_version();
 
                 if viewport_version != current_viewport_version {


### PR DESCRIPTION
Hey there 👋 

I'm writing a VST plugin host, which might have another `iced` app as a guest.

In that case, when the guest window opens, the glow context might not be current when redrawing, causing the UI to be frozen.

This commit adds a check prior to redrawing for whether the context is current. It forces the context to become current if it's not. This fixes hosting issues with multiple windows for me. I suppose it might be a necessary change if `iced` itself had more than one window open at a time.

This was not a problem using the wgpu back-end.