### PR TITLE
Fix `Element::explain` being hidden by multi-layer widgets

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -498,7 +498,9 @@ where
             .widget
             .draw(state, renderer, theme, style, layout, cursor, viewport);
 
-        explain_layout(renderer, self.color, layout);
+        renderer.with_layer(Rectangle::INFINITE, |renderer| {
+            explain_layout(renderer, self.color, layout);
+        });
     }
 
     fn mouse_interaction(


### PR DESCRIPTION
Small quality-of-life change to give users the option to use either a single color for `explain`, or to have it cycle through colors. Colors change at each level of the hierarchy, so it's easier to see what elements are part of what other elements, and to tell the difference between overlapping elements.
See the `layout` example:

<img width="603" alt="layout example" src="https://github.com/user-attachments/assets/22343a45-6679-4696-8bfd-c4bb454918b0" />

I'm very unsure about what to name things and what to re-export where, but hopefully this is close to useable.

The change is non-breaking, since `explain` now takes `Into<ExplainColor>` which has a blanket `impl From<C: Into<Color>>` (so we can just pass a `Color`, same as before).