### PR TITLE
Sliders: replace Into<f64> with AsPrimitive<f64>

### DIFF
--- a/core/src/angle.rs
+++ b/core/src/angle.rs
@@ -71,6 +71,18 @@ impl num_traits::FromPrimitive for Degrees {
     }
 }
 
+impl num_traits::AsPrimitive<f32> for Degrees {
+    fn as_(self) -> f32 {
+        self.0
+    }
+}
+
+impl num_traits::AsPrimitive<f64> for Degrees {
+    fn as_(self) -> f64 {
+        f64::from(self.0)
+    }
+}
+
 /// Radians
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct Radians(pub f32);
@@ -140,6 +152,18 @@ impl num_traits::FromPrimitive for Radians {
 
     fn from_f64(n: f64) -> Option<Self> {
         Some(Self(n as f32))
+    }
+}
+
+impl num_traits::AsPrimitive<f32> for Radians {
+    fn as_(self) -> f32 {
+        self.0
+    }
+}
+
+impl num_traits::AsPrimitive<f64> for Radians {
+    fn as_(self) -> f64 {
+        f64::from(self.0)
     }
 }
 

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -595,7 +595,7 @@ mod grid {
                     let columns = region.columns();
                     let (total_rows, total_columns) =
                         (rows.clone().count(), columns.clone().count());
-                    let width = 2.0 / Cell::SIZE as f32;
+                    let width = 2.0 / Cell::SIZE;
                     let color = Color::from_rgb8(70, 74, 83);
 
                     frame.translate(Vector::new(-width / 2.0, -width / 2.0));
@@ -791,11 +791,11 @@ mod grid {
     }
 
     impl Cell {
-        const SIZE: u16 = 20;
+        const SIZE: f32 = 20.0;
 
         fn at(position: Point) -> Cell {
-            let i = (position.y / Cell::SIZE as f32).ceil() as isize;
-            let j = (position.x / Cell::SIZE as f32).ceil() as isize;
+            let i = (position.y / Cell::SIZE).ceil() as isize;
+            let j = (position.x / Cell::SIZE).ceil() as isize;
 
             Cell {
                 i: i.saturating_sub(1),
@@ -826,17 +826,17 @@ mod grid {
 
     impl Region {
         fn rows(&self) -> RangeInclusive<isize> {
-            let first_row = (self.y / Cell::SIZE as f32).floor() as isize;
+            let first_row = (self.y / Cell::SIZE).floor() as isize;
 
-            let visible_rows = (self.height / Cell::SIZE as f32).ceil() as isize;
+            let visible_rows = (self.height / Cell::SIZE).ceil() as isize;
 
             first_row..=first_row + visible_rows
         }
 
         fn columns(&self) -> RangeInclusive<isize> {
-            let first_column = (self.x / Cell::SIZE as f32).floor() as isize;
+            let first_column = (self.x / Cell::SIZE).floor() as isize;
 
-            let visible_columns = (self.width / Cell::SIZE as f32).ceil() as isize;
+            let visible_columns = (self.width / Cell::SIZE).ceil() as isize;
 
             first_column..=first_column + visible_columns
         }

--- a/graphics/src/geometry/frame.rs
+++ b/graphics/src/geometry/frame.rs
@@ -169,7 +169,7 @@ where
     }
 
     /// Applies a uniform scaling to the current transform of the [`Frame`].
-    pub fn scale(&mut self, scale: impl Into<f32>) {
+    pub fn scale(&mut self, scale: f32) {
         self.raw.scale(scale);
     }
 
@@ -202,7 +202,7 @@ pub trait Backend: Sized {
 
     fn translate(&mut self, translation: Vector);
     fn rotate(&mut self, angle: impl Into<Radians>);
-    fn scale(&mut self, scale: impl Into<f32>);
+    fn scale(&mut self, scale: f32);
     fn scale_nonuniform(&mut self, scale: impl Into<Vector>);
 
     fn draft(&mut self, clip_bounds: Rectangle) -> Self;
@@ -247,7 +247,7 @@ impl Backend for () {
 
     fn translate(&mut self, _translation: Vector) {}
     fn rotate(&mut self, _angle: impl Into<Radians>) {}
-    fn scale(&mut self, _scale: impl Into<f32>) {}
+    fn scale(&mut self, _scale: f32) {}
     fn scale_nonuniform(&mut self, _scale: impl Into<Vector>) {}
 
     fn draft(&mut self, _clip_bounds: Rectangle) -> Self {}

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -582,7 +582,7 @@ mod geometry {
             delegate!(self, frame, frame.rotate(angle));
         }
 
-        fn scale(&mut self, scale: impl Into<f32>) {
+        fn scale(&mut self, scale: f32) {
             delegate!(self, frame, frame.scale(scale));
         }
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -248,9 +248,7 @@ impl geometry::frame::Backend for Frame {
         self.transform = self.transform.pre_rotate(angle.into().0.to_degrees());
     }
 
-    fn scale(&mut self, scale: impl Into<f32>) {
-        let scale = scale.into();
-
+    fn scale(&mut self, scale: f32) {
         self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -340,9 +340,7 @@ impl geometry::frame::Backend for Frame {
     }
 
     #[inline]
-    fn scale(&mut self, scale: impl Into<f32>) {
-        let scale = scale.into();
-
+    fn scale(&mut self, scale: f32) {
         self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -267,15 +267,15 @@ where
                 } else if cursor_position.x >= bounds.x + bounds.width {
                     Some(*self.range.end())
                 } else {
-                    let step: f64 = if state.keyboard_modifiers.shift() {
+                    let step = if state.keyboard_modifiers.shift() {
                         self.shift_step.unwrap_or(self.step)
                     } else {
                         self.step
                     }
                     .as_();
 
-                    let start: f64 = (*self.range.start()).as_();
-                    let end: f64 = (*self.range.end()).as_();
+                    let start = (*self.range.start()).as_();
+                    let end = (*self.range.end()).as_();
 
                     let percent = f64::from(cursor_position.x - bounds.x) / f64::from(bounds.width);
 
@@ -287,7 +287,7 @@ where
             };
 
             let increment = |value: T| -> Option<T> {
-                let step: f64 = if state.keyboard_modifiers.shift() {
+                let step = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
@@ -305,7 +305,7 @@ where
             };
 
             let decrement = |value: T| -> Option<T> {
-                let step: f64 = if state.keyboard_modifiers.shift() {
+                let step = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -52,6 +52,10 @@ use std::ops::RangeInclusive;
 /// The [`Slider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
 ///
+/// Note: Under the hood values are converted to/from f64 so only values representable exactly as an f64
+/// are possible to select via the slider. However it is likely that the precision of the slider at these
+/// scales is already less than the precision lost from the f64 representation.
+///
 /// # Example
 /// ```no_run
 /// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
@@ -211,7 +215,7 @@ where
 
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Slider<'_, T, Message, Theme>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive,
     Message: Clone,
     Theme: Catalog,
     Renderer: core::Renderer,
@@ -263,15 +267,15 @@ where
                 } else if cursor_position.x >= bounds.x + bounds.width {
                     Some(*self.range.end())
                 } else {
-                    let step = if state.keyboard_modifiers.shift() {
+                    let step: f64 = if state.keyboard_modifiers.shift() {
                         self.shift_step.unwrap_or(self.step)
                     } else {
                         self.step
                     }
-                    .into();
+                    .as_();
 
-                    let start = (*self.range.start()).into();
-                    let end = (*self.range.end()).into();
+                    let start: f64 = (*self.range.start()).as_();
+                    let end: f64 = (*self.range.end()).as_();
 
                     let percent = f64::from(cursor_position.x - bounds.x) / f64::from(bounds.width);
 
@@ -283,17 +287,17 @@ where
             };
 
             let increment = |value: T| -> Option<T> {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let steps = (value.into() / step).round();
+                let steps = (value.as_() / step).round();
                 let new_value = step * (steps + 1.0);
 
-                if new_value > (*self.range.end()).into() {
+                if new_value > (*self.range.end()).as_() {
                     return Some(*self.range.end());
                 }
 
@@ -301,17 +305,17 @@ where
             };
 
             let decrement = |value: T| -> Option<T> {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let steps = (value.into() / step).round();
+                let steps = (value.as_() / step).round();
                 let new_value = step * (steps - 1.0);
 
-                if new_value < (*self.range.start()).into() {
+                if new_value < (*self.range.start()).as_() {
                     return Some(*self.range.start());
                 }
 
@@ -319,7 +323,7 @@ where
             };
 
             let change = |new_value: T| {
-                if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
+                if (self.value.as_() - new_value.as_()).abs() > f64::EPSILON {
                     shell.publish((self.on_change)(new_value));
 
                     self.value = new_value;
@@ -438,11 +442,11 @@ where
             } => (f32::from(width), bounds.height, border_radius),
         };
 
-        let value = self.value.into() as f32;
+        let value = self.value.as_() as f32;
         let (range_start, range_end) = {
             let (start, end) = self.range.clone().into_inner();
 
-            (start.into() as f32, end.into() as f32)
+            (start.as_() as f32, end.as_() as f32)
         };
 
         let offset = if range_start >= range_end {
@@ -533,7 +537,7 @@ where
 impl<'a, T, Message, Theme, Renderer> From<Slider<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive + 'a,
     Message: Clone + 'a,
     Theme: Catalog + 'a,
     Renderer: core::Renderer + 'a,

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -52,6 +52,10 @@ use std::ops::RangeInclusive;
 /// The [`Slider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
 ///
+/// Note: Under the hood values are converted to/from f64 so only values representable exactly as an f64
+/// are possible to select via the slider. However it is likely that the precision of the slider at these
+/// scales is already less than the precision lost from the f64 representation.
+///
 /// # Example
 /// ```no_run
 /// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
@@ -211,7 +215,7 @@ where
 
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Slider<'_, T, Message, Theme>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive,
     Message: Clone,
     Theme: Catalog,
     Renderer: core::Renderer,
@@ -263,15 +267,15 @@ where
                 } else if cursor_position.x >= bounds.x + bounds.width {
                     Some(*self.range.end())
                 } else {
-                    let step = if state.keyboard_modifiers.shift() {
+                    let step: f64 = if state.keyboard_modifiers.shift() {
                         self.shift_step.unwrap_or(self.step)
                     } else {
                         self.step
                     }
-                    .into();
+                    .as_();
 
-                    let start = (*self.range.start()).into();
-                    let end = (*self.range.end()).into();
+                    let start: f64 = (*self.range.start()).as_();
+                    let end: f64 = (*self.range.end()).as_();
 
                     let percent = f64::from(cursor_position.x - bounds.x) / f64::from(bounds.width);
 
@@ -283,17 +287,17 @@ where
             };
 
             let increment = |value: T| -> Option<T> {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let steps = (value.into() / step).round();
+                let steps = (value.as_() / step).round();
                 let new_value = step * (steps + 1.0);
 
-                if new_value > (*self.range.end()).into() {
+                if new_value > (*self.range.end()).as_() {
                     return Some(*self.range.end());
                 }
 
@@ -301,17 +305,17 @@ where
             };
 
             let decrement = |value: T| -> Option<T> {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let steps = (value.into() / step).round();
+                let steps = (value.as_() / step).round();
                 let new_value = step * (steps - 1.0);
 
-                if new_value < (*self.range.start()).into() {
+                if new_value < (*self.range.start()).as_() {
                     return Some(*self.range.start());
                 }
 
@@ -319,7 +323,7 @@ where
             };
 
             let change = |new_value: T| {
-                if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
+                if (self.value.as_() - new_value.as_()).abs() > f64::EPSILON {
                     shell.publish((self.on_change)(new_value));
 
                     self.value = new_value;
@@ -436,11 +440,11 @@ where
             } => (f32::from(width), bounds.height, border_radius),
         };
 
-        let value = self.value.into() as f32;
+        let value = self.value.as_() as f32;
         let (range_start, range_end) = {
             let (start, end) = self.range.clone().into_inner();
 
-            (start.into() as f32, end.into() as f32)
+            (start.as_() as f32, end.as_() as f32)
         };
 
         let offset = if range_start >= range_end {
@@ -531,7 +535,7 @@ where
 impl<'a, T, Message, Theme, Renderer> From<Slider<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive + 'a,
     Message: Clone + 'a,
     Theme: Catalog + 'a,
     Renderer: core::Renderer + 'a,

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -89,8 +89,8 @@ where
     Theme: Catalog,
 {
     range: RangeInclusive<T>,
-    step: T,
-    shift_step: Option<T>,
+    step: f64,
+    shift_step: Option<f64>,
     value: T,
     default: Option<T>,
     on_change: Box<dyn Fn(T) -> Message + 'a>,
@@ -103,7 +103,7 @@ where
 
 impl<'a, T, Message, Theme> Slider<'a, T, Message, Theme>
 where
-    T: Copy + From<u8> + PartialOrd,
+    T: Copy + PartialOrd,
     Message: Clone,
     Theme: Catalog,
 {
@@ -138,7 +138,7 @@ where
             value,
             default: None,
             range,
-            step: T::from(1),
+            step: 1.0,
             shift_step: None,
             on_change: Box::new(on_change),
             on_release: None,
@@ -181,16 +181,16 @@ where
     }
 
     /// Sets the step size of the [`Slider`].
-    pub fn step(mut self, step: impl Into<T>) -> Self {
-        self.step = step.into();
+    pub fn step(mut self, step: impl num_traits::AsPrimitive<f64>) -> Self {
+        self.step = step.as_();
         self
     }
 
     /// Sets the optional "shift" step for the [`Slider`].
     ///
     /// If set, this value is used as the step while the shift key is pressed.
-    pub fn shift_step(mut self, shift_step: impl Into<T>) -> Self {
-        self.shift_step = Some(shift_step.into());
+    pub fn shift_step(mut self, shift_step: impl num_traits::AsPrimitive<f64>) -> Self {
+        self.shift_step = Some(shift_step.as_());
         self
     }
 
@@ -271,8 +271,7 @@ where
                         self.shift_step.unwrap_or(self.step)
                     } else {
                         self.step
-                    }
-                    .as_();
+                    };
 
                     let start = (*self.range.start()).as_();
                     let end = (*self.range.end()).as_();
@@ -291,8 +290,7 @@ where
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
-                }
-                .as_();
+                };
 
                 let steps = (value.as_() / step).round();
                 let new_value = step * (steps + 1.0);
@@ -309,8 +307,7 @@ where
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
-                }
-                .as_();
+                };
 
                 let steps = (value.as_() / step).round();
                 let new_value = step * (steps - 1.0);

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -266,7 +266,7 @@ where
             } else if cursor_position.y <= bounds.y {
                 Some(*self.range.end())
             } else {
-                let step: f64 = if state.keyboard_modifiers.shift() {
+                let step = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
@@ -287,7 +287,7 @@ where
         };
 
         let increment = |value: T| -> Option<T> {
-            let step: f64 = if state.keyboard_modifiers.shift() {
+            let step = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step
@@ -305,7 +305,7 @@ where
         };
 
         let decrement = |value: T| -> Option<T> {
-            let step: f64 = if state.keyboard_modifiers.shift() {
+            let step = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -51,6 +51,10 @@ use crate::core::{self, Element, Event, Length, Pixels, Point, Rectangle, Shell,
 /// The [`VerticalSlider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
 ///
+/// Note: Under the hood values are converted to/from f64 so only values representable exactly as an f64
+/// are possible to select via the slider. However it is likely that the precision of the slider at these
+/// scales is already less than the precision lost from the f64 representation.
+///
 /// # Example
 /// ```no_run
 /// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
@@ -211,7 +215,7 @@ where
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for VerticalSlider<'_, T, Message, Theme>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive,
     Message: Clone,
     Theme: Catalog,
     Renderer: core::Renderer,
@@ -262,15 +266,15 @@ where
             } else if cursor_position.y <= bounds.y {
                 Some(*self.range.end())
             } else {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let start = (*self.range.start()).into();
-                let end = (*self.range.end()).into();
+                let start = (*self.range.start()).as_();
+                let end = (*self.range.end()).as_();
 
                 let percent =
                     1.0 - f64::from(cursor_position.y - bounds.y) / f64::from(bounds.height);
@@ -283,17 +287,17 @@ where
         };
 
         let increment = |value: T| -> Option<T> {
-            let step = if state.keyboard_modifiers.shift() {
+            let step: f64 = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step
             }
-            .into();
+            .as_();
 
-            let steps = (value.into() / step).round();
+            let steps = (value.as_() / step).round();
             let new_value = step * (steps + 1.0);
 
-            if new_value > (*self.range.end()).into() {
+            if new_value > (*self.range.end()).as_() {
                 return Some(*self.range.end());
             }
 
@@ -301,17 +305,17 @@ where
         };
 
         let decrement = |value: T| -> Option<T> {
-            let step = if state.keyboard_modifiers.shift() {
+            let step: f64 = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step
             }
-            .into();
+            .as_();
 
-            let steps = (value.into() / step).round();
+            let steps = (value.as_() / step).round();
             let new_value = step * (steps - 1.0);
 
-            if new_value < (*self.range.start()).into() {
+            if new_value < (*self.range.start()).as_() {
                 return Some(*self.range.start());
             }
 
@@ -319,7 +323,7 @@ where
         };
 
         let change = |new_value: T| {
-            if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
+            if (self.value.as_() - new_value.as_()).abs() > f64::EPSILON {
                 shell.publish((self.on_change)(new_value));
 
                 self.value = new_value;
@@ -435,11 +439,11 @@ where
             } => (f32::from(width), bounds.width, border_radius),
         };
 
-        let value = self.value.into() as f32;
+        let value = self.value.as_() as f32;
         let (range_start, range_end) = {
             let (start, end) = self.range.clone().into_inner();
 
-            (start.into() as f32, end.into() as f32)
+            (start.as_() as f32, end.as_() as f32)
         };
 
         let offset = if range_start >= range_end {
@@ -530,7 +534,7 @@ where
 impl<'a, T, Message, Theme, Renderer> From<VerticalSlider<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive + 'a,
     Message: Clone + 'a,
     Theme: Catalog + 'a,
     Renderer: core::Renderer + 'a,

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -51,6 +51,10 @@ use crate::core::{self, Element, Event, Length, Pixels, Point, Rectangle, Shell,
 /// The [`VerticalSlider`] range of numeric values is generic and its step size defaults
 /// to 1 unit.
 ///
+/// Note: Under the hood values are converted to/from f64 so only values representable exactly as an f64
+/// are possible to select via the slider. However it is likely that the precision of the slider at these
+/// scales is already less than the precision lost from the f64 representation.
+///
 /// # Example
 /// ```no_run
 /// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
@@ -211,7 +215,7 @@ where
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for VerticalSlider<'_, T, Message, Theme>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive,
     Message: Clone,
     Theme: Catalog,
     Renderer: core::Renderer,
@@ -262,15 +266,15 @@ where
             } else if cursor_position.y <= bounds.y {
                 Some(*self.range.end())
             } else {
-                let step = if state.keyboard_modifiers.shift() {
+                let step: f64 = if state.keyboard_modifiers.shift() {
                     self.shift_step.unwrap_or(self.step)
                 } else {
                     self.step
                 }
-                .into();
+                .as_();
 
-                let start = (*self.range.start()).into();
-                let end = (*self.range.end()).into();
+                let start = (*self.range.start()).as_();
+                let end = (*self.range.end()).as_();
 
                 let percent =
                     1.0 - f64::from(cursor_position.y - bounds.y) / f64::from(bounds.height);
@@ -283,17 +287,17 @@ where
         };
 
         let increment = |value: T| -> Option<T> {
-            let step = if state.keyboard_modifiers.shift() {
+            let step: f64 = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step
             }
-            .into();
+            .as_();
 
-            let steps = (value.into() / step).round();
+            let steps = (value.as_() / step).round();
             let new_value = step * (steps + 1.0);
 
-            if new_value > (*self.range.end()).into() {
+            if new_value > (*self.range.end()).as_() {
                 return Some(*self.range.end());
             }
 
@@ -301,17 +305,17 @@ where
         };
 
         let decrement = |value: T| -> Option<T> {
-            let step = if state.keyboard_modifiers.shift() {
+            let step: f64 = if state.keyboard_modifiers.shift() {
                 self.shift_step.unwrap_or(self.step)
             } else {
                 self.step
             }
-            .into();
+            .as_();
 
-            let steps = (value.into() / step).round();
+            let steps = (value.as_() / step).round();
             let new_value = step * (steps - 1.0);
 
-            if new_value < (*self.range.start()).into() {
+            if new_value < (*self.range.start()).as_() {
                 return Some(*self.range.start());
             }
 
@@ -319,7 +323,7 @@ where
         };
 
         let change = |new_value: T| {
-            if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
+            if (self.value.as_() - new_value.as_()).abs() > f64::EPSILON {
                 shell.publish((self.on_change)(new_value));
 
                 self.value = new_value;
@@ -433,11 +437,11 @@ where
             } => (f32::from(width), bounds.width, border_radius),
         };
 
-        let value = self.value.into() as f32;
+        let value = self.value.as_() as f32;
         let (range_start, range_end) = {
             let (start, end) = self.range.clone().into_inner();
 
-            (start.into() as f32, end.into() as f32)
+            (start.as_() as f32, end.as_() as f32)
         };
 
         let offset = if range_start >= range_end {
@@ -528,7 +532,7 @@ where
 impl<'a, T, Message, Theme, Renderer> From<VerticalSlider<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,
+    T: Copy + num_traits::AsPrimitive<f64> + num_traits::FromPrimitive + 'a,
     Message: Clone + 'a,
     Theme: Catalog + 'a,
     Renderer: core::Renderer + 'a,


### PR DESCRIPTION
This change is intended to allow the Slider and VerticalSlider structs to work with larger integer types such as u64 and usize.

I had a use case for this on a personal project and @edwloef suggested the change on the discord so I've put up this PR for it.
