### PR TITLE
Reconfigure wgpu surface on SurfaceError Lost or Outdated

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1021,11 +1021,20 @@ async fn run_instance<P>(
                                     let physical_size =
                                         window.state.physical_size();
 
-                                    current_compositor.configure_surface(
-                                        &mut window.surface,
-                                        physical_size.width,
-                                        physical_size.height,
-                                    );
+                                    if error == compositor::SurfaceError::Lost {
+                                        window.surface = current_compositor
+                                            .create_surface(
+                                                window.raw.clone(),
+                                                physical_size.width,
+                                                physical_size.height,
+                                            );
+                                    } else {
+                                        current_compositor.configure_surface(
+                                            &mut window.surface,
+                                            physical_size.width,
+                                            physical_size.height,
+                                        );
+                                    }
 
                                     window.raw.request_redraw();
                                 }


### PR DESCRIPTION
While developing an app with `iced` with a local dev environment using `Niri`, I noticed that until I resized the rendered iced app that nothing in iced apps was interactable. This applied to my app but also was replicated in the demos `tour` and `bezier_tool` (and likely all others).

I tracked down the issue to us not handling `wgpu` surface errors `wgpu::SurfaceError::Outdated` and `wgpu::SurfaceError::Lost`.

See the following Niri issue for some reports: https://github.com/YaLTeR/niri/issues/1910

This change reconfigures the wgpu surface when this error is received. I wasn't sure what level to do this change, in wgpu's compositor.rs, or in winit/src/lib.rs `run_instance`. I guess that depends on whether this behavior should be applied to backends other than wgpu. Please advise.