### PR TITLE
fix(ime): the candidate window position of fcitx5 which does't work well with winit's set_ime_cursor_area()

### DIFF
--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -266,14 +266,16 @@ where
         }
 
         if self.ime_state != Some((cursor, purpose)) {
-            let (cursor_y, cursor_height) = if cfg!(any(target_os = "windows", target_os = "macos"))
-            {
-                (cursor.y, cursor.height)
-            } else {
-                // Specify the bottom-left position of the cursor because
-                // only the position is supported on Linux (or other platforms).
-                (cursor.y + cursor.height, 0f32)
-            };
+            // Specify only the bottom-left position of the cursor on Linux
+            // because fcitx5 doesn't work well with cursor areas of
+            // the top-left position and height.
+            // The candidate window hides the composing text (a.k.a. preedit).
+            let (cursor_y, cursor_height) =
+                if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
+                    (cursor.y + cursor.height, 0.0)
+                } else {
+                    (cursor.y, cursor.height)
+                };
             self.raw.set_ime_cursor_area(
                 LogicalPosition::new(cursor.x, cursor_y),
                 LogicalSize::new(cursor.width, cursor_height),

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -266,9 +266,17 @@ where
         }
 
         if self.ime_state != Some((cursor, purpose)) {
+            let (cursor_y, cursor_height) = if cfg!(any(target_os = "windows", target_os = "macos"))
+            {
+                (cursor.y, cursor.height)
+            } else {
+                // Specify the bottom-left position of the cursor because
+                // only the position is supported on Linux (or other platforms).
+                (cursor.y + cursor.height, 0f32)
+            };
             self.raw.set_ime_cursor_area(
-                LogicalPosition::new(cursor.x, cursor.y),
-                LogicalSize::new(cursor.width, cursor.height),
+                LogicalPosition::new(cursor.x, cursor_y),
+                LogicalSize::new(cursor.width, cursor_height),
             );
             self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
 


### PR DESCRIPTION
This is a workaround fix of #3258.

~~As I noted in #3258, this probably be a bug of the winit's Linux implmentation.~~

As I noted in #3258, this seems to be **a bug of the fcitx5**.

The fcitx5 is just one of the input method frontends on Linux, but it is the de-facto standard on desktop environments other than GNOME which is tightly integrated with the ibus.

This workaround won't break if they will fix their ~~Linux~~ **fcitx5** implementation to handle the cursor area rectangle consistent with other platforms or **the ibus**. Because this change specifies zero height rect for Linux which is the left-top corner position (as they documented) == the bottom-left corner position (current actual behavior).

|Before|After|
|-|-|
|<img width="517" height="642" alt="image" src="https://github.com/user-attachments/assets/892bdc56-f3db-4470-9229-1a91a1e4398f" />|<img width="517" height="642" alt="image" src="https://github.com/user-attachments/assets/083cab44-8907-4db0-898c-a167aeaba487" />|
