### PR TITLE
wgpu: Update to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/iced"
 readme = "README.md"
 keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
+resolver = "2"
 
 [features]
 default = ["wgpu", "default_system_font"]

--- a/examples/integration_wgpu/Cargo.toml
+++ b/examples/integration_wgpu/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 
 [dependencies]
 iced_winit = { path = "../../winit" }
-iced_wgpu = { path = "../../wgpu", features=["spirv"] }
+iced_wgpu = { path = "../../wgpu", features = ["spirv"] }
 env_logger = "0.8"

--- a/examples/integration_wgpu/Cargo.toml
+++ b/examples/integration_wgpu/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 
 [dependencies]
 iced_winit = { path = "../../winit" }
-iced_wgpu = { path = "../../wgpu" }
+iced_wgpu = { path = "../../wgpu", features=["spirv"] }
 env_logger = "0.8"

--- a/examples/integration_wgpu/src/scene.rs
+++ b/examples/integration_wgpu/src/scene.rs
@@ -79,7 +79,7 @@ fn build_pipeline(device: &wgpu::Device) -> wgpu::RenderPipeline {
                         color: wgpu::BlendComponent::REPLACE,
                         alpha: wgpu::BlendComponent::REPLACE,
                     }),
-                    write_mask: wgpu::ColorWrite::ALL,
+                    write_mask: wgpu::ColorWrites::ALL,
                 }],
             }),
             primitive: wgpu::PrimitiveState {

--- a/graphics/src/window.rs
+++ b/graphics/src/window.rs
@@ -4,7 +4,7 @@ mod compositor;
 #[cfg(feature = "opengl")]
 mod gl_compositor;
 
-pub use compositor::{Compositor, SwapChainError};
+pub use compositor::{Compositor, SurfaceError};
 
 #[cfg(feature = "opengl")]
 pub use gl_compositor::GLCompositor;

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -51,6 +51,7 @@ pub trait Compositor: Sized {
         &mut self,
         renderer: &mut Self::Renderer,
         swap_chain: &mut Self::SwapChain,
+        surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -16,9 +16,6 @@ pub trait Compositor: Sized {
     /// The surface of the backend.
     type Surface;
 
-    /// The swap chain of the backend.
-    type SwapChain;
-
     /// Creates a new [`Compositor`].
     fn new<W: HasRawWindowHandle>(
         settings: Self::Settings,
@@ -37,12 +34,12 @@ pub trait Compositor: Sized {
     ///
     /// [`SwapChain`]: Self::SwapChain
     /// [`Surface`]: Self::Surface
-    fn create_swap_chain(
+    fn configure_surface(
         &mut self,
-        surface: &Self::Surface,
+        surface: &mut Self::Surface,
         width: u32,
         height: u32,
-    ) -> Self::SwapChain;
+    );
 
     /// Draws the output primitives to the next frame of the given [`SwapChain`].
     ///
@@ -50,7 +47,6 @@ pub trait Compositor: Sized {
     fn draw<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        swap_chain: &mut Self::SwapChain,
         surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -52,12 +52,12 @@ pub trait Compositor: Sized {
         background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
-    ) -> Result<mouse::Interaction, SwapChainError>;
+    ) -> Result<mouse::Interaction, SurfaceError>;
 }
 
 /// Result of an unsuccessful call to [`Compositor::draw`].
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
-pub enum SwapChainError {
+pub enum SurfaceError {
     /// A timeout was encountered while trying to acquire the next frame.
     #[error(
         "A timeout was encountered while trying to acquire the next frame"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -28,7 +28,7 @@ spirv = ["wgpu/spirv"]
 
 [dependencies]
 wgpu = "0.10"
-wgpu_glyph = {git="https://github.com/rukai/wgpu_glyph.git", branch="update_wgpu_0.10"}
+wgpu_glyph = "0.14"
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -24,10 +24,11 @@ farbfeld = ["image_rs/farbfeld"]
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
+spirv = ["wgpu/spirv"]
 
 [dependencies]
-wgpu = "0.9"
-wgpu_glyph = "0.13"
+wgpu = "0.10"
+wgpu_glyph = {git="https://github.com/rukai/wgpu_glyph.git", branch="update_wgpu_0.10"}
 glyph_brush = "0.7"
 raw-window-handle = "0.3"
 log = "0.4"

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -61,7 +61,7 @@ impl Pipeline {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -73,7 +73,7 @@ impl Pipeline {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Sampler {
                             comparison: false,
                             filtering: true,
@@ -86,7 +86,7 @@ impl Pipeline {
         let uniforms_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::image uniforms buffer"),
             size: mem::size_of::<Uniforms>() as u64,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -117,7 +117,7 @@ impl Pipeline {
                 label: Some("iced_wgpu::image texture atlas layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float {
                             filterable: true,
@@ -142,7 +142,6 @@ impl Pipeline {
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("shader/image.wgsl"),
                 )),
-                flags: wgpu::ShaderFlags::all(),
             });
 
         let pipeline =
@@ -155,7 +154,7 @@ impl Pipeline {
                     buffers: &[
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<Vertex>() as u64,
-                            step_mode: wgpu::InputStepMode::Vertex,
+                            step_mode: wgpu::VertexStepMode::Vertex,
                             attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
                                 format: wgpu::VertexFormat::Float32x2,
@@ -164,7 +163,7 @@ impl Pipeline {
                         },
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<Instance>() as u64,
-                            step_mode: wgpu::InputStepMode::Instance,
+                            step_mode: wgpu::VertexStepMode::Instance,
                             attributes: &wgpu::vertex_attr_array!(
                                 1 => Float32x2,
                                 2 => Float32x2,
@@ -192,7 +191,7 @@ impl Pipeline {
                                 operation: wgpu::BlendOperation::Add,
                             },
                         }),
-                        write_mask: wgpu::ColorWrite::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
@@ -212,20 +211,20 @@ impl Pipeline {
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::image vertex buffer"),
                 contents: bytemuck::cast_slice(&QUAD_VERTS),
-                usage: wgpu::BufferUsage::VERTEX,
+                usage: wgpu::BufferUsages::VERTEX,
             });
 
         let indices =
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::image index buffer"),
                 contents: bytemuck::cast_slice(&QUAD_INDICES),
-                usage: wgpu::BufferUsage::INDEX,
+                usage: wgpu::BufferUsages::INDEX,
             });
 
         let instances = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::image instance buffer"),
             size: mem::size_of::<Instance>() as u64 * Instance::MAX as u64,
-            usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -36,9 +36,9 @@ impl Atlas {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Bgra8UnormSrgb,
-            usage: wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::COPY_SRC
-                | wgpu::TextureUsage::SAMPLED,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
         });
 
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor {
@@ -107,7 +107,7 @@ impl Atlas {
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::image staging buffer"),
                 contents: &padded_data,
-                usage: wgpu::BufferUsage::COPY_SRC,
+                usage: wgpu::BufferUsages::COPY_SRC,
             });
 
         match &entry {
@@ -316,6 +316,7 @@ impl Atlas {
                     y,
                     z: layer as u32,
                 },
+                aspect: wgpu::TextureAspect::default(),
             },
             extent,
         );
@@ -342,9 +343,9 @@ impl Atlas {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Bgra8UnormSrgb,
-            usage: wgpu::TextureUsage::COPY_DST
-                | wgpu::TextureUsage::COPY_SRC
-                | wgpu::TextureUsage::SAMPLED,
+            usage: wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
         });
 
         let amount_to_copy = self.layers.len() - amount;
@@ -365,6 +366,7 @@ impl Atlas {
                         y: 0,
                         z: i as u32,
                     },
+                    aspect: wgpu::TextureAspect::default(),
                 },
                 wgpu::ImageCopyTexture {
                     texture: &new_texture,
@@ -374,6 +376,7 @@ impl Atlas {
                         y: 0,
                         z: i as u32,
                     },
+                    aspect: wgpu::TextureAspect::default(),
                 },
                 wgpu::Extent3d {
                     width: SIZE,

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -23,7 +23,7 @@ impl Pipeline {
                 label: Some("iced_wgpu::quad uniforms layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
@@ -38,7 +38,7 @@ impl Pipeline {
         let constants_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::quad uniforms buffer"),
             size: mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -64,7 +64,6 @@ impl Pipeline {
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("shader/quad.wgsl"),
                 )),
-                flags: wgpu::ShaderFlags::all(),
             });
 
         let pipeline =
@@ -77,7 +76,7 @@ impl Pipeline {
                     buffers: &[
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<Vertex>() as u64,
-                            step_mode: wgpu::InputStepMode::Vertex,
+                            step_mode: wgpu::VertexStepMode::Vertex,
                             attributes: &[wgpu::VertexAttribute {
                                 shader_location: 0,
                                 format: wgpu::VertexFormat::Float32x2,
@@ -86,7 +85,7 @@ impl Pipeline {
                         },
                         wgpu::VertexBufferLayout {
                             array_stride: mem::size_of::<layer::Quad>() as u64,
-                            step_mode: wgpu::InputStepMode::Instance,
+                            step_mode: wgpu::VertexStepMode::Instance,
                             attributes: &wgpu::vertex_attr_array!(
                                 1 => Float32x2,
                                 2 => Float32x2,
@@ -115,7 +114,7 @@ impl Pipeline {
                                 operation: wgpu::BlendOperation::Add,
                             },
                         }),
-                        write_mask: wgpu::ColorWrite::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
@@ -135,20 +134,20 @@ impl Pipeline {
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::quad vertex buffer"),
                 contents: bytemuck::cast_slice(&QUAD_VERTS),
-                usage: wgpu::BufferUsage::VERTEX,
+                usage: wgpu::BufferUsages::VERTEX,
             });
 
         let indices =
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("iced_wgpu::quad index buffer"),
                 contents: bytemuck::cast_slice(&QUAD_INDICES),
-                usage: wgpu::BufferUsage::INDEX,
+                usage: wgpu::BufferUsages::INDEX,
             });
 
         let instances = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::quad instance buffer"),
             size: mem::size_of::<layer::Quad>() as u64 * MAX_INSTANCES as u64,
-            usage: wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -12,7 +12,7 @@ pub struct Settings {
     pub present_mode: wgpu::PresentMode,
 
     /// The internal graphics backend to use.
-    pub internal_backend: wgpu::BackendBit,
+    pub internal_backend: wgpu::Backends,
 
     /// The bytes of the font that will be used by default.
     ///
@@ -54,7 +54,7 @@ impl Settings {
     pub fn from_env() -> Self {
         Settings {
             internal_backend: backend_from_env()
-                .unwrap_or(wgpu::BackendBit::PRIMARY),
+                .unwrap_or(wgpu::Backends::all()),
             ..Self::default()
         }
     }
@@ -64,7 +64,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             present_mode: wgpu::PresentMode::Mailbox,
-            internal_backend: wgpu::BackendBit::PRIMARY,
+            internal_backend: wgpu::Backends::all(),
             default_font: None,
             default_text_size: 20,
             text_multithreading: false,
@@ -73,16 +73,16 @@ impl Default for Settings {
     }
 }
 
-fn backend_from_env() -> Option<wgpu::BackendBit> {
+fn backend_from_env() -> Option<wgpu::Backends> {
     std::env::var("WGPU_BACKEND").ok().map(|backend| {
         match backend.to_lowercase().as_str() {
-            "vulkan" => wgpu::BackendBit::VULKAN,
-            "metal" => wgpu::BackendBit::METAL,
-            "dx12" => wgpu::BackendBit::DX12,
-            "dx11" => wgpu::BackendBit::DX11,
-            "gl" => wgpu::BackendBit::GL,
-            "webgpu" => wgpu::BackendBit::BROWSER_WEBGPU,
-            "primary" => wgpu::BackendBit::PRIMARY,
+            "vulkan" => wgpu::Backends::VULKAN,
+            "metal" => wgpu::Backends::METAL,
+            "dx12" => wgpu::Backends::DX12,
+            "dx11" => wgpu::Backends::DX11,
+            "gl" => wgpu::Backends::GL,
+            "webgpu" => wgpu::Backends::BROWSER_WEBGPU,
+            "primary" => wgpu::Backends::PRIMARY,
             other => panic!("Unknown backend: {}", other),
         }
     })

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -29,7 +29,7 @@ struct Buffer<T> {
     label: &'static str,
     raw: wgpu::Buffer,
     size: usize,
-    usage: wgpu::BufferUsage,
+    usage: wgpu::BufferUsages,
     _type: std::marker::PhantomData<T>,
 }
 
@@ -38,7 +38,7 @@ impl<T> Buffer<T> {
         label: &'static str,
         device: &wgpu::Device,
         size: usize,
-        usage: wgpu::BufferUsage,
+        usage: wgpu::BufferUsages,
     ) -> Self {
         let raw = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some(label),
@@ -85,7 +85,7 @@ impl Pipeline {
                 label: Some("iced_wgpu::triangle uniforms layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX,
+                    visibility: wgpu::ShaderStages::VERTEX,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: true,
@@ -101,7 +101,7 @@ impl Pipeline {
             "iced_wgpu::triangle uniforms buffer",
             device,
             UNIFORM_BUFFER_SIZE,
-            wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         );
 
         let constant_bind_group =
@@ -137,7 +137,6 @@ impl Pipeline {
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("shader/triangle.wgsl"),
                 )),
-                flags: wgpu::ShaderFlags::all(),
             });
 
         let pipeline =
@@ -149,7 +148,7 @@ impl Pipeline {
                     entry_point: "vs_main",
                     buffers: &[wgpu::VertexBufferLayout {
                         array_stride: mem::size_of::<Vertex2D>() as u64,
-                        step_mode: wgpu::InputStepMode::Vertex,
+                        step_mode: wgpu::VertexStepMode::Vertex,
                         attributes: &wgpu::vertex_attr_array!(
                             // Position
                             0 => Float32x2,
@@ -175,7 +174,7 @@ impl Pipeline {
                                 operation: wgpu::BlendOperation::Add,
                             },
                         }),
-                        write_mask: wgpu::ColorWrite::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
@@ -203,13 +202,13 @@ impl Pipeline {
                 "iced_wgpu::triangle vertex buffer",
                 device,
                 VERTEX_BUFFER_SIZE,
-                wgpu::BufferUsage::VERTEX | wgpu::BufferUsage::COPY_DST,
+                wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
             ),
             index_buffer: Buffer::new(
                 "iced_wgpu::triangle index buffer",
                 device,
                 INDEX_BUFFER_SIZE,
-                wgpu::BufferUsage::INDEX | wgpu::BufferUsage::COPY_DST,
+                wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
             ),
         }
     }

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -31,7 +31,7 @@ impl Blit {
                 label: Some("iced_wgpu::triangle:msaa uniforms layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Sampler {
                         comparison: false,
                         filtering: false,
@@ -55,7 +55,7 @@ impl Blit {
                 label: Some("iced_wgpu::triangle::msaa texture layout"),
                 entries: &[wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Texture {
                         sample_type: wgpu::TextureSampleType::Float {
                             filterable: false,
@@ -80,7 +80,6 @@ impl Blit {
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("../shader/blit.wgsl"),
                 )),
-                flags: wgpu::ShaderFlags::all(),
             });
 
         let pipeline =
@@ -109,7 +108,7 @@ impl Blit {
                                 operation: wgpu::BlendOperation::Add,
                             },
                         }),
-                        write_mask: wgpu::ColorWrite::ALL,
+                        write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),
                 primitive: wgpu::PrimitiveState {
@@ -232,7 +231,7 @@ impl Targets {
             sample_count,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         });
 
         let resolve = device.create_texture(&wgpu::TextureDescriptor {
@@ -242,8 +241,8 @@ impl Targets {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT
-                | wgpu::TextureUsage::SAMPLED,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
         });
 
         let attachment =

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -140,7 +140,7 @@ impl iced_graphics::window::Compositor for Compositor {
         background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
-    ) -> Result<mouse::Interaction, iced_graphics::window::SwapChainError> {
+    ) -> Result<mouse::Interaction, iced_graphics::window::SurfaceError> {
         match surface.get_current_frame() {
             Ok(frame) => {
                 let mut encoder = self.device.create_command_encoder(
@@ -206,16 +206,16 @@ impl iced_graphics::window::Compositor for Compositor {
             }
             Err(error) => match error {
                 wgpu::SurfaceError::Timeout => {
-                    Err(iced_graphics::window::SwapChainError::Timeout)
+                    Err(iced_graphics::window::SurfaceError::Timeout)
                 }
                 wgpu::SurfaceError::Outdated => {
-                    Err(iced_graphics::window::SwapChainError::Outdated)
+                    Err(iced_graphics::window::SurfaceError::Outdated)
                 }
                 wgpu::SurfaceError::Lost => {
-                    Err(iced_graphics::window::SwapChainError::Lost)
+                    Err(iced_graphics::window::SurfaceError::Lost)
                 }
                 wgpu::SurfaceError::OutOfMemory => {
-                    Err(iced_graphics::window::SwapChainError::OutOfMemory)
+                    Err(iced_graphics::window::SurfaceError::OutOfMemory)
                 }
             },
         }

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -45,7 +45,7 @@ impl Compositor {
 
         let format = compatible_surface
             .as_ref()
-            .and_then(|surf| adapter.get_swap_chain_preferred_format(surf))?;
+            .and_then(|surf| surf.get_preferred_format(&adapter))?;
 
         let (device, queue) = adapter
             .request_device(
@@ -88,7 +88,7 @@ impl iced_graphics::window::Compositor for Compositor {
     type Settings = Settings;
     type Renderer = Renderer;
     type Surface = wgpu::Surface;
-    type SwapChain = wgpu::SwapChain;
+    type SwapChain = ();
 
     fn new<W: HasRawWindowHandle>(
         settings: Self::Settings,
@@ -121,10 +121,10 @@ impl iced_graphics::window::Compositor for Compositor {
         width: u32,
         height: u32,
     ) -> Self::SwapChain {
-        self.device.create_swap_chain(
-            surface,
-            &wgpu::SwapChainDescriptor {
-                usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+        surface.configure(
+            &self.device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format: self.format,
                 present_mode: self.settings.present_mode,
                 width,
@@ -136,13 +136,14 @@ impl iced_graphics::window::Compositor for Compositor {
     fn draw<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        swap_chain: &mut Self::SwapChain,
+        _swap_chain: &mut Self::SwapChain,
+        surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> Result<mouse::Interaction, iced_graphics::window::SwapChainError> {
-        match swap_chain.get_current_frame() {
+        match surface.get_current_frame() {
             Ok(frame) => {
                 let mut encoder = self.device.create_command_encoder(
                     &wgpu::CommandEncoderDescriptor {
@@ -150,13 +151,18 @@ impl iced_graphics::window::Compositor for Compositor {
                     },
                 );
 
+                let view = &frame
+                    .output
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+
                 let _ =
                     encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                         label: Some(
                             "iced_wgpu::window::Compositor render pass",
                         ),
                         color_attachments: &[wgpu::RenderPassColorAttachment {
-                            view: &frame.output.view,
+                            view,
                             resolve_target: None,
                             ops: wgpu::Operations {
                                 load: wgpu::LoadOp::Clear({
@@ -180,7 +186,7 @@ impl iced_graphics::window::Compositor for Compositor {
                     &mut self.device,
                     &mut self.staging_belt,
                     &mut encoder,
-                    &frame.output.view,
+                    view,
                     viewport,
                     output,
                     overlay,
@@ -201,16 +207,16 @@ impl iced_graphics::window::Compositor for Compositor {
                 Ok(mouse_interaction)
             }
             Err(error) => match error {
-                wgpu::SwapChainError::Timeout => {
+                wgpu::SurfaceError::Timeout => {
                     Err(iced_graphics::window::SwapChainError::Timeout)
                 }
-                wgpu::SwapChainError::Outdated => {
+                wgpu::SurfaceError::Outdated => {
                     Err(iced_graphics::window::SwapChainError::Outdated)
                 }
-                wgpu::SwapChainError::Lost => {
+                wgpu::SurfaceError::Lost => {
                     Err(iced_graphics::window::SwapChainError::Lost)
                 }
-                wgpu::SwapChainError::OutOfMemory => {
+                wgpu::SurfaceError::OutOfMemory => {
                     Err(iced_graphics::window::SwapChainError::OutOfMemory)
                 }
             },

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -45,7 +45,7 @@ impl Compositor {
 
         let format = compatible_surface
             .as_ref()
-            .and_then(|surf| surf.get_preferred_format(&adapter))?;
+            .and_then(|surface| surface.get_preferred_format(&adapter))?;
 
         let (device, queue) = adapter
             .request_device(

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -88,7 +88,6 @@ impl iced_graphics::window::Compositor for Compositor {
     type Settings = Settings;
     type Renderer = Renderer;
     type Surface = wgpu::Surface;
-    type SwapChain = ();
 
     fn new<W: HasRawWindowHandle>(
         settings: Self::Settings,
@@ -115,12 +114,12 @@ impl iced_graphics::window::Compositor for Compositor {
         }
     }
 
-    fn create_swap_chain(
+    fn configure_surface(
         &mut self,
-        surface: &Self::Surface,
+        surface: &mut Self::Surface,
         width: u32,
         height: u32,
-    ) -> Self::SwapChain {
+    ) {
         surface.configure(
             &self.device,
             &wgpu::SurfaceConfiguration {
@@ -130,13 +129,12 @@ impl iced_graphics::window::Compositor for Compositor {
                 width,
                 height,
             },
-        )
+        );
     }
 
     fn draw<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        _swap_chain: &mut Self::SwapChain,
         surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -227,7 +227,7 @@ async fn run_instance<A, E, C>(
     use iced_futures::futures::stream::StreamExt;
     use winit::event;
 
-    let surface = compositor.create_surface(&window);
+    let mut surface = compositor.create_surface(&window);
     let mut clipboard = Clipboard::connect(&window);
 
     let mut state = State::new(&application, &window);
@@ -370,6 +370,7 @@ async fn run_instance<A, E, C>(
                 match compositor.draw(
                     &mut renderer,
                     &mut swap_chain,
+                    &mut surface,
                     state.viewport(),
                     state.background_color(),
                     &primitive,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -392,7 +392,7 @@ async fn run_instance<A, E, C>(
                     }
                     Err(error) => match error {
                         // This is an unrecoverable error.
-                        window::SwapChainError::OutOfMemory => {
+                        window::SurfaceError::OutOfMemory => {
                             panic!("{}", error);
                         }
                         _ => {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -232,15 +232,14 @@ async fn run_instance<A, E, C>(
 
     let mut state = State::new(&application, &window);
     let mut viewport_version = state.viewport_version();
-    let mut swap_chain = {
-        let physical_size = state.physical_size();
 
-        compositor.create_swap_chain(
-            &surface,
-            physical_size.width,
-            physical_size.height,
-        )
-    };
+    let physical_size = state.physical_size();
+
+    compositor.configure_surface(
+        &mut surface,
+        physical_size.width,
+        physical_size.height,
+    );
 
     let mut user_interface = ManuallyDrop::new(build_user_interface(
         &mut application,
@@ -358,8 +357,8 @@ async fn run_instance<A, E, C>(
                         .draw(&mut renderer, state.cursor_position());
                     debug.draw_finished();
 
-                    swap_chain = compositor.create_swap_chain(
-                        &surface,
+                    compositor.configure_surface(
+                        &mut surface,
                         physical_size.width,
                         physical_size.height,
                     );
@@ -369,7 +368,6 @@ async fn run_instance<A, E, C>(
 
                 match compositor.draw(
                     &mut renderer,
-                    &mut swap_chain,
                     &mut surface,
                     state.viewport(),
                     state.background_color(),


### PR DESCRIPTION
- ~~blocked by: https://github.com/hecrj/wgpu_glyph/pull/73~~ (no longer blocking)
- Opengl backedn of wgpu now works as expected in iced (I never managed to run it in prev versions, but now it works)
  - EDIT: nope, never mind, on my second device it does not work at all, so it's still unstable (at least on linux)
- Images in OpenGL are for some reason black, I will investigate this a little bit more soon.
- Wgpu SwapChain not longer exists, so surface was added as an argument to draw() in compositor trait, ~~wgpu implementation of compositors uses `()` as a SwapChain type now.~~

Fixes #933.