### PR TITLE
Fix default Theme for overlay::Element

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,7 +610,7 @@ pub mod overlay {
     /// This is an alias of an [`overlay::Element`] with a default `Renderer`.
     ///
     /// [`overlay::Element`]: crate::core::overlay::Element
-    pub type Element<'a, Message, Theme = crate::Renderer, Renderer = crate::Renderer> =
+    pub type Element<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> =
         crate::core::overlay::Element<'a, Message, Theme, Renderer>;
 
     pub use iced_widget::overlay::*;


### PR DESCRIPTION
I'm a beginner with iced so I may be missing something, in fact I'm surprised the current code even compiles.