### PR TITLE
feat(font): add arraystring name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
 name = "iced_core"
 version = "0.15.0-dev"
 dependencies = [
+ "arrayvec",
  "bitflags 2.11.0",
  "bytes",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ web-sys = "=0.3.85"
 web-time = "1.1"
 wgpu = { version = "28.0", default-features = false, features = ["std", "wgsl"] }
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed", default-features = false, features = ["rwh_06"] }
+arrayvec = "0.7.6"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ rustc-hash.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
+arrayvec.workspace = true
 
 serde.workspace = true
 serde.optional = true

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -1,6 +1,8 @@
 //! Load and use fonts.
 use std::hash::Hash;
 
+pub use arrayvec::ArrayString;
+
 /// A font.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Font {
@@ -29,11 +31,20 @@ impl Font {
         ..Self::DEFAULT
     };
 
-    /// Creates a non-monospaced [`Font`] with the given [`Family::Name`] and
+    /// Creates a non-monospaced [`Font`] with the given [`Name`] and
     /// normal [`Weight`].
     pub const fn with_name(name: &'static str) -> Self {
         Font {
-            family: Family::Name(name),
+            family: Family::Name(Name::Static(name)),
+            ..Self::DEFAULT
+        }
+    }
+
+    /// Creates a non-monospaced [`Font`] with the given [`Name`] and
+    /// normal [`Weight`].
+    pub fn with_array_name(name: ArrayString<128>) -> Self {
+        Font {
+            family: Family::Name(Name::Array(name)),
             ..Self::DEFAULT
         }
     }
@@ -43,7 +54,7 @@ impl Font {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Family {
     /// The name of a font family of choice.
-    Name(&'static str),
+    Name(Name),
 
     /// Serif fonts represent the formal text style for a script.
     Serif,
@@ -66,6 +77,15 @@ pub enum Family {
     /// The sole criterion of a monospace font is that all glyphs have the same
     /// fixed width.
     Monospace,
+}
+
+/// Font name
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Name {
+    /// A static reference
+    Static(&'static str),
+    /// A string of at most 128 chars. Use this when youfor example have configurable font
+    Array(ArrayString<128>),
 }
 
 /// The weight of some text.

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -259,17 +259,20 @@ pub fn align(
 }
 
 /// Returns the attributes of the given [`Font`].
-pub fn to_attributes(font: Font) -> cosmic_text::Attrs<'static> {
+pub fn to_attributes<'a>(font: &'a Font) -> cosmic_text::Attrs<'a> {
     cosmic_text::Attrs::new()
-        .family(to_family(font.family))
+        .family(to_family(&font.family))
         .weight(to_weight(font.weight))
         .stretch(to_stretch(font.stretch))
         .style(to_style(font.style))
 }
 
-fn to_family(family: font::Family) -> cosmic_text::Family<'static> {
+fn to_family<'a>(family: &'a font::Family) -> cosmic_text::Family<'a> {
     match family {
-        font::Family::Name(name) => cosmic_text::Family::Name(name),
+        font::Family::Name(name) => cosmic_text::Family::Name(match name {
+            font::Name::Static(str) => str,
+            font::Name::Array(array_string) => array_string.as_str(),
+        }),
         font::Family::SansSerif => cosmic_text::Family::SansSerif,
         font::Family::Serif => cosmic_text::Family::Serif,
         font::Family::Cursive => cosmic_text::Family::Cursive,

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -54,7 +54,7 @@ impl Cache {
             buffer.set_text(
                 font_system,
                 key.content,
-                &text::to_attributes(key.font),
+                &text::to_attributes(&key.font),
                 text::to_shaping(key.shaping, key.content),
                 None,
             );

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -529,7 +529,7 @@ impl editor::Editor for Editor {
 
                 for line in buffer.lines.iter_mut() {
                     let _ = line.set_attrs_list(cosmic_text::AttrsList::new(&text::to_attributes(
-                        new_font,
+                        &new_font,
                     )));
                 }
 
@@ -653,7 +653,7 @@ impl editor::Editor for Editor {
 
         let mut font_system = text::font_system().write().expect("Write font system");
 
-        let attributes = text::to_attributes(font);
+        let attributes = text::to_attributes(&font);
 
         for line in &mut buffer_mut_from_editor(&mut internal.editor).lines
             [current_line..=last_visible_line]
@@ -668,7 +668,7 @@ impl editor::Editor for Editor {
                         range,
                         &cosmic_text::Attrs {
                             color_opt: format.color.map(text::to_color),
-                            ..if let Some(font) = format.font {
+                            ..if let Some(font) = &format.font {
                                 text::to_attributes(font)
                             } else {
                                 attributes.clone()

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -100,7 +100,7 @@ impl core::text::Paragraph for Paragraph {
         buffer.set_text(
             font_system.raw(),
             text.content,
-            &text::to_attributes(text.font),
+            &text::to_attributes(&text.font),
             text::to_shaping(text.shaping, text.content),
             None,
         );
@@ -156,7 +156,7 @@ impl core::text::Paragraph for Paragraph {
         buffer.set_rich_text(
             font_system.raw(),
             text.content.iter().enumerate().map(|(i, span)| {
-                let attrs = text::to_attributes(span.font.unwrap_or(text.font));
+                let attrs = text::to_attributes(span.font.as_ref().unwrap_or(&text.font));
 
                 let attrs = match (span.size, span.line_height) {
                     (None, None) => attrs,
@@ -182,7 +182,7 @@ impl core::text::Paragraph for Paragraph {
 
                 (span.text.as_ref(), attrs.metadata(i))
             }),
-            &text::to_attributes(text.font),
+            &text::to_attributes(&text.font),
             cosmic_text::Shaping::Advanced,
             None,
         );


### PR DESCRIPTION
Currently if you want to have a font of which name isn't static such as when you have settings, you have to leak the string which is against rust's philosophy. Therefore I added a variant for arraystring
