### PR TITLE
Move `status` of button from widget to `State`

### DIFF
--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -81,7 +81,6 @@ where
     padding: Padding,
     clip: bool,
     class: Theme::Class<'a>,
-    status: Option<Status>,
 }
 
 enum OnPress<'a, Message> {
@@ -118,7 +117,6 @@ where
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),
-            status: None,
         }
     }
 
@@ -202,6 +200,7 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct State {
     is_pressed: bool,
+    status: Option<Status>,
 }
 
 impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
@@ -353,9 +352,10 @@ where
             Status::Active
         };
 
+        let state = tree.state.downcast_mut::<State>();
         if let Event::Window(window::Event::RedrawRequested(_now)) = event {
-            self.status = Some(current_status);
-        } else if self.status.is_some_and(|status| status != current_status) {
+            state.status = Some(current_status);
+        } else if state.status.is_some_and(|status| status != current_status) {
             shell.request_redraw();
         }
     }
@@ -372,8 +372,9 @@ where
     ) {
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
+        let state = tree.state.downcast_ref::<State>();
         let style =
-            theme.style(&self.class, self.status.unwrap_or(Status::Disabled));
+            theme.style(&self.class, state.status.unwrap_or(Status::Disabled));
 
         if style.background.is_some()
             || style.border.width > 0.0


### PR DESCRIPTION
When the button is being recreated as part of an overlay like in an [iced_aw::ContextMenu](https://github.com/iced-rs/iced_aw/blob/def1db9aac1e58a47e0c3127d4d4e95d724ca8ad/src/widget/context_menu.rs#L228-L259), but the widget tree state is managed outside, then the button will be rendered with the wrong status (the default is always `None`, so it will fall back to `Status::Disabled` rendering).

By moving the `status` from the widget data to the persistent `State` of the widget tree, the rendering works as expected.

This `Status` was added to the widget data as part of the [Reactive Rendering](https://github.com/iced-rs/iced/pull/2662) rework.
I noticed this with a local (only partially updated) branch of `iced_aw`, which is based on the latest iced master branch.

I am not sure about the internals of iced. Is there a reason this was done outside of the persistent widget tree State?