### PR TITLE
 Fix panic when drawing empty image in `iced_tiny_skia`

### DIFF
--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -348,6 +348,9 @@ pub enum Error {
     /// Loading images is unsupported.
     #[error("loading images is unsupported")]
     Unsupported,
+    /// The image is empty.
+    #[error("the image is empty")]
+    Empty,
     /// Not enough memory to allocate the image.
     #[error("not enough memory to allocate the image")]
     OutOfMemory,

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -106,6 +106,10 @@ impl Cache {
                 }
             };
 
+            if image.width() == 0 || image.height() == 0 {
+                return Err(raster::Error::Empty);
+            }
+
             let mut buffer =
                 vec![0u32; image.width() as usize * image.height() as usize];
 


### PR DESCRIPTION
Always alocate the min size for the tiny_skia buffer

https://github.com/linebender/tiny-skia/blob/main/src/pixmap.rs#L295

Fixes #2877.
