### PR TITLE
Fix the svg `Status` not being updated on cursor movement

### DIFF
--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -20,9 +20,10 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::svg;
 use crate::core::widget::Tree;
+use crate::core::window;
 use crate::core::{
-    Color, ContentFit, Element, Layout, Length, Point, Rectangle, Rotation,
-    Size, Theme, Vector, Widget,
+    Clipboard, Color, ContentFit, Element, Event, Layout, Length, Point,
+    Rectangle, Rotation, Shell, Size, Theme, Vector, Widget,
 };
 
 use std::path::PathBuf;
@@ -62,6 +63,7 @@ where
     class: Theme::Class<'a>,
     rotation: Rotation,
     opacity: f32,
+    status: Option<Status>,
 }
 
 impl<'a, Theme> Svg<'a, Theme>
@@ -78,6 +80,7 @@ where
             class: Theme::default(),
             rotation: Rotation::default(),
             opacity: 1.0,
+            status: None,
         }
     }
 
@@ -194,6 +197,30 @@ where
         layout::Node::new(final_size)
     }
 
+    fn update(
+        &mut self,
+        _state: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _renderer: &Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
+    ) {
+        let current_status = if cursor.is_over(layout.bounds()) {
+            Status::Hovered
+        } else {
+            Status::Idle
+        };
+
+        if let Event::Window(window::Event::RedrawRequested(_now)) = event {
+            self.status = Some(current_status);
+        } else if self.status.is_some_and(|status| status != current_status) {
+            shell.request_redraw();
+        }
+    }
+
     fn draw(
         &self,
         _state: &Tree,
@@ -201,7 +228,7 @@ where
         theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
-        cursor: mouse::Cursor,
+        _cursor: mouse::Cursor,
         _viewport: &Rectangle,
     ) {
         let Size { width, height } = renderer.measure_svg(&self.handle);
@@ -230,15 +257,8 @@ where
 
         let drawing_bounds = Rectangle::new(position, final_size);
 
-        let is_mouse_over = cursor.is_over(bounds);
-
-        let status = if is_mouse_over {
-            Status::Hovered
-        } else {
-            Status::Idle
-        };
-
-        let style = theme.style(&self.class, status);
+        let style =
+            theme.style(&self.class, self.status.unwrap_or(Status::Idle));
 
         renderer.draw_svg(
             svg::Svg {


### PR DESCRIPTION
Currently, the `Status` passed to `theme.style` is set in `draw`. This means that a redraw needs to be triggered for it to change, so I moved it into `update` with the same reactive rendering logic as `Button` and some other widgets.