### PR TITLE
Fix text_input stale modifier state on KeyPressed

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -836,9 +836,11 @@ where
                 text,
                 modified_key,
                 physical_key,
+                modifiers,
                 ..
             }) => {
                 let state = state::<Renderer>(tree);
+                state.keyboard_modifiers = *modifiers;
 
                 if let Some(focus) = &mut state.is_focused {
                     let modifiers = state.keyboard_modifiers;


### PR DESCRIPTION
## Summary

- Sync `keyboard_modifiers` from the `modifiers` field on `KeyPressed` events, not just from `ModifiersChanged`

## Problem

`text_input` tracks modifier state exclusively via `ModifiersChanged` events. When a `text_input` is created while a modifier key is already held (e.g. a search bar opened via Cmd+F), it never receives the initial `ModifiersChanged` event. Its internal `keyboard_modifiers` remains empty, so shortcuts like Cmd+V are not recognised and the bare character is inserted instead.

## Fix

A one-line addition: set `state.keyboard_modifiers = *modifiers` at the top of the `KeyPressed` handler, before checking for shortcuts. The `modifiers` field on `KeyPressed` always reflects the current modifier state, so this keeps the widget in sync even when it missed earlier `ModifiersChanged` events.