### PR TITLE
Use unstable sort in `group`

### DIFF
--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -47,7 +47,9 @@ pub fn list<T>(
 pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
     const AREA_THRESHOLD: f32 = 20_000.0;
 
-    damage.sort_by(|a, b| {
+    // Keep unstable sort here because `distance` uses `hypot` which has
+    // non-deterministic precision.
+    damage.sort_unstable_by(|a, b| {
         a.center()
             .distance(Point::ORIGIN)
             .total_cmp(&b.center().distance(Point::ORIGIN))


### PR DESCRIPTION
`distance` function uses `hypot` internally, which has non-deterministic precision [1]. This is a problem for stable sorting, which needs deterministic results. And indeed, with the right circumstances [2] this breaks stable sort guarantees.

[1]: https://doc.rust-lang.org/std/primitive.f32.html#method.hypot
[2]: https://github.com/pop-os/cosmic-launcher/issues/352

With this change, I no longer get `panic_on_ord_violation` panic mentioned in https://github.com/pop-os/cosmic-launcher/issues/352.