### PR TITLE
Fixed typo in Anchor documentation

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -378,7 +378,7 @@ impl Scrollbar {
 /// on a given axis.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Anchor {
-    /// Scroller is anchoer to the start of the [`Viewport`].
+    /// Scroller is anchored to the start of the [`Viewport`].
     #[default]
     Start,
     /// Content is aligned to the end of the [`Viewport`].


### PR DESCRIPTION
Small typo in the Anchor doc comment