### PR TITLE
Implement `Sub<Vector>` for `Cursor`

### DIFF
--- a/core/src/mouse/cursor.rs
+++ b/core/src/mouse/cursor.rs
@@ -89,6 +89,20 @@ impl std::ops::Add<Vector> for Cursor {
     }
 }
 
+impl std::ops::Sub<Vector> for Cursor {
+    type Output = Self;
+
+    fn sub(self, translation: Vector) -> Self::Output {
+        match self {
+            Cursor::Available(point) => Cursor::Available(point - translation),
+            Cursor::Levitating(point) => {
+                Cursor::Levitating(point - translation)
+            }
+            Cursor::Unavailable => Cursor::Unavailable,
+        }
+    }
+}
+
 impl std::ops::Mul<Transformation> for Cursor {
     type Output = Self;
 


### PR DESCRIPTION
`Cursor` implements `Add<Vector>`, so not having `Sub<Vector>` has confused me more than a few times.