### PR TITLE
Fix error on chromium like browsers when canvas initial size is (0,0)

### DIFF
--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -66,18 +66,9 @@ impl crate::graphics::Compositor for Compositor {
         )
         .expect("Create softbuffer surface for window");
 
-        let clip_mask = {
-            if width > 0 && height > 0 {
-                tiny_skia::Mask::new(width, height)
-            } else {
-                tiny_skia::Mask::new(1, 1)
-            }
-        }
-        .expect("Create clip mask");
-
         let mut surface = Surface {
             window,
-            clip_mask,
+            clip_mask: tiny_skia::Mask::new(1, 1).expect("Create clip mask"),
             layer_stack: VecDeque::new(),
             background_color: Color::BLACK,
             max_age: 0,


### PR DESCRIPTION
On chromium based browsers, there is a chance that the canvas size is (0,0) at the surface creation using the `tiny-skia` backend, which results in a panic.

I fixed by creating a dumb `tiny_skia::Mask::new(1, 1)` until the next `configure_surface`.

