### PR TITLE
Fix missing `fn operate` in `tooltip` widget

### DIFF
--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -364,6 +364,24 @@ where
             None
         }
     }
+
+    fn operate(
+        &mut self,
+        tree: &mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation,
+    ) {
+        operation.container(None, layout.bounds());
+        operation.traverse(&mut |operation| {
+            self.content.as_widget_mut().operate(
+                &mut tree.children[0],
+                layout,
+                renderer,
+                operation,
+            );
+        });
+    }
 }
 
 impl<'a, Message, Theme, Renderer> From<Tooltip<'a, Message, Theme, Renderer>>


### PR DESCRIPTION
Fixes #3110.