### PR TITLE
add efficient `Edit::ReplaceAll` variant for `TextEditor`

### DIFF
--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -114,6 +114,8 @@ pub enum Edit {
     Backspace,
     /// Delete the next character.
     Delete,
+    /// Replace all the text in the editor.
+    ReplaceAll(Arc<String>),
 }
 
 /// A cursor movement.

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -409,6 +409,20 @@ impl editor::Editor for Editor {
                             cosmic_text::Action::Delete,
                         );
                     }
+                    Edit::ReplaceAll(text) => {
+                        let buffer = buffer_mut_from_editor(editor);
+
+                        buffer.set_rich_text(
+                            font_system.raw(),
+                            std::iter::once((
+                                &**text,
+                                cosmic_text::Attrs::new(),
+                            )),
+                            &cosmic_text::Attrs::new(),
+                            cosmic_text::Shaping::Advanced,
+                            None,
+                        );
+                    }
                 }
 
                 let cursor = editor.cursor();


### PR DESCRIPTION
Closes [discord discussion](https://discord.com/channels/628993209984614400/1021827652321038529/threads/1436312651176345630).

There's some debate as to the most optimal type for the contents of the `Arc`. I think the result of that decision may well apply to `Edit::Paste<Arc<String>>`, too, but I don't want to get too bogged down in this specific PR myself.
