### PR TITLE
Prevent crashes from `svg` rendering

### DIFF
--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -7,7 +7,8 @@ use tiny_skia::Transform;
 
 use std::cell::RefCell;
 use std::collections::hash_map;
-use std::{fs, panic};
+use std::fs;
+use std::panic;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -170,17 +171,12 @@ impl Cache {
 
             // SVG rendering can panic on malformed or complex vectors.
             // We catch panics to prevent crashes and continue gracefully.
-            let render_result =
-                panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    resvg::render(tree, transform, &mut image.as_mut());
-                }));
+            let render = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                resvg::render(tree, transform, &mut image.as_mut());
+            }));
 
-            if render_result.is_err() {
-                log::warn!(
-                    "SVG rendering panicked for handle ID: {}",
-                    handle.id()
-                );
-                return None;
+            if let Err(error) = render {
+                log::warn!("SVG rendering for {handle:?} panicked: {error:?}");
             }
 
             if let Some([r, g, b, _]) = key.color {

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -5,7 +5,8 @@ use crate::image::atlas::{self, Atlas};
 use resvg::tiny_skia;
 use resvg::usvg;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::{fs, panic};
+use std::fs;
+use std::panic;
 use std::sync::Arc;
 
 /// Entry in cache corresponding to an svg handle
@@ -156,17 +157,15 @@ impl Cache {
 
                 // SVG rendering can panic on malformed or complex vectors.
                 // We catch panics to prevent crashes and continue gracefully.
-                let render_result =
+                let render =
                     panic::catch_unwind(panic::AssertUnwindSafe(|| {
                         resvg::render(tree, transform, &mut img.as_mut());
                     }));
 
-                if render_result.is_err() {
+                if let Err(error) = render {
                     log::warn!(
-                        "SVG rendering panicked for handle ID: {}",
-                        handle.id()
+                        "SVG rendering for {handle:?} panicked: {error:?}"
                     );
-                    return None;
                 }
 
                 let mut rgba = img.take();


### PR DESCRIPTION
When rendering certain SVGs, resvg::render can panic because resvg uses several assert! calls internally. This caused application crashes in Cosmic Desktop: https://github.com/pop-os/cosmic-epoch/issues/2452

This patch wraps the render call in std::panic::catch_unwind. If resvg panics, the panic is caught and None is returned instead of crashing the app.

Example problematic SVG:
```
<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">                                                    
  <defs>                                                                                                             
    <filter id="specular" width="50" height="50">                                              
      <feSpecularLighting result="specular" lighting-color="white"                                                   
                          x="10" y="10" width="5" height="5">                                                        
        <fePointLight x="50" y="50" z="200"/>                                                                        
      </feSpecularLighting>                                                                                          
    </filter>                                                                                                        
  </defs>                                                                                                            
  <rect width="100" height="100" fill="blue" filter="url(#specular)"/>                                               
</svg>
```
