### PR TITLE
tweak default rule style

### DIFF
--- a/style/src/rule.rs
+++ b/style/src/rule.rs
@@ -82,10 +82,10 @@ pub struct Style {
 impl std::default::Default for Style {
     fn default() -> Self {
         Style {
-            color: [0.6, 0.6, 0.6, 0.51].into(),
+            color: [0.6, 0.6, 0.6, 0.6].into(),
             width: 1,
             radius: 0.0,
-            fill_mode: FillMode::Percent(90.0),
+            fill_mode: FillMode::Full,
         }
     }
 }


### PR DESCRIPTION
(Reuploaded from https://github.com/hecrj/iced/pull/666)

I tweaked the Rule style to have just a bit more contrast. It also makes more sense to have the rule span its full width by default.