### PR TITLE
Correct padding vector in TextEditor to use (left, top) instead of (top, left)

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1235,7 +1235,7 @@ impl<Message> Update<Message> {
                 mouse::Event::ButtonPressed(mouse::Button::Left) => {
                     if let Some(cursor_position) = cursor.position_in(bounds) {
                         let cursor_position = cursor_position
-                            - Vector::new(padding.top, padding.left);
+                            - Vector::new(padding.left, padding.top);
 
                         let click = mouse::Click::new(
                             cursor_position,
@@ -1256,7 +1256,7 @@ impl<Message> Update<Message> {
                 mouse::Event::CursorMoved { .. } => match state.drag_click {
                     Some(mouse::click::Kind::Single) => {
                         let cursor_position = cursor.position_in(bounds)?
-                            - Vector::new(padding.top, padding.left);
+                            - Vector::new(padding.left, padding.top);
 
                         Some(Update::Drag(cursor_position))
                     }


### PR DESCRIPTION
Fix swapped padding components in `TextEditor` mouse handling.

**Before**

```rust
let cursor_position = cursor_position
    - Vector::new(padding.top, padding.left);
```

**After**

```rust
let cursor_position = cursor_position
    - Vector::new(padding.left, padding.top);
```

**How to reproduce**

Use a `TextEditor` with different horizontal and vertical padding, for example:

```rust
text_editor(&self.content).padding([0, 40])
```

Type multiple lines, then click or drag selection anywhere in the text. With the old code the caret and selection appear offset relative to the mouse position. With the fix they line up with the rendered text.

**Example**

![offset-padding](https://github.com/user-attachments/assets/ea3948ea-bf36-4740-8e99-7df2609f2b64)
