### PR TITLE
Fix copy/paste shortcuts for non latin keyboard layouts

### DIFF
--- a/core/src/keyboard/key.rs
+++ b/core/src/keyboard/key.rs
@@ -30,6 +30,91 @@ impl Key {
             Self::Unidentified => Key::Unidentified,
         }
     }
+
+    /// Tries to convert this logical [`Key`] into its latin character, using the
+    /// [`Physical`] key provided for translation if it isn't already in latin.
+    ///
+    /// Returns `None` if no latin variant could be found.
+    ///
+    /// ```
+    /// use iced_core::keyboard::key::{Key, Named, Physical, Code};
+    ///
+    /// // Latin c
+    /// assert_eq!(
+    ///     Key::Character("c".into()).to_latin(Physical::Code(Code::KeyC)),
+    ///     Some('c'),
+    /// );
+    ///
+    /// // Cyrillic с
+    /// assert_eq!(
+    ///     Key::Character("с".into()).to_latin(Physical::Code(Code::KeyC)),
+    ///     Some('c'),
+    /// );
+    ///
+    /// // Arrow Left
+    /// assert_eq!(
+    ///     Key::Named(Named::ArrowLeft).to_latin(Physical::Code(Code::ArrowLeft)),
+    ///     None,
+    /// );
+    /// ```
+    pub fn to_latin(&self, physical_key: Physical) -> Option<char> {
+        let Self::Character(s) = self else {
+            return None;
+        };
+
+        let mut chars = s.chars();
+        let c = chars.next()?;
+
+        if chars.next().is_none() && c <= '\u{ff}' {
+            return Some(c);
+        }
+
+        let Physical::Code(code) = physical_key else {
+            return None;
+        };
+
+        let latin = match code {
+            Code::KeyA => 'a',
+            Code::KeyB => 'b',
+            Code::KeyC => 'c',
+            Code::KeyD => 'd',
+            Code::KeyE => 'e',
+            Code::KeyF => 'f',
+            Code::KeyG => 'g',
+            Code::KeyH => 'h',
+            Code::KeyI => 'i',
+            Code::KeyJ => 'j',
+            Code::KeyK => 'k',
+            Code::KeyL => 'l',
+            Code::KeyM => 'm',
+            Code::KeyN => 'n',
+            Code::KeyO => 'o',
+            Code::KeyP => 'p',
+            Code::KeyQ => 'q',
+            Code::KeyR => 'r',
+            Code::KeyS => 's',
+            Code::KeyT => 't',
+            Code::KeyU => 'u',
+            Code::KeyV => 'v',
+            Code::KeyW => 'w',
+            Code::KeyX => 'x',
+            Code::KeyY => 'y',
+            Code::KeyZ => 'z',
+            Code::Digit0 => '0',
+            Code::Digit1 => '1',
+            Code::Digit2 => '2',
+            Code::Digit3 => '3',
+            Code::Digit4 => '4',
+            Code::Digit5 => '5',
+            Code::Digit6 => '6',
+            Code::Digit7 => '7',
+            Code::Digit8 => '8',
+            Code::Digit9 => '9',
+            _ => return None,
+        };
+
+        Some(latin)
+    }
 }
 
 impl From<Named> for Key {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -902,6 +902,7 @@ where
                 key,
                 text,
                 modified_key,
+                physical_key,
                 ..
             }) => {
                 let state = state::<Renderer>(tree);
@@ -909,8 +910,8 @@ where
                 if let Some(focus) = &mut state.is_focused {
                     let modifiers = state.keyboard_modifiers;
 
-                    match key.as_ref() {
-                        keyboard::Key::Character("c")
+                    match key.to_latin(*physical_key) {
+                        Some('c')
                             if state.keyboard_modifiers.command()
                                 && !self.is_secure =>
                         {
@@ -926,7 +927,7 @@ where
                             shell.capture_event();
                             return;
                         }
-                        keyboard::Key::Character("x")
+                        Some('x')
                             if state.keyboard_modifiers.command()
                                 && !self.is_secure =>
                         {
@@ -955,7 +956,7 @@ where
                             update_cache(state, &self.value);
                             return;
                         }
-                        keyboard::Key::Character("v")
+                        Some('v')
                             if state.keyboard_modifiers.command()
                                 && !state.keyboard_modifiers.alt() =>
                         {
@@ -994,9 +995,7 @@ where
                             update_cache(state, &self.value);
                             return;
                         }
-                        keyboard::Key::Character("a")
-                            if state.keyboard_modifiers.command() =>
-                        {
+                        Some('a') if state.keyboard_modifiers.command() => {
                             let cursor_before = state.cursor;
 
                             state.cursor.select_all(&self.value);


### PR DESCRIPTION
Currently if I switch from US English layout to Russian, copy paste stops working. That's because keyboard input is matched on input character, which depends on current keyboard layout.

This patch will make it match keyboard input by physical key, so that CUA shortcuts still work even if you switch layout.

This is consistent with other gui frameworks, such as Qt or gtk, and browser behavior.
