### PR TITLE
iced_winit: handle window creation failure without panicking

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -334,9 +334,15 @@ where
                                 #[cfg(target_os = "macos")]
                                 let position = window_attributes.position.take();
 
-                                let window = event_loop
-                                    .create_window(window_attributes)
-                                    .expect("Create window");
+                                let window = match event_loop.create_window(window_attributes) {
+                                    Ok(window) => window,
+                                    Err(error) => {
+                                        // Avoid panicking on window creation failure.
+                                        self.error = Some(Error::WindowCreationFailed(error));
+                                        event_loop.exit();
+                                        return;
+                                    }
+                                };
 
                                 #[cfg(target_os = "macos")]
                                 if let Some(position) = position {


### PR DESCRIPTION
What

Replace expect("Create window") with a graceful error path.
On window creation failure, record Error::WindowCreationFailed(...) and exit the event loop instead of panicking.

Why

Improves robustness: avoids hard crashes on OS/windowing failures.
Improves safety: removes an “this can’t fail” assumption in a platform boundary.
Improves performance indirectly: fewer crash/restart loops during failure scenarios.

How verified

cargo check -p iced_winit
cargo test -p iced_winit
