### PR TITLE
Fix window holes behind transparent objects

### DIFF
--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -26,7 +26,12 @@ impl iced_graphics::window::GLCompositor for Compositor {
 
         // Enable alpha blending
         gl.enable(glow::BLEND);
-        gl.blend_func(glow::SRC_ALPHA, glow::ONE_MINUS_SRC_ALPHA);
+        gl.blend_func_separate(
+            glow::SRC_ALPHA,
+            glow::ONE_MINUS_SRC_ALPHA,
+            glow::ONE,
+            glow::ONE_MINUS_SRC_ALPHA,
+        );
 
         // Disable multisampling by default
         gl.disable(glow::MULTISAMPLE);


### PR DESCRIPTION
Without this change, the transparent objects composed over the opaque
background creates the transparency of the entire window through which
the desktop wallpaper could be seen.
This problem manifested itself with glow backend and wayland compositor
(gnome).

This patch completely eliminates this problem. With it, the final image
produced by glow backend corresponds to the image produced by the wgpu
backend.

Fixes #1018