### PR TITLE
Add horizontal and vertical padding methods.

### DIFF
--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -69,20 +69,14 @@ pub fn right(padding: impl Into<Pixels>) -> Padding {
     Padding::default().right(padding)
 }
 
-/// Create a [`Padding`] with equal left and right sides.
+/// Create some [`Padding`] with equal left and right sides.
 pub fn horizontal(padding: impl Into<Pixels>) -> Padding {
-    let padding: Pixels = padding.into();
-        Padding::default()
-        .left(padding.clone())
-        .right(padding)
+    Padding::default().horizontal(padding)
 }
 
-/// Create a [`Padding`] with equal top and bottom sides.
+/// Create some [`Padding`] with equal top and bottom sides.
 pub fn vertical(padding: impl Into<Pixels>) -> Padding {
-    let padding: Pixels = padding.into();
-    Padding::default()
-        .top(padding.clone())
-        .bottom(padding)
+    Padding::default().vertical(padding)
 }
 
 impl Padding {
@@ -144,14 +138,42 @@ impl Padding {
         }
     }
 
-    /// Returns the total amount of vertical [`Padding`].
-    pub fn vertical(self) -> f32 {
-        self.top + self.bottom
+    /// Sets the [`left`] and [`right`] of the [`Padding`].
+    ///
+    /// [`left`]: Self::left
+    /// [`right`]: Self::right
+    pub fn horizontal(self, horizontal: impl Into<Pixels>) -> Self {
+        let horizontal = horizontal.into();
+
+        Self {
+            left: horizontal.0,
+            right: horizontal.0,
+            ..self
+        }
+    }
+
+    /// Sets the [`top`] and [`bottom`] of the [`Padding`].
+    ///
+    /// [`top`]: Self::top
+    /// [`bottom`]: Self::bottom
+    pub fn vertical(self, vertical: impl Into<Pixels>) -> Self {
+        let vertical = vertical.into();
+
+        Self {
+            top: vertical.0,
+            bottom: vertical.0,
+            ..self
+        }
     }
 
     /// Returns the total amount of horizontal [`Padding`].
-    pub fn horizontal(self) -> f32 {
+    pub fn x(self) -> f32 {
         self.left + self.right
+    }
+
+    /// Returns the total amount of vertical [`Padding`].
+    pub fn y(self) -> f32 {
+        self.top + self.bottom
     }
 
     /// Fits the [`Padding`] between the provided `inner` and `outer` [`Size`].
@@ -215,7 +237,7 @@ impl From<[f32; 2]> for Padding {
 
 impl From<Padding> for Size {
     fn from(padding: Padding) -> Self {
-        Self::new(padding.horizontal(), padding.vertical())
+        Self::new(padding.x(), padding.y())
     }
 }
 

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -272,8 +272,8 @@ impl Rectangle<f32> {
         Self {
             x: self.x - padding.left,
             y: self.y - padding.top,
-            width: self.width + padding.horizontal(),
-            height: self.height + padding.vertical(),
+            width: self.width + padding.x(),
+            height: self.height + padding.y(),
         }
     }
 
@@ -284,8 +284,8 @@ impl Rectangle<f32> {
         Self {
             x: self.x + padding.left,
             y: self.y + padding.top,
-            width: self.width - padding.horizontal(),
-            height: self.height - padding.vertical(),
+            width: self.width - padding.x(),
+            height: self.height - padding.y(),
         }
     }
 

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -383,7 +383,7 @@ where
         let size = {
             let intrinsic = Size::new(
                 0.0,
-                (f32::from(text_line_height) + self.padding.vertical())
+                (f32::from(text_line_height) + self.padding.y())
                     * self.options.len() as f32,
             );
 
@@ -424,7 +424,7 @@ where
 
                     let option_height =
                         f32::from(self.text_line_height.to_absolute(text_size))
-                            + self.padding.vertical();
+                            + self.padding.y();
 
                     let new_hovered_option =
                         (cursor_position.y / option_height) as usize;
@@ -454,7 +454,7 @@ where
 
                     let option_height =
                         f32::from(self.text_line_height.to_absolute(text_size))
-                            + self.padding.vertical();
+                            + self.padding.y();
 
                     *self.hovered_option =
                         Some((cursor_position.y / option_height) as usize);
@@ -515,7 +515,7 @@ where
             self.text_size.unwrap_or_else(|| renderer.default_size());
         let option_height =
             f32::from(self.text_line_height.to_absolute(text_size))
-                + self.padding.vertical();
+                + self.padding.y();
 
         let offset = viewport.y - bounds.y;
         let start = (offset / option_height) as usize;

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -665,7 +665,7 @@ where
                     line_height: self.text_line_height,
                     font,
                     bounds: Size::new(
-                        bounds.width - self.padding.horizontal(),
+                        bounds.width - self.padding.x(),
                         f32::from(self.text_line_height.to_absolute(text_size)),
                     ),
                     align_x: text::Alignment::Default,

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -287,10 +287,7 @@ where
                                     span.padding.top,
                                 ),
                             bounds.size()
-                                + Size::new(
-                                    span.padding.horizontal(),
-                                    span.padding.vertical(),
-                                ),
+                                + Size::new(span.padding.x(), span.padding.y()),
                         );
 
                         renderer.fill_quad(

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -654,7 +654,7 @@ where
                     limits
                         .height(min_bounds.height)
                         .max()
-                        .expand(Size::new(0.0, self.padding.vertical())),
+                        .expand(Size::new(0.0, self.padding.y())),
                 )
             }
         }


### PR DESCRIPTION
e.g.

```rust
let status_bar = container(text("status bar area"))
    .padding(padding::horizontal(3));
```

the point of this PR is:
* to improve the API for everyone.
* to make is so that the number, `3` in the example above, is only specified once.
* so that default values do not have to be specified or overridden.

currently the alternatives are as follows:

1 - specification of vertical and horizontal
```rust
let status_bar = container(text("status bar area"))
    .padding([0, 3]);
```
* the reader does know the order and has to refer to the API docs, 
* the intention is not clear, is the intention to override the default top/bottom to 0 and set the left/right to 3, or is the intention just to *add* horizontal padding?

2 - use the struct
```rust
let status_bar = container(text("status bar area"))
    .padding(Padding { left: 3, right: 3, ..padding::default() });
```
* way to verbose
* not readable
* used the word 'padding' 3 times on the same line.
* duplicates the `3` value.

there may be more alternatives, but hopefully the above goes some way to understanding why i feel `horizontal` and `vertical` methods are useful.
