### PR TITLE
examples/counter: add title to run()

### DIFF
--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -2,7 +2,7 @@ use iced::Center;
 use iced::widget::{Column, button, column, text};
 
 pub fn main() -> iced::Result {
-    iced::run(Counter::update, Counter::view)
+    iced::run("Counter App", Counter::update, Counter::view)
 }
 
 #[derive(Default)]


### PR DESCRIPTION
The example was not compiling with iced `0.13.1`.