### PR TITLE
makes `modified_key` the default for `key` of `keyboard::Event`

### DIFF
--- a/core/src/keyboard/event.rs
+++ b/core/src/keyboard/event.rs
@@ -12,11 +12,14 @@ use crate::keyboard::{Key, Location, Modifiers};
 pub enum Event {
     /// A keyboard key was pressed.
     KeyPressed {
-        /// The key pressed.
+        /// The key pressed. Tries to meet expectations, currently equal to `modified_key`.
         key: Key,
 
         /// The key pressed with all keyboard modifiers applied, except Ctrl.
         modified_key: Key,
+
+        /// The key on keyboard layer 0 pressed.
+        baselayer_key: Key,
 
         /// The physical key pressed.
         physical_key: key::Physical,
@@ -33,11 +36,14 @@ pub enum Event {
 
     /// A keyboard key was released.
     KeyReleased {
-        /// The key released.
+        /// The key released. Tries to meet expectations, currently equal to `modified_key`.
         key: Key,
 
         /// The key released with all keyboard modifiers applied, except Ctrl.
         modified_key: Key,
+
+        /// The key on keyboard layer 0 released.
+        baselayer_key: Key,
 
         /// The physical key released.
         physical_key: key::Physical,

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -375,7 +375,8 @@ pub fn press_key(
 
     Event::Keyboard(keyboard::Event::KeyPressed {
         key: key.clone(),
-        modified_key: key,
+        modified_key: key.clone(),
+        baselayer_key: key,
         physical_key: keyboard::key::Physical::Unidentified(
             keyboard::key::NativeCode::Unidentified,
         ),
@@ -391,7 +392,8 @@ pub fn release_key(key: impl Into<keyboard::Key>) -> Event {
 
     Event::Keyboard(keyboard::Event::KeyReleased {
         key: key.clone(),
-        modified_key: key,
+        modified_key: key.clone(),
+        baselayer_key: key,
         physical_key: keyboard::key::Physical::Unidentified(
             keyboard::key::NativeCode::Unidentified,
         ),

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -204,7 +204,7 @@ pub fn window_event(
         // Ignore keyboard presses/releases during window focus/unfocus
         WindowEvent::KeyboardInput { is_synthetic, .. } if is_synthetic => None,
         WindowEvent::KeyboardInput { event, .. } => Some(Event::Keyboard({
-            let key = {
+            let baselayer_key = {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
@@ -242,8 +242,9 @@ pub fn window_event(
                 ..
             } = event;
 
-            let key = self::key(key);
             let modified_key = self::key(logical_key);
+            let key = modified_key.clone();
+            let baselayer_key = self::key(baselayer_key);
             let physical_key = self::physical_key(physical_key);
             let modifiers = self::modifiers(modifiers);
 
@@ -265,6 +266,7 @@ pub fn window_event(
                     keyboard::Event::KeyPressed {
                         key,
                         modified_key,
+                        baselayer_key,
                         physical_key,
                         modifiers,
                         location,
@@ -275,6 +277,7 @@ pub fn window_event(
                     keyboard::Event::KeyReleased {
                         key,
                         modified_key,
+                        baselayer_key,
                         physical_key,
                         modifiers,
                         location,


### PR DESCRIPTION
Proposal for https://github.com/iced-rs/iced/issues/2997
it fixes https://github.com/iced-rs/iced/issues/2997
replacement of https://github.com/iced-rs/iced/pull/2998

Replacement needed because: me == bad at git.

Modified key as a better default. Added `baselaye_key` for those who want especially that.