### PR TITLE
Fix `keyboard::listen` reporting captured key events

### DIFF
--- a/futures/src/keyboard.rs
+++ b/futures/src/keyboard.rs
@@ -11,6 +11,7 @@ pub fn listen() -> Subscription<Event> {
     subscription::filter_map(Listen, move |event| match event {
         subscription::Event::Interaction {
             event: core::Event::Keyboard(event),
+            status: core::event::Status::Ignored,
             ..
         } => Some(event),
         _ => None,


### PR DESCRIPTION
Fix for `keyboard::listen` reporting captured key events