### PR TITLE
Fix RTL relayout being skipped for single-line text

### DIFF
--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -260,7 +260,7 @@ pub fn align(
 
             needs_relayout = true;
         } else if let Some(line) = buffer.lines.first_mut() {
-            needs_relayout = line.set_align(None);
+            needs_relayout |= line.set_align(None);
         }
     }
 


### PR DESCRIPTION
Single-line RTL text are not relayouting and are being drawn outside of the window:

before:
<img width="797" height="528" alt="Screenshot_2026-03-26_12-51-23" src="https://github.com/user-attachments/assets/10ece799-f4e0-4025-8139-deb4a662557a" />

after:
<img width="736" height="526" alt="Screenshot_2026-03-26_12-50-53" src="https://github.com/user-attachments/assets/7e2014b6-5d3b-46b8-aa00-3996a2ce825a" />


fixes https://github.com/iced-rs/iced/issues/2816