### PR TITLE
Update `cosmic-text` to `0.15`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,22 +997,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.14.2"
+name = "core_maths"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
 dependencies = [
  "bitflags 2.10.0",
- "fontdb 0.16.2",
+ "fontdb 0.23.0",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa",
  "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1115,7 +1125,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=1d68a5405986287475fd49a7793c2edd0ea41d0b#1d68a5405986287475fd49a7793c2edd0ea41d0b"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=99b46959369f38a06c11353bf1be81d383b289fc#99b46959369f38a06c11353bf1be81d383b289fc"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -1611,20 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
-dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser 0.20.0",
-]
-
-[[package]]
-name = "fontdb"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
@@ -1635,6 +1631,20 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser 0.21.1",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -2127,6 +2137,19 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -3072,6 +3095,12 @@ checksum = "f67562e5eff6b20553fa9be1c503356768420994e28f67e3eafe6f41910e57ad"
 dependencies = [
  "web-time",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linked-hash-map"
@@ -4804,6 +4833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
+ "core_maths",
  "font-types",
 ]
 
@@ -5116,7 +5146,6 @@ checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
- "libm",
  "smallvec",
  "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
@@ -6308,12 +6337,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
@@ -6323,6 +6346,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,8 +184,8 @@ bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
 cargo-hot = { package = "cargo-hot-protocol", git = "https://github.com/hecrj/cargo-hot.git", rev = "b8dc518b8640928178a501257e353b73bc06cf47" }
-cosmic-text = "0.14"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "1d68a5405986287475fd49a7793c2edd0ea41d0b" }
+cosmic-text = "0.15"
+cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "99b46959369f38a06c11353bf1be81d383b289fc" }
 futures = { version = "0.3", default-features = false }
 glam = "0.25"
 guillotiere = "0.6"

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -56,6 +56,7 @@ impl Cache {
                 key.content,
                 &text::to_attributes(key.font),
                 text::to_shaping(key.shaping, key.content),
+                None,
             );
 
             let bounds = text::align(&mut buffer, font_system, key.align_x);

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -75,6 +75,7 @@ impl editor::Editor for Editor {
             text,
             &cosmic_text::Attrs::new(),
             cosmic_text::Shaping::Advanced,
+            None,
         );
 
         Editor(Some(Arc::new(Internal {
@@ -449,7 +450,10 @@ impl editor::Editor for Editor {
             Action::Scroll { lines } => {
                 editor.action(
                     font_system.raw(),
-                    cosmic_text::Action::Scroll { lines },
+                    cosmic_text::Action::Scroll {
+                        pixels: lines as f32
+                            * self.buffer().metrics().line_height,
+                    },
                 );
             }
         }

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -89,6 +89,7 @@ impl core::text::Paragraph for Paragraph {
             text.content,
             &text::to_attributes(text.font),
             text::to_shaping(text.shaping, text.content),
+            None,
         );
 
         let min_bounds =


### PR DESCRIPTION
A new version of `cosmic-text` was released yesterday, and `Shaping::Advanced` is now 2-3x faster :tada: 

<img width="1032" height="780" alt="image" src="https://github.com/user-attachments/assets/da9d4b7a-e06c-44f4-99f6-d4f4398e3dfb" />

<img width="1914" height="710" alt="image" src="https://github.com/user-attachments/assets/0dbc9302-113b-4817-954e-d8a3453b00ff" />

Other benchmarks seem mostly unaffected!