### PR TITLE
Fix WGPU backend when using chromium+linux (webgl only)

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -288,6 +288,10 @@ impl graphics::Compositor for Compositor {
                     settings.present_mode = present_mode;
                 }
 
+                if !wgpu::util::is_browser_webgpu_supported().await {
+                    settings.backends = wgpu::Backends::GL;
+                }
+
                 Ok(new(settings, compatible_window).await?)
             }
             Some(backend) => Err(graphics::Error::GraphicsAdapterNotFound {


### PR DESCRIPTION
When using the WGPU backend on chromium with Linux, the instance tries to get the adapter, which is null (due to the lack of support by the browser).

So, this change forces the WebGL on browser when WebGPU is unsupported.

And the source of this wgpu function give more details about it.
[https://docs.rs/wgpu/latest/wgpu/util/fn.is_browser_webgpu_supported.html](https://docs.rs/wgpu/latest/wgpu/util/fn.is_browser_webgpu_supported.html)