### PR TITLE
Fix navigation keys on higher layers not working

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1173,9 +1173,6 @@ impl<Message> Binding<Message> {
             return None;
         }
 
-        #[cfg(target_os = "macos")]
-        let key = convert_macos_shortcut(&key, modifiers);
-
         let combination = match key.as_ref() {
             keyboard::Key::Character("c") if modifiers.command() => {
                 Some(Self::Copy)
@@ -1197,6 +1194,10 @@ impl<Message> Binding<Message> {
         if let Some(binding) = combination {
             return Some(binding);
         }
+
+        #[cfg(target_os = "macos")]
+        let modified_key =
+            convert_macos_shortcut(&key, modifiers).unwrap_or(modified_key);
 
         match modified_key.as_ref() {
             keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
@@ -1497,28 +1498,20 @@ pub fn default(theme: &Theme, status: Status) -> Style {
 pub(crate) fn convert_macos_shortcut(
     key: &keyboard::Key,
     modifiers: keyboard::Modifiers,
-) -> &keyboard::Key {
+) -> Option<keyboard::Key> {
     if modifiers != keyboard::Modifiers::CTRL {
-        return key;
+        return None;
     }
 
-    match key.as_ref() {
-        keyboard::Key::Character("b") => {
-            &keyboard::Key::Named(key::Named::ArrowLeft)
-        }
-        keyboard::Key::Character("f") => {
-            &keyboard::Key::Named(key::Named::ArrowRight)
-        }
-        keyboard::Key::Character("a") => {
-            &keyboard::Key::Named(key::Named::Home)
-        }
-        keyboard::Key::Character("e") => &keyboard::Key::Named(key::Named::End),
-        keyboard::Key::Character("h") => {
-            &keyboard::Key::Named(key::Named::Backspace)
-        }
-        keyboard::Key::Character("d") => {
-            &keyboard::Key::Named(key::Named::Delete)
-        }
-        _ => key,
-    }
+    let key = match key.as_ref() {
+        keyboard::Key::Character("b") => key::Named::ArrowLeft,
+        keyboard::Key::Character("f") => key::Named::ArrowRight,
+        keyboard::Key::Character("a") => key::Named::Home,
+        keyboard::Key::Character("e") => key::Named::End,
+        keyboard::Key::Character("h") => key::Named::Backspace,
+        keyboard::Key::Character("d") => key::Named::Delete,
+        _ => return None,
+    };
+
+    Some(keyboard::Key::Named(key))
 }

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1142,8 +1142,14 @@ pub enum Binding<Message> {
 /// A key press.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyPress {
-    /// The key pressed.
+    /// The original key pressed without modifiers applied to it.
+    ///
+    /// You should use this key for combinations (e.g. Ctrl+C).
     pub key: keyboard::Key,
+    /// The key pressed with modifiers applied to it.
+    ///
+    /// You should use this key for any single key bindings (e.g. motions).
+    pub modified_key: keyboard::Key,
     /// The state of the keyboard modifiers.
     pub modifiers: keyboard::Modifiers,
     /// The text produced by the key press.
@@ -1157,6 +1163,7 @@ impl<Message> Binding<Message> {
     pub fn from_key_press(event: KeyPress) -> Option<Self> {
         let KeyPress {
             key,
+            modified_key,
             modifiers,
             text,
             status,
@@ -1169,17 +1176,7 @@ impl<Message> Binding<Message> {
         #[cfg(target_os = "macos")]
         let key = convert_macos_shortcut(&key, modifiers);
 
-        match key.as_ref() {
-            keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
-            keyboard::Key::Named(key::Named::Backspace) => {
-                Some(Self::Backspace)
-            }
-            keyboard::Key::Named(key::Named::Delete)
-                if text.is_none() || text.as_deref() == Some("\u{7f}") =>
-            {
-                Some(Self::Delete)
-            }
-            keyboard::Key::Named(key::Named::Escape) => Some(Self::Unfocus),
+        let combination = match key.as_ref() {
             keyboard::Key::Character("c") if modifiers.command() => {
                 Some(Self::Copy)
             }
@@ -1194,6 +1191,24 @@ impl<Message> Binding<Message> {
             keyboard::Key::Character("a") if modifiers.command() => {
                 Some(Self::SelectAll)
             }
+            _ => None,
+        };
+
+        if let Some(binding) = combination {
+            return Some(binding);
+        }
+
+        match modified_key.as_ref() {
+            keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
+            keyboard::Key::Named(key::Named::Backspace) => {
+                Some(Self::Backspace)
+            }
+            keyboard::Key::Named(key::Named::Delete)
+                if text.is_none() || text.as_deref() == Some("\u{7f}") =>
+            {
+                Some(Self::Delete)
+            }
+            keyboard::Key::Named(key::Named::Escape) => Some(Self::Unfocus),
             _ => {
                 if let Some(text) = text {
                     let c = text.chars().find(|c| !c.is_control())?;
@@ -1332,6 +1347,7 @@ impl<Message> Update<Message> {
             },
             Event::Keyboard(keyboard::Event::KeyPressed {
                 key,
+                modified_key,
                 modifiers,
                 text,
                 ..
@@ -1346,6 +1362,7 @@ impl<Message> Update<Message> {
 
                 let key_press = KeyPress {
                     key: key.clone(),
+                    modified_key: modified_key.clone(),
                     modifiers: *modifiers,
                     text: text.clone(),
                     status,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1039,9 +1039,14 @@ where
                     }
 
                     #[cfg(target_os = "macos")]
-                    let key = crate::text_editor::convert_macos_shortcut(
-                        key, modifiers,
-                    );
+                    let macos_shortcut =
+                        crate::text_editor::convert_macos_shortcut(
+                            key, modifiers,
+                        );
+
+                    #[cfg(target_os = "macos")]
+                    let modified_key =
+                        macos_shortcut.as_ref().unwrap_or(modified_key);
 
                     match modified_key.as_ref() {
                         keyboard::Key::Named(key::Named::Enter) => {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -899,7 +899,10 @@ where
                 }
             }
             Event::Keyboard(keyboard::Event::KeyPressed {
-                key, text, ..
+                key,
+                text,
+                modified_key,
+                ..
             }) => {
                 let state = state::<Renderer>(tree);
 
@@ -1040,7 +1043,7 @@ where
                         key, modifiers,
                     );
 
-                    match key.as_ref() {
+                    match modified_key.as_ref() {
                         keyboard::Key::Named(key::Named::Enter) => {
                             if let Some(on_submit) = self.on_submit.clone() {
                                 shell.publish(on_submit);


### PR DESCRIPTION
Some keyboard layouts have navigation keys in "unusual" positions on higher levels (e.g., Neo family layouts). These did not work at all, but this fixes them by not using `key_without_modifiers()` for `Named(…)` logical keys.

I also thought of implementing this by checking if `key_without_modifiers()` changes the `std::mem::discriminant` of the key (which would also be unexpected) and then you could return the logical key instead, but then you'd probably have to handle dead keys seperately, so I think doing this only for `Named` keys should be easier.

Fixes #2997.