### PR TITLE
wgpu: request devices with `SHADER_F16` feature

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -154,7 +154,7 @@ impl Compositor {
             let result = adapter
                 .request_device(&wgpu::DeviceDescriptor {
                     label: Some("iced_wgpu::window::compositor device descriptor"),
-                    required_features: wgpu::Features::empty(),
+                    required_features: wgpu::Features::SHADER_F16,
                     required_limits: required_limits.clone(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,


### PR DESCRIPTION
Fixes this panic:
```
thread 'main' (9604) panicked at /home/edwin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-27.0.1/src/backend/wgpu_core.rs:1058:30:
wgpu error: Validation Error

Caused by:
  In Device::create_shader_module, label = 'iced_wgpu.quad.solid.shader'
    
Shader validation error: Function [1] 'unpack_u32' is invalid
   ┌─ iced_wgpu.quad.solid.shader:9:1
   │  
 9 │ ╭ fn unpack_u32(data: vec2<u32>) -> vec4<f32> {
10 │ │     let rg: vec2<f32> = unpack2x16float(data.x);
   │ │                         ^^^^^^^^^^^^^^^ naga::ir::Expression [2]
11 │ │     let ba: vec2<f32> = unpack2x16float(data.y);
12 │ │ 
13 │ │     return vec4<f32>(rg.y, rg.x, ba.y, ba.x);
   │ ╰─────────────────────────────────────────────^ naga::ir::Function [1]
   │  
   = Expression [2] is invalid
   = Shader requires capability Capabilities(SHADER_FLOAT16_IN_FLOAT32)


      Expression [2] is invalid
        Shader requires capability Capabilities(SHADER_FLOAT16_IN_FLOAT32)
```
which is caused by validation of [these two lines](https://github.com/iced-rs/iced/blob/fd25ff1d3607872cb3163fa5e2d58fe82ab642fb/wgpu/src/shader/color.wgsl#L10-L11) when the device feature that provides these functions isn't present.

An easy way to reproduce this panic is running an iced app through Mesa's `lavapipe` vulkan emulation layer.