### PR TITLE
iced_wgpu: skip svg upload for 0x0 allocations

### DIFF
--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -105,6 +105,10 @@ impl Cache {
             (scale * size.height).ceil() as u32,
         );
 
+        if width == 0 || height == 0 {
+            return None;
+        }
+
         let color = color.map(Color::into_rgba8);
         let key = (id, width, height, color);
 
@@ -121,10 +125,6 @@ impl Cache {
 
         match self.load(handle) {
             Svg::Loaded(tree) => {
-                if width == 0 || height == 0 {
-                    return None;
-                }
-
                 // TODO: Optimize!
                 // We currently rerasterize the SVG when its size changes. This is slow
                 // as heck. A GPU rasterizer like `pathfinder` may perform better.


### PR DESCRIPTION
What

- 
- Early-return in iced_wgpu SVG upload when the computed raster size is 0x0, before loading/parsing/caching the SVG.
- Keeps behavior unchanged for non-zero sizes.

Why

- Performance: avoids wasted SVG load/raster work in edge layout cases.
- Robustness: avoids surprising cache churn when size is effectively “not renderable.”
- 

No API change.

How verified

cargo check -p iced_wgpu --features svg
