### PR TITLE
add efficient `is_empty` method to `text_editor::Content`

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -475,13 +475,7 @@ where
 
     /// Returns whether or not the the [`Content`] is empty.
     pub fn is_empty(&self) -> bool {
-        let editor = &self.0.borrow().editor;
-
-        match editor.line_count() {
-            0 => true,
-            1 => editor.line(0).map(|l| l.text.is_empty()).unwrap_or(true),
-            _ => false,
-        }
+        self.0.borrow().editor.is_empty()
     }
 }
 


### PR DESCRIPTION
Closes #3105 

~The `unwrap_or` could alternatively be a plain `unwrap` on `editor.line(0)` because we already matched for `line_count` == 1.~ just defer to the inner `is_empty` method...