### PR TITLE
Indent and Unindent Text Editor Actions

### DIFF
--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -106,6 +106,10 @@ pub enum Edit {
     Paste(Arc<String>),
     /// Break the current line.
     Enter,
+    /// Indent the current line.
+    Indent,
+    /// Unindent the current line.
+    Unindent,
     /// Delete the previous character.
     Backspace,
     /// Delete the next character.

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -377,6 +377,18 @@ impl editor::Editor for Editor {
                     Edit::Paste(text) => {
                         editor.insert_string(&text, None);
                     }
+                    Edit::Indent => {
+                        editor.action(
+                            font_system.raw(),
+                            cosmic_text::Action::Indent,
+                        );
+                    }
+                    Edit::Unindent => {
+                        editor.action(
+                            font_system.raw(),
+                            cosmic_text::Action::Unindent,
+                        );
+                    }
                     Edit::Enter => {
                         editor.action(
                             font_system.raw(),


### PR DESCRIPTION
Cosmic-Text filters out tab characters when doing edits, advising the use of their indent/unindent actions instead. This provides a way to make use of those actions. 