### PR TITLE
Use a single SDF for all quad corners

### DIFF
--- a/wgpu/src/shader/quad.wgsl
+++ b/wgpu/src/shader/quad.wgsl
@@ -5,31 +5,9 @@ struct Globals {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 
-fn distance_alg(
-    frag_coord: vec2<f32>,
-    position: vec2<f32>,
-    size: vec2<f32>,
-    radius: f32
-) -> f32 {
-    var inner_half_size: vec2<f32> = (size - vec2<f32>(radius, radius) * 2.0) / 2.0;
-    var top_left: vec2<f32> = position + vec2<f32>(radius, radius);
-    return rounded_box_sdf(frag_coord - top_left - inner_half_size, inner_half_size, 0.0);
-}
-
-// Given a vector from a point to the center of a rounded rectangle of the given `size` and
-// border `radius`, determines the point's distance from the nearest edge of the rounded rectangle
-fn rounded_box_sdf(to_center: vec2<f32>, size: vec2<f32>, radius: f32) -> f32 {
-    return length(max(abs(to_center) - size + vec2<f32>(radius, radius), vec2<f32>(0.0, 0.0))) - radius;
-}
-
-// Based on the fragment position and the center of the quad, select one of the 4 radii.
-// Order matches CSS border radius attribute:
-// radii.x = top-left, radii.y = top-right, radii.z = bottom-right, radii.w = bottom-left
-fn select_border_radius(radii: vec4<f32>, position: vec2<f32>, center: vec2<f32>) -> f32 {
-    var rx = radii.x;
-    var ry = radii.y;
-    rx = select(radii.x, radii.y, position.x > center.x);
-    ry = select(radii.w, radii.z, position.x > center.x);
-    rx = select(rx, ry, position.y > center.y);
-    return rx;
+fn rounded_box_sdf(p: vec2<f32>, size: vec2<f32>, corners: vec4<f32>) -> f32 {
+    var box_half = select(corners.yz, corners.xw, p.x > 0.0);
+    var corner = select(box_half.y, box_half.x, p.y > 0.0);
+    var q = abs(p) - size + corner;
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - corner;
 }


### PR DESCRIPTION
Fixes #2894, extracted from #2957

This PR makes the quad shader just use a single SDF, instead of the weird stuff it was doing before. This also means we only need to run the SDF once when using a border instead of twice.