### PR TITLE
⌘ + Backspace and ⌘ + Delete macOS Shortcuts in `text_input`

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1034,14 +1034,15 @@ where
                                 return;
                             };
 
-                            if modifiers.jump()
-                                && state.cursor.selection(&self.value).is_none()
-                            {
-                                if self.is_secure {
-                                    let cursor_pos =
-                                        state.cursor.end(&self.value);
-                                    state.cursor.select_range(0, cursor_pos);
-                                } else {
+                            if state.cursor.selection(&self.value).is_none() {
+                                if (self.is_secure && modifiers.jump())
+                                    || modifiers.macos_command()
+                                {
+                                    state.cursor.select_range(
+                                        state.cursor.start(&self.value),
+                                        0,
+                                    );
+                                } else if modifiers.jump() {
                                     state
                                         .cursor
                                         .select_left_by_words(&self.value);
@@ -1064,17 +1065,15 @@ where
                                 return;
                             };
 
-                            if modifiers.jump()
-                                && state.cursor.selection(&self.value).is_none()
-                            {
-                                if self.is_secure {
-                                    let cursor_pos =
-                                        state.cursor.end(&self.value);
+                            if state.cursor.selection(&self.value).is_none() {
+                                if (self.is_secure && modifiers.jump())
+                                    || modifiers.macos_command()
+                                {
                                     state.cursor.select_range(
-                                        cursor_pos,
+                                        state.cursor.start(&self.value),
                                         self.value.len(),
                                     );
-                                } else {
+                                } else if modifiers.jump() {
                                     state
                                         .cursor
                                         .select_right_by_words(&self.value);
@@ -1132,54 +1131,21 @@ where
 
                             shell.capture_event();
                         }
-                        keyboard::Key::Named(key::Named::ArrowLeft)
-                            if modifiers.macos_command() =>
-                        {
-                            let cursor_before = state.cursor;
-
-                            if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    0,
-                                );
-                            } else {
-                                state.cursor.move_to(0);
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
-                        keyboard::Key::Named(key::Named::ArrowRight)
-                            if modifiers.macos_command() =>
-                        {
-                            let cursor_before = state.cursor;
-
-                            if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    self.value.len(),
-                                );
-                            } else {
-                                state.cursor.move_to(self.value.len());
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
                         keyboard::Key::Named(key::Named::ArrowLeft) => {
                             let cursor_before = state.cursor;
 
-                            if modifiers.jump() && !self.is_secure {
+                            if (self.is_secure && modifiers.jump())
+                                || modifiers.macos_command()
+                            {
+                                if modifiers.shift() {
+                                    state.cursor.select_range(
+                                        state.cursor.start(&self.value),
+                                        0,
+                                    );
+                                } else {
+                                    state.cursor.move_to(0);
+                                }
+                            } else if modifiers.jump() {
                                 if modifiers.shift() {
                                     state
                                         .cursor
@@ -1206,7 +1172,18 @@ where
                         keyboard::Key::Named(key::Named::ArrowRight) => {
                             let cursor_before = state.cursor;
 
-                            if modifiers.jump() && !self.is_secure {
+                            if (self.is_secure && modifiers.jump())
+                                || modifiers.macos_command()
+                            {
+                                if modifiers.shift() {
+                                    state.cursor.select_range(
+                                        state.cursor.start(&self.value),
+                                        self.value.len(),
+                                    );
+                                } else {
+                                    state.cursor.move_to(self.value.len());
+                                }
+                            } else if modifiers.jump() {
                                 if modifiers.shift() {
                                     state
                                         .cursor


### PR DESCRIPTION
These changes add support to `text_input`s for the macOS shortcuts:
- ⌘ + Backspace: Delete from cursor to start of line
- ⌘ + Delete: Delete from cursor to end of line

Edit to try to be clearer about the secondary change made in the process of adding the shortcuts:

For delete-by-word on a secure `text_input`, where the word boundaries should not be exposed, the deletion was instead being made to the start/end of the `text_input`.  For move/select-by-word on a secure `text_input`, the move/selection was being made by one character.  For consistency, I modified the move/select-by-word behavior for secure `text_input` to match the range of movement in the delete-by-word behavior.  I.e. I changed move/select-by-word behavior for a secure `text_input` to move/select to the start/end of the `text_input`. 