### PR TITLE
Minor fixes to custom_shader example

### DIFF
--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -116,7 +116,7 @@ impl IcedCubes {
         ]
         .spacing(40);
 
-        let controls = column![top_controls, bottom_controls,]
+        let controls = column![top_controls, bottom_controls]
             .spacing(10)
             .padding(20)
             .align_x(Center);
@@ -141,5 +141,8 @@ fn control<'a>(
     label: &'static str,
     control: impl Into<Element<'a, Message>>,
 ) -> Element<'a, Message> {
-    row![text(label), control.into()].spacing(10).into()
+    row![text(label), control.into()]
+        .spacing(10)
+        .align_y(Center)
+        .into()
 }

--- a/examples/custom_shader/src/scene/camera.rs
+++ b/examples/custom_shader/src/scene/camera.rs
@@ -17,7 +17,7 @@ impl Default for Camera {
             eye: vec3(0.0, 2.0, 3.0),
             target: glam::Vec3::ZERO,
             up: glam::Vec3::Y,
-            fov_y: 45.0,
+            fov_y: 45.0f32.to_radians(),
             near: 0.1,
             far: 100.0,
         }

--- a/examples/custom_shader/src/scene/pipeline/buffer.rs
+++ b/examples/custom_shader/src/scene/pipeline/buffer.rs
@@ -4,7 +4,6 @@ use crate::wgpu;
 pub struct Buffer {
     pub raw: wgpu::Buffer,
     label: &'static str,
-    size: u64,
     usage: wgpu::BufferUsages,
 }
 
@@ -23,13 +22,12 @@ impl Buffer {
                 mapped_at_creation: false,
             }),
             label,
-            size,
             usage,
         }
     }
 
     pub fn resize(&mut self, device: &wgpu::Device, new_size: u64) {
-        if new_size > self.size {
+        if new_size > self.raw.size() {
             self.raw = device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some(self.label),
                 size: new_size,


### PR DESCRIPTION
A handful of minor changes and fixes.

1. Vertically align the controls with their labels
2. Correctly use rads when defining the camera's field of view, rather than degrees (which does happen to work fine, but is not what is intended. The original code looks to be taken from the learn WGPU tutorial, which uses `cgmath`, rather than `glam`, which, in turn, uses `Rad` and `Deg` types.)
3. The dynamically resizable `Buffer` never does updates its own `size` value upon `::resize()`. It looks like we can instead rely on the underlying raw buffer's `::size()` when determining whether the raw buffer should be recreated. The pre-existing behaviour recreates the raw buffer every frame, because `size` is initialised to hold just one cube, and thus the condition to create a new buffer is basically always met.