### PR TITLE
Fix tiny skia primitive rendering

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -36,15 +36,6 @@ impl Engine {
         clip_mask: &mut tiny_skia::Mask,
         clip_bounds: Rectangle,
     ) {
-        debug_assert!(
-            quad.bounds.width.is_normal(),
-            "Quad with non-normal width!"
-        );
-        debug_assert!(
-            quad.bounds.height.is_normal(),
-            "Quad with non-normal height!"
-        );
-
         let physical_bounds = quad.bounds * transformation;
 
         if !clip_bounds.intersects(&physical_bounds) {
@@ -472,7 +463,7 @@ impl Engine {
         transformation: Transformation,
         pixels: &mut tiny_skia::PixmapMut<'_>,
         clip_mask: &mut tiny_skia::Mask,
-        layer_bounds: Rectangle,
+        clip_bounds: Rectangle,
     ) {
         match primitive {
             Primitive::Fill { path, paint, rule } => {
@@ -487,14 +478,12 @@ impl Engine {
                     } * transformation
                 };
 
-                let Some(clip_bounds) =
-                    layer_bounds.intersection(&physical_bounds)
-                else {
+                if !clip_bounds.intersects(&physical_bounds) {
                     return;
-                };
+                }
 
-                let clip_mask =
-                    (physical_bounds != clip_bounds).then_some(clip_mask as &_);
+                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
+                    .then_some(clip_mask as &_);
 
                 pixels.fill_path(
                     path,
@@ -520,14 +509,12 @@ impl Engine {
                     } * transformation
                 };
 
-                let Some(clip_bounds) =
-                    layer_bounds.intersection(&physical_bounds)
-                else {
+                if !clip_bounds.intersects(&physical_bounds) {
                     return;
-                };
+                }
 
-                let clip_mask =
-                    (physical_bounds != clip_bounds).then_some(clip_mask as &_);
+                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
+                    .then_some(clip_mask as &_);
 
                 pixels.stroke_path(
                     path,

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -233,8 +233,8 @@ impl Layer {
                         .filter_map(|bounds| bounds.intersection(group_bounds))
                         .collect()
                 }
-                Item::Cached(_, bounds, _) => {
-                    vec![*bounds]
+                Item::Cached(_, bounds, transformation) => {
+                    vec![*bounds * *transformation]
                 }
             },
             |primitive_a, primitive_b| match (primitive_a, primitive_b) {


### PR DESCRIPTION
Fixes #2934 

The `loading_spinners` example is currently broken on master with tiny skia, not rendering the circular progress bars correctly and crashing after a second with a debug assert `Quad with non-normal width`. 

https://github.com/user-attachments/assets/14934b7e-fc89-4769-846e-c51d0c7125c3

The circular loading spinner is implemented with `Renderer::draw_geometry`, different from the linear spinner using `Renderer::fill_quad`, which is working fine.

Damage calculation does not currently respect the transformation of a cached primitive, leading to all circular spinners having their bounds set to `Rectangle { x: 0.0, y: 0.0, width: 40.0, height: 40.0 }`. 
The same issue applies to calculating the clip bounds, which also doesn't respect the primitive group transformation.

This PR ...
- [x] Applies transformation to clip_bounds and damage bounds for cached primitives
- [x] Renames bounds in tiny skia's draw function to avoid names like `new_clip_bounds`
- [x] Removes the debug assertion which causes issues with zero width quads, crashing the example. Replacing the debug check with `is_finite()` also is not a solution, since that crashes for layout explaining in the tour example.

Result:

https://github.com/user-attachments/assets/b97b546e-5dfa-44c0-af91-f09cd52b1f11


