### PR TITLE
Replace `format!` with `concat!` for string literals

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -53,9 +53,9 @@ impl Editor {
             },
             Task::batch([
                 Task::perform(
-                    load_file(format!(
-                        "{}/src/main.rs",
-                        env!("CARGO_MANIFEST_DIR")
+                    load_file(concat!(
+                        env!("CARGO_MANIFEST_DIR"),
+                        "/src/main.rs",
                     )),
                     Message::FileOpened,
                 ),

--- a/examples/ferris/src/main.rs
+++ b/examples/ferris/src/main.rs
@@ -95,9 +95,9 @@ impl Image {
         let i_am_ferris = column![
             "Hello!",
             Element::from(
-                image(format!(
-                    "{}/../tour/images/ferris.png",
-                    env!("CARGO_MANIFEST_DIR")
+                image(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../tour/images/ferris.png",
                 ))
                 .width(self.width)
                 .content_fit(self.content_fit)

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -25,9 +25,9 @@ impl Tiger {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let handle = svg::Handle::from_path(format!(
-            "{}/resources/tiger.svg",
-            env!("CARGO_MANIFEST_DIR")
+        let handle = svg::Handle::from_path(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/resources/tiger.svg",
         ));
 
         let svg =

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -559,7 +559,7 @@ fn ferris<'a>(
         if cfg!(target_arch = "wasm32") {
             image("tour/images/ferris.png")
         } else {
-            image(format!("{}/images/ferris.png", env!("CARGO_MANIFEST_DIR")))
+            image(concat!(env!("CARGO_MANIFEST_DIR"), "/images/ferris.png"))
         }
         .filter_method(filter_method)
         .width(width),


### PR DESCRIPTION
- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.