### PR TITLE
Add option to reuse wgpu Renderer screenshot buffers to improve performance

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -223,6 +223,9 @@ impl Renderer {
 
     /// Create wgpu buffers required for use with `screenshot_into`.
     ///
+    /// To reuse this buffer, the `CLEAR_TEXTURE` wgpu feature must be enabled
+    /// in `DeviceDescriptor::required_features` when creating the device.
+    ///
     /// Reusing the wgpu buffers improves performance when calling `screenshot` several times.
     ///
     /// The passed `name` must be a unique identifier used as part of the wgpu buffer labels
@@ -310,7 +313,7 @@ impl Renderer {
             &mut encoder,
             &texture,
             SCREENSHOT_FORMAT,
-            &screenshot_buffers.convert_buffers,
+            &mut screenshot_buffers.convert_buffers,
         );
 
         encoder.copy_texture_to_buffer(


### PR DESCRIPTION
When taking several screenshots with the `iced_wgpu::Renderer`, the wgpu-buffers aren't reused currently. Buffer creation takes ~40% of the time of the whole screenshot. This PR adds the option to reuse the screenshot-buffers, including reusing buffers for color conversion.

Performance measurements on my machine:
* current `convert`: 1.3ms
* new `convert_buffered` when reusing buffers: 0.1ms
* current `screenshot`: 14ms
* new `screenshot_into` when reusing buffers including using `convert_buffered`: 8ms