### PR TITLE
make `overlay::from_children` and `layout::flex::resolve` generic over the widget type

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -9,7 +9,7 @@ use crate::{
     Vector, Widget,
 };
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 
 /// A generic [`Widget`].
 ///
@@ -235,6 +235,17 @@ impl<'a, Message, Theme, Renderer>
 {
     fn borrow(&self) -> &(dyn Widget<Message, Theme, Renderer> + 'a) {
         self.widget.borrow()
+    }
+}
+
+impl<'a, Message, Theme, Renderer>
+    BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
+    for Element<'a, Message, Theme, Renderer>
+{
+    fn borrow_mut(
+        &mut self,
+    ) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
+        self.widget.borrow_mut()
     }
 }
 


### PR DESCRIPTION
A bunch of other widget functions are already generic over `impl Borrow<dyn Widget>`, these were missing presumably because they need mutable access to the widget. This is useful when working with concrete widget types instead of type-erased `Element`s.