### PR TITLE
fix: sync text_input modifier state from KeyPressed events

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -836,15 +836,14 @@ where
                 text,
                 modified_key,
                 physical_key,
+                modifiers,
                 ..
             }) => {
                 let state = state::<Renderer>(tree);
 
                 if let Some(focus) = &mut state.is_focused {
-                    let modifiers = state.keyboard_modifiers;
-
                     match key.to_latin(*physical_key) {
-                        Some('c') if state.keyboard_modifiers.command() && !self.is_secure => {
+                        Some('c') if modifiers.command() && !self.is_secure => {
                             if let Some((start, end)) = state.cursor.selection(&self.value) {
                                 shell.write_clipboard(clipboard::Content::Text(
                                     self.value.select(start, end).to_string(),
@@ -854,7 +853,7 @@ where
                             shell.capture_event();
                             return;
                         }
-                        Some('x') if state.keyboard_modifiers.command() && !self.is_secure => {
+                        Some('x') if modifiers.command() && !self.is_secure => {
                             let Some(on_input) = &self.on_input else {
                                 return;
                             };
@@ -877,8 +876,8 @@ where
                             return;
                         }
                         Some('v')
-                            if state.keyboard_modifiers.command()
-                                && !state.keyboard_modifiers.alt() =>
+                            if modifiers.command()
+                                && !modifiers.alt() =>
                         {
                             let Some(on_input) = &self.on_input else {
                                 return;
@@ -909,7 +908,7 @@ where
                             update_cache(state, &self.value);
                             return;
                         }
-                        Some('a') if state.keyboard_modifiers.command() => {
+                        Some('a') if modifiers.command() => {
                             let cursor_before = state.cursor;
 
                             state.cursor.select_all(&self.value);
@@ -949,7 +948,7 @@ where
                     }
 
                     #[cfg(target_os = "macos")]
-                    let macos_shortcut = crate::text_editor::convert_macos_shortcut(key, modifiers);
+                    let macos_shortcut = crate::text_editor::convert_macos_shortcut(key, *modifiers);
 
                     #[cfg(target_os = "macos")]
                     let modified_key = macos_shortcut.as_ref().unwrap_or(modified_key);


### PR DESCRIPTION
Previously, text_input only updated keyboard_modifiers via
ModifiersChanged events. A widget created while a modifier
was already held (e.g. a search bar opened via Cmd+F) never
received the initial ModifiersChanged, leaving modifiers
stale. This caused shortcuts like Cmd+V to be missed and
the bare character inserted instead.
