### PR TITLE
Make combo box callbacks `'a`

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -136,11 +136,11 @@ where
     text_input: TextInput<'a, TextInputEvent, Theme, Renderer>,
     font: Option<Renderer::Font>,
     selection: text_input::Value,
-    on_selected: Box<dyn Fn(T) -> Message>,
-    on_option_hovered: Option<Box<dyn Fn(T) -> Message>>,
+    on_selected: Box<dyn Fn(T) -> Message + 'a>,
+    on_option_hovered: Option<Box<dyn Fn(T) -> Message + 'a>>,
     on_open: Option<Message>,
     on_close: Option<Message>,
-    on_input: Option<Box<dyn Fn(String) -> Message>>,
+    on_input: Option<Box<dyn Fn(String) -> Message + 'a>>,
     padding: Padding,
     size: Option<f32>,
     text_shaping: text::Shaping,
@@ -161,7 +161,7 @@ where
         state: &'a State<T>,
         placeholder: &str,
         selection: Option<&T>,
-        on_selected: impl Fn(T) -> Message + 'static,
+        on_selected: impl Fn(T) -> Message + 'a,
     ) -> Self {
         let text_input = TextInput::new(placeholder, &state.value())
             .on_input(TextInputEvent::TextChanged)
@@ -189,14 +189,14 @@ where
 
     /// Sets the message that should be produced when some text is typed into
     /// the [`TextInput`] of the [`ComboBox`].
-    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'static) -> Self {
+    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'a) -> Self {
         self.on_input = Some(Box::new(on_input));
         self
     }
 
     /// Sets the message that will be produced when an option of the
     /// [`ComboBox`] is hovered using the arrow keys.
-    pub fn on_option_hovered(mut self, on_option_hovered: impl Fn(T) -> Message + 'static) -> Self {
+    pub fn on_option_hovered(mut self, on_option_hovered: impl Fn(T) -> Message + 'a) -> Self {
         self.on_option_hovered = Some(Box::new(on_option_hovered));
         self
     }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1698,7 +1698,7 @@ pub fn combo_box<'a, T, Message, Theme, Renderer>(
     state: &'a combo_box::State<T>,
     placeholder: &str,
     selection: Option<&T>,
-    on_selected: impl Fn(T) -> Message + 'static,
+    on_selected: impl Fn(T) -> Message + 'a,
 ) -> ComboBox<'a, T, Message, Theme, Renderer>
 where
     T: std::fmt::Display + Clone,


### PR DESCRIPTION
Replaces `'static` bounds on combo box message functions with `'a`, so they can borrow from app state.