### PR TITLE
feat: add scale factor to window opened event

### DIFF
--- a/core/src/window/event.rs
+++ b/core/src/window/event.rs
@@ -17,6 +17,8 @@ pub enum Event {
         /// The size of the created window. This is its "inner" size, or the size of the
         /// client area, in logical pixels.
         size: Size,
+        /// The scale factor of the created window.
+        scale_factor: f32,
     },
 
     /// A window was closed.

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -674,7 +674,8 @@ async fn run_instance<P>(
                     id,
                     core::Event::Window(window::Event::Opened {
                         position: window.position(),
-                        size: window.logical_size(),
+                        size: window.state.logical_size(),
+                        scale_factor: window.raw.scale_factor() as f32,
                     }),
                 ));
 
@@ -1408,7 +1409,7 @@ fn run_action<'a, P, C>(
             }
             window::Action::GetSize(id, channel) => {
                 if let Some(window) = window_manager.get_mut(id) {
-                    let size = window.logical_size();
+                    let size = window.state.logical_size();
                     let _ = channel.send(Size::new(size.width, size.height));
                 }
             }
@@ -1662,7 +1663,7 @@ fn run_action<'a, P, C>(
                         continue;
                     };
 
-                    let size = window.logical_size();
+                    let size = window.state.logical_size();
                     let ui = ui.relayout(size, &mut window.renderer);
                     let _ = interfaces.insert(id, ui);
 
@@ -1719,7 +1720,7 @@ fn run_action<'a, P, C>(
                 };
 
                 let cache = ui.into_cache();
-                let size = window.logical_size();
+                let size = window.state.logical_size();
 
                 let _ = interfaces.insert(
                     id,

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -186,10 +186,6 @@ where
             })
     }
 
-    pub fn logical_size(&self) -> Size {
-        self.state.logical_size()
-    }
-
     pub fn request_redraw(&mut self, redraw_request: RedrawRequest) {
         match redraw_request {
             RedrawRequest::NextFrame => {


### PR DESCRIPTION
... and remove one small helper on `Window` that wasn't consistently used anyways.

This makes it possible to immediately know the system scale factor of a window, in contrast to only after it changes once. With some (only slightly messy) math and only a little bit of flashing on scale factor change, this makes it possible to control the physical size of windows from Iced.