### PR TITLE
Add `CornerPreference` window setting for Windows

### DIFF
--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -1,7 +1,7 @@
 //! Configure your windows.
 #[cfg(target_os = "windows")]
 #[path = "settings/windows.rs"]
-mod platform;
+pub mod platform;
 
 #[cfg(target_os = "macos")]
 #[path = "settings/macos.rs"]

--- a/core/src/window/settings/windows.rs
+++ b/core/src/window/settings/windows.rs
@@ -14,6 +14,11 @@ pub struct PlatformSpecific {
     /// The shadow is hidden by default.
     /// Enabling the shadow causes a thin 1px line to appear on the top of the window.
     pub undecorated_shadow: bool,
+
+    /// Sets the preferred style of the window corners.
+    ///
+    /// Supported starting with Windows 11 Build 22000.
+    pub corner_preference: CornerPreference,
 }
 
 impl Default for PlatformSpecific {
@@ -22,6 +27,33 @@ impl Default for PlatformSpecific {
             drag_and_drop: true,
             skip_taskbar: false,
             undecorated_shadow: false,
+            corner_preference: Default::default(),
         }
     }
+}
+
+/// Describes how the corners of a window should look like.
+#[repr(i32)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CornerPreference {
+    /// Corresponds to `DWMWCP_DEFAULT`.
+    ///
+    /// Let the system decide when to round window corners.
+    #[default]
+    Default = 0,
+
+    /// Corresponds to `DWMWCP_DONOTROUND`.
+    ///
+    /// Never round window corners.
+    DoNotRound = 1,
+
+    /// Corresponds to `DWMWCP_ROUND`.
+    ///
+    /// Round the corners, if appropriate.
+    Round = 2,
+
+    /// Corresponds to `DWMWCP_ROUNDSMALL`.
+    ///
+    /// Round the corners if appropriate, with a small radius.
+    RoundSmall = 3,
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -91,7 +91,10 @@ pub fn window_attributes(
 
     #[cfg(target_os = "windows")]
     {
-        use winit::platform::windows::WindowAttributesExtWindows;
+        use window::settings::platform;
+        use winit::platform::windows::{
+            CornerPreference, WindowAttributesExtWindows,
+        };
 
         attributes = attributes
             .with_drag_and_drop(settings.platform_specific.drag_and_drop);
@@ -101,6 +104,21 @@ pub fn window_attributes(
 
         attributes = attributes.with_undecorated_shadow(
             settings.platform_specific.undecorated_shadow,
+        );
+
+        attributes = attributes.with_corner_preference(
+            match settings.platform_specific.corner_preference {
+                platform::CornerPreference::Default => {
+                    CornerPreference::Default
+                }
+                platform::CornerPreference::DoNotRound => {
+                    CornerPreference::DoNotRound
+                }
+                platform::CornerPreference::Round => CornerPreference::Round,
+                platform::CornerPreference::RoundSmall => {
+                    CornerPreference::RoundSmall
+                }
+            },
         );
     }
 


### PR DESCRIPTION
I'm not a great fan of how windows 11 makes the corners comically round, so I've added the ability to customise this under the platform specific options for windows.

The `CornerPreference` enum was pretty much yoinked from winit.