### PR TITLE
Update `cosmic-text` to `0.19.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe782a9e7520cc7de2232c957a47f99d3a35e855552677d07a557bc1a3b66ed"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
@@ -1138,7 +1138,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=1d68895e9c4c9b73739f826e81c2e3012c155cce#1d68895e9c4c9b73739f826e81c2e3012c155cce"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=e429a025df36ab8145708acb309080ae3deec17a#e429a025df36ab8145708acb309080ae3deec17a"
 dependencies = [
  "cosmic-text",
  "etagere",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,8 +199,8 @@ bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
 cargo-hot = { version = "0.1", package = "cargo-hot-protocol" }
-cosmic-text = "0.18"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "1d68895e9c4c9b73739f826e81c2e3012c155cce" }
+cosmic-text = "0.19"
+cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "e429a025df36ab8145708acb309080ae3deec17a" }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 glam = "0.25"
 guillotiere = "0.6"

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -134,6 +134,22 @@ pub fn font_system() -> &'static RwLock<FontSystem> {
         #[cfg(feature = "fira-sans")]
         raw.db_mut().set_sans_serif_family("Fira Sans");
 
+        #[cfg(target_os = "macos")]
+        {
+            #[cfg(not(feature = "fira-sans"))]
+            raw.db_mut().set_sans_serif_family(".SF NS");
+            raw.db_mut().set_serif_family("Times New Roman");
+            raw.db_mut().set_monospace_family("Menlo");
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            #[cfg(not(feature = "fira-sans"))]
+            raw.db_mut().set_sans_serif_family("Segoe UI");
+            raw.db_mut().set_serif_family("Times New Roman");
+            raw.db_mut().set_monospace_family("Consolas");
+        }
+
         RwLock::new(FontSystem {
             raw,
             loaded_fonts: HashSet::new(),

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -268,7 +268,8 @@ pub fn align(
     if needs_relayout {
         log::trace!("Relayouting paragraph...");
 
-        buffer.set_size(font_system, Some(min_bounds.width), Some(min_bounds.height));
+        buffer.set_size(Some(min_bounds.width), Some(min_bounds.height));
+        buffer.shape_until_scroll(font_system, false);
     }
 
     min_bounds

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -46,18 +46,18 @@ impl Cache {
 
             let max_height = key.bounds.height.max(key.line_height);
 
-            buffer.set_size(font_system, Some(key.bounds.width), Some(max_height));
+            buffer.set_size(Some(key.bounds.width), Some(max_height));
 
-            buffer.set_wrap(font_system, text::to_wrap(key.wrapping));
-            buffer.set_ellipsize(font_system, text::to_ellipsize(key.ellipsis, max_height));
+            buffer.set_wrap(text::to_wrap(key.wrapping));
+            buffer.set_ellipsize(text::to_ellipsize(key.ellipsis, max_height));
 
             buffer.set_text(
-                font_system,
                 key.content,
                 &text::to_attributes(key.font),
                 text::to_shaping(key.shaping, key.content),
                 None,
             );
+            buffer.shape_until_scroll(font_system, false);
 
             let bounds = text::align(&mut buffer, font_system, key.align_x);
 

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -93,12 +93,12 @@ impl editor::Editor for Editor {
         let mut font_system = text::font_system().write().expect("Write font system");
 
         buffer.set_text(
-            font_system.raw(),
             text,
             &cosmic_text::Attrs::new(),
             cosmic_text::Shaping::Advanced,
             None,
         );
+        buffer.shape_until_scroll(font_system.raw(), false);
 
         Editor(Some(Arc::new(Internal {
             editor: cosmic_text::Editor::new(buffer),
@@ -547,14 +547,11 @@ impl editor::Editor for Editor {
                 internal.hint = new_hint_factor.is_some();
                 internal.hint_factor = new_hint_factor.unwrap_or(1.0);
 
-                buffer.set_hinting(
-                    font_system.raw(),
-                    if internal.hint {
-                        cosmic_text::Hinting::Enabled
-                    } else {
-                        cosmic_text::Hinting::Disabled
-                    },
-                );
+                buffer.set_hinting(if internal.hint {
+                    cosmic_text::Hinting::Enabled
+                } else {
+                    cosmic_text::Hinting::Disabled
+                });
 
                 hinting_changed = true;
             }
@@ -565,13 +562,10 @@ impl editor::Editor for Editor {
             {
                 log::trace!("Updating `Metrics` of `Editor`...");
 
-                buffer.set_metrics(
-                    font_system.raw(),
-                    cosmic_text::Metrics::new(
-                        new_size.0 * internal.hint_factor,
-                        new_line_height.0 * internal.hint_factor,
-                    ),
-                );
+                buffer.set_metrics(cosmic_text::Metrics::new(
+                    new_size.0 * internal.hint_factor,
+                    new_line_height.0 * internal.hint_factor,
+                ));
             }
 
             let new_wrap = text::to_wrap(new_wrapping);
@@ -579,20 +573,21 @@ impl editor::Editor for Editor {
             if new_wrap != buffer.wrap() {
                 log::trace!("Updating `Wrap` strategy of `Editor`...");
 
-                buffer.set_wrap(font_system.raw(), new_wrap);
+                buffer.set_wrap(new_wrap);
             }
 
             if new_bounds != internal.bounds || hinting_changed {
                 log::trace!("Updating size of `Editor`...");
 
                 buffer.set_size(
-                    font_system.raw(),
                     Some(new_bounds.width * internal.hint_factor),
                     Some(new_bounds.height * internal.hint_factor),
                 );
 
                 internal.bounds = new_bounds;
             }
+
+            buffer.shape_until_scroll(font_system.raw(), false);
 
             if let Some(topmost_line_changed) = internal.topmost_line_changed.take() {
                 log::trace!(

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -82,28 +82,27 @@ impl core::text::Paragraph for Paragraph {
         );
 
         if hint {
-            buffer.set_hinting(font_system.raw(), cosmic_text::Hinting::Enabled);
+            buffer.set_hinting(cosmic_text::Hinting::Enabled);
         }
 
         buffer.set_size(
-            font_system.raw(),
             Some(text.bounds.width * hint_factor),
             Some(text.bounds.height * hint_factor),
         );
 
-        buffer.set_wrap(font_system.raw(), text::to_wrap(text.wrapping));
-        buffer.set_ellipsize(
-            font_system.raw(),
-            text::to_ellipsize(text.ellipsis, text.bounds.height * hint_factor),
-        );
+        buffer.set_wrap(text::to_wrap(text.wrapping));
+        buffer.set_ellipsize(text::to_ellipsize(
+            text.ellipsis,
+            text.bounds.height * hint_factor,
+        ));
 
         buffer.set_text(
-            font_system.raw(),
             text.content,
             &text::to_attributes(text.font),
             text::to_shaping(text.shaping, text.content),
             None,
         );
+        buffer.shape_until_scroll(font_system.raw(), false);
 
         let min_bounds = text::align(&mut buffer, font_system.raw(), text.align_x) / hint_factor;
 
@@ -142,19 +141,17 @@ impl core::text::Paragraph for Paragraph {
         );
 
         if hint {
-            buffer.set_hinting(font_system.raw(), cosmic_text::Hinting::Enabled);
+            buffer.set_hinting(cosmic_text::Hinting::Enabled);
         }
 
         buffer.set_size(
-            font_system.raw(),
             Some(text.bounds.width * hint_factor),
             Some(text.bounds.height * hint_factor),
         );
 
-        buffer.set_wrap(font_system.raw(), text::to_wrap(text.wrapping));
+        buffer.set_wrap(text::to_wrap(text.wrapping));
 
         buffer.set_rich_text(
-            font_system.raw(),
             text.content.iter().enumerate().map(|(i, span)| {
                 let attrs = text::to_attributes(span.font.unwrap_or(text.font));
 
@@ -187,6 +184,8 @@ impl core::text::Paragraph for Paragraph {
             None,
         );
 
+        buffer.shape_until_scroll(font_system.raw(), false);
+
         let min_bounds = text::align(&mut buffer, font_system.raw(), text.align_x) / hint_factor;
 
         Self(Arc::new(Internal {
@@ -211,10 +210,12 @@ impl core::text::Paragraph for Paragraph {
         let mut font_system = text::font_system().write().expect("Write font system");
 
         paragraph.buffer.set_size(
-            font_system.raw(),
             Some(new_bounds.width * paragraph.hint_factor),
             Some(new_bounds.height * paragraph.hint_factor),
         );
+        paragraph
+            .buffer
+            .shape_until_scroll(font_system.raw(), false);
 
         let min_bounds = text::align(&mut paragraph.buffer, font_system.raw(), paragraph.align_x)
             / paragraph.hint_factor;

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -622,7 +622,7 @@ fn prepare(
             }
 
             Some(cryoglyph::TextArea {
-                buffer,
+                text: buffer.layout_runs(),
                 left: position.x,
                 top: position.y,
                 scale,


### PR DESCRIPTION
This PR updates `cosmic-text` to its latest release: `0.19.0`. See https://github.com/pop-os/cosmic-text/releases/tag/0.19.0.

Also, it sets default fonts explicitly for both Windows and macOS, which should avoid hitting font fallback logic unnecessarily.

On my MacBook, I get a considerable speedup in some of our benchmarks:

<img width="966" height="511" alt="image" src="https://github.com/user-attachments/assets/8303335b-49f7-4fc1-8fbc-dd635263d077" />


