### PR TITLE
Allow canvas' "Frame"s to be retained

### DIFF
--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -93,6 +93,7 @@ impl Frame {
         );
 
         let mut tessellator = &mut self.fill_tessellator;
+        let options = FillOptions::default().with_fill_rule(rule.into());
 
         let result = if self.transforms.current.is_identity {
             tessellator.tessellate_path(path.raw(), &options, &mut buffers)

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -1,10 +1,10 @@
 use iced_native::{Point, Rectangle, Size, Vector};
+use lyon::tessellation::{FillTessellator, StrokeTessellator};
 
 use crate::{
     canvas::{Fill, Geometry, Path, Stroke, Text},
     triangle, Primitive,
 };
-use lyon::tessellation::FillTessellator;
 
 /// The frame of a [`Canvas`].
 ///
@@ -16,6 +16,7 @@ pub struct Frame {
     primitives: Vec<Primitive>,
     transforms: Transforms,
     fill_tessellator: FillTessellator,
+    stroke_tessellator: StrokeTessellator,
 }
 
 #[derive(Debug)]
@@ -48,6 +49,7 @@ impl Frame {
                 },
             },
             fill_tessellator: FillTessellator::new(),
+            stroke_tessellator: StrokeTessellator::new(),
         }
     }
 
@@ -92,7 +94,7 @@ impl Frame {
             FillVertex(color.into_linear()),
         );
 
-        let mut tessellator = &mut self.fill_tessellator;
+        let tessellator = &mut self.fill_tessellator;
         let options = FillOptions::default().with_fill_rule(rule.into());
 
         let result = if self.transforms.current.is_identity {
@@ -144,9 +146,7 @@ impl Frame {
     /// Draws the stroke of the given [`Path`] on the [`Frame`] with the
     /// provided style.
     pub fn stroke(&mut self, path: &Path, stroke: impl Into<Stroke>) {
-        use lyon::tessellation::{
-            BuffersBuilder, StrokeOptions, StrokeTessellator,
-        };
+        use lyon::tessellation::{BuffersBuilder, StrokeOptions};
 
         let stroke = stroke.into();
 
@@ -155,7 +155,7 @@ impl Frame {
             StrokeVertex(stroke.color.into_linear()),
         );
 
-        let mut tessellator = StrokeTessellator::new();
+        let tessellator = &mut self.stroke_tessellator;
 
         let mut options = StrokeOptions::default();
         options.line_width = stroke.width;


### PR DESCRIPTION
This allows users to improve performance of canvas by retaining the
`Frame` struct between view updates. This avoids
allocations/deallocations that happen internally in lyon. See
https://github.com/nical/lyon/pull/683.

Full example usage: https://github.com/yamadapc/augmented-audio/blob/master/crates/plugin-host-gui2/src/ui/main_content_view/volume_meter/mod.rs

Minimal (non-working) example:
```rust
struct Visualisation {
    frame: RefCell<Frame>, // <- RefCell is to hack around the current `draw(&self, ...)` API (no mutable ref. to self)
}

impl Visualisation {
    fn new() -> Self {
        Self {
            // The size does not matter at this point
            frame: RefCell::new(Frame::new(Size::new(100., 100.))),
        }
    }

   fn view(&mut self) -> Element<Message> {
        Canvas::new(self).width(Length::Fill).height(Length::Fill)
            .into()
    }
}

impl Program<Message> for Visualisation {
    fn draw(&self, bounds: Rectangle, _cursor: Cursor) -> Vec<Geometry> {
        let mut frame = self.frame.borrow_mut();
        // Because frame is retained internal vecs/structures already have proper capacity
        frame.resize(bounds.size());

        // Draw on the frame

        geometry.push(frame.geometry()); // `Frame::geometry` doesn't consume the Frame
        geometry
    }
}
```

~~I should update the other tessellator usages as well, since they probably would also benefit~~. Potentially it'd be good that https://github.com/hecrj/iced/pull/683 is merged first.