### PR TITLE
re-export runtime widget task

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,7 @@ pub mod debug {
 
 pub mod task {
     //! Create runtime tasks.
-    pub use crate::runtime::task::{Handle, Task};
+    pub use crate::runtime::task::{Handle, Task, widget};
 
     #[cfg(feature = "sipper")]
     pub use crate::runtime::task::{Never, Sipper, Straw, sipper, stream};


### PR DESCRIPTION
hi, just a tiny change to re-export runtime widget task for conveniece