### PR TITLE
Fix early return in image `State::prepare` skipping layer finalization

### DIFF
--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -235,7 +235,7 @@ impl State {
                     let clip_bounds = (*clip_bounds * scale).round();
 
                     if bounds.width < 1.0 || bounds.height < 1.0 {
-                        return;
+                        continue;
                     }
 
                     if let Some((atlas_entry, bind_group)) =
@@ -284,7 +284,7 @@ impl State {
                     let clip_bounds = (*clip_bounds * scale).round();
 
                     if bounds.width < 1.0 || bounds.height < 1.0 {
-                        return;
+                        continue;
                     }
 
                     if let Some((atlas_entry, bind_group)) = cache.upload_vector(


### PR DESCRIPTION
The sub-pixel bounds guards added in 0fe99b19 and 1463ec84 use `return` instead of `continue` inside the image loop in `State::prepare`. When any image in the batch has bounds smaller than 1px, `return` exits the whole function instead of just skipping that image. This means `layer.push()`, `layer.prepare()`, and the instance vec `.clear()` calls at the bottom never run, which leaves stale instances around and causes a wgpu buffer validation error on the next frame.

This changes both to `continue` so we just skip the sub-pixel image and let the rest of the function finish normally.

Fixes #3272