### PR TITLE
Add `command` instruction to `tester`

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -367,6 +367,24 @@ impl<P: Program> Application<P> {
         }
     }
 
+    /// Sets the command logic of the [`Application`].
+    pub fn command(
+        self,
+        _f: impl Fn(&P::State, &str) -> Option<P::Message>,
+    ) -> Application<
+        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
+    > {
+        Application {
+            #[cfg(feature = "tester")]
+            raw: program::with_command(self.raw, _f),
+            #[cfg(not(feature = "tester"))]
+            raw: self.raw,
+            settings: self.settings,
+            window: self.window,
+            presets: self.presets,
+        }
+    }
+
     /// Sets the theme logic of the [`Application`].
     pub fn theme(
         self,
@@ -494,6 +512,14 @@ impl<P: Program> Program for Application<P> {
 
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
         debug::hot(|| self.raw.subscription(state))
+    }
+
+    fn command(
+        &self,
+        state: &Self::State,
+        command: &str,
+    ) -> Option<Self::Message> {
+        debug::hot(|| self.raw.command(state, command))
     }
 
     fn theme(

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -338,6 +338,17 @@ impl<P: Program + 'static> Emulator<P> {
                 self.resubscribe(program);
                 self.wait_for(task);
             }
+            Instruction::Command(command) => {
+                self.cache = Some(user_interface.into_cache());
+
+                if let Some(message) = program.command(&self.state, command) {
+                    let task = program.update(&mut self.state, message);
+                    self.resubscribe(program);
+                    self.wait_for(task);
+                } else {
+                    self.runtime.send(Event::Ready);
+                }
+            }
             Instruction::Expect(expectation) => match expectation {
                 instruction::Expectation::Text(text) => {
                     use widget::Operation;

--- a/test/src/instruction.rs
+++ b/test/src/instruction.rs
@@ -13,6 +13,8 @@ use std::fmt;
 pub enum Instruction {
     /// A user [`Interaction`].
     Interact(Interaction),
+    /// A testing command
+    Command(String),
     /// A testing [`Expectation`].
     Expect(Expectation),
 }
@@ -28,6 +30,7 @@ impl fmt::Display for Instruction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Instruction::Interact(interaction) => interaction.fmt(f),
+            Instruction::Command(command) => write!(f, "command {command}"),
             Instruction::Expect(expectation) => expectation.fmt(f),
         }
     }
@@ -534,6 +537,7 @@ mod parser {
     fn instruction(input: &str) -> IResult<&str, Instruction> {
         alt((
             map(interaction, Instruction::Interact),
+            map(command, Instruction::Command),
             map(expectation, Instruction::Expect),
         ))
         .parse(input)
@@ -545,6 +549,11 @@ mod parser {
             map(keyboard, Interaction::Keyboard),
         ))
         .parse(input)
+    }
+
+    fn command(input: &str) -> IResult<&str, String> {
+        let (rest, _) = tag("command ").parse_complete(input)?;
+        Ok(("", rest.to_string()))
     }
 
     fn mouse(input: &str) -> IResult<&str, Mouse> {


### PR DESCRIPTION
This adds a `command` instruction to turn arbitrary text into a `Message` executed by the `Emulator`. The motivating usage is mocking user interactions outside of `iced`, e.g., system file dialogs.

Some open design questions:
- Should declaring commands use existing `Subscription` infrastructure, including `map`ping `Message`s?
- Should there be a strict/typed parsing format for arguments instead of passing a single `&str`?
- Should one `command` be able to send a sequence of `Message`s?