### PR TITLE
Add COPY_SRC to compositor surface

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -323,10 +323,20 @@ impl graphics::Compositor for Compositor {
         width: u32,
         height: u32,
     ) {
+        let capabilities = surface.get_capabilities(&self.adapter);
+        let has_copy_src =
+            capabilities.usages.contains(wgpu::TextureUsages::COPY_SRC);
+        let usage = if has_copy_src {
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+        } else {
+            wgpu::TextureUsages::RENDER_ATTACHMENT
+        };
+
         surface.configure(
             &self.engine.device,
             &wgpu::SurfaceConfiguration {
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                usage,
                 format: self.format,
                 present_mode: self.settings.present_mode,
                 width,


### PR DESCRIPTION
I have been working on [iced_glass](https://github.com/maxbergmark/iced_glass), a widget library for iced that provides Liquid Glass-like effects in iced. To achieve these effects, it is essential to be able to read from the underlying background texture while rendering. 

This PR enables the COPY_SRC texture usage for the rendering surface, if that usage is available on the current platform. This approach is non-intrusive, and should not be noticeable to anyone currently using iced. If the PR is accepted, the end user will be able to query the texture usages before rendering, to confirm that the COPY_SRC flag is active for the background texture. 

I have tested this change myself, but I don't have the possibility to verify how this behaves on different machines or renderers that don't support COPY_SRC. If there is anything that I should change, or need to clarify, please let me know! This same change could also be done on the `master` branch, to enable COPY_SRC in iced 0.15.

<div align="center">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/7c5d1d4e-784a-4902-a5f4-0875424459b9" />
</div>

### Alternatives considered

#### Feature flag
Adding COPY_SRC could be hidden behind a feature flag. The main reason for not choosing this approach is that it adds complexity across the project, and hides a feature that could be enabled by default. A feature flag could also lead to confusion, if the underlying surface doesn't support COPY_SRC. In those cases, the end user would enable the feature, but get a runtime error when trying to copy the texture.