### PR TITLE
iced_wgpu: derive Pod/Zeroable for quad::Gradient

### DIFF
--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -6,7 +6,7 @@ use bytemuck::{Pod, Zeroable};
 use std::ops::Range;
 
 /// A quad filled with interpolated colors.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 #[repr(C)]
 pub struct Gradient {
     /// The background gradient data of the quad.
@@ -16,11 +16,18 @@ pub struct Gradient {
     pub quad: Quad,
 }
 
-#[allow(unsafe_code)]
-unsafe impl Pod for Gradient {}
+#[cfg(test)]
+mod tests {
+    use super::Gradient;
+    use bytemuck::{Pod, Zeroable};
 
-#[allow(unsafe_code)]
-unsafe impl Zeroable for Gradient {}
+    fn assert_pod_zeroable<T: Pod + Zeroable>() {}
+
+    #[test]
+    fn gradient_is_pod_and_zeroable() {
+        assert_pod_zeroable::<Gradient>();
+    }
+}
 
 #[derive(Debug)]
 pub struct Layer {


### PR DESCRIPTION
**What**

1. Replace manual unsafe impl bytemuck::{Pod, Zeroable} for quad::Gradient with #[derive(Pod, Zeroable)].
2. Add a tiny unit test that enforces Gradient: Pod + Zeroable going forward.

**Why**

1. Reduces unsafe surface area and aligns with the workspace’s unsafe_code = "deny" posture.
2. Keeps the shader/instance buffer layout explicit via #[repr(C)], while letting bytemuck’s derive enforce invariants.

**How verified**

- cargo check -p iced_wgpu
- cargo test -p iced_wgpu

**Reviewer notes**

- No behavior change intended; this is purely a safety/maintainability improvement.

**Scope**

- Intentionally tiny + mechanical: only changes quad::Gradient and adds a compile-only unit test.

**Risk**

- Minimal: Gradient is #[repr(C)] and composed of types that already derive Pod/Zeroable (Quad, gradient::Packed), so the derive is a stricter compiler-checked replacement for the previous manual impls.