### PR TITLE
Enable synchronous image loading to prevent flicker

### DIFF
--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -30,6 +30,9 @@ pub struct Image<H = Handle> {
     ///
     /// 0 means transparent. 1 means opaque.
     pub opacity: f32,
+
+    /// Don't render the next frame until the image is ready to display.
+    pub load_blocking: bool,
 }
 
 impl Image<Handle> {
@@ -41,6 +44,7 @@ impl Image<Handle> {
             rotation: Radians(0.0),
             border_radius: border::Radius::default(),
             opacity: 1.0,
+            load_blocking: false,
         }
     }
 
@@ -59,6 +63,13 @@ impl Image<Handle> {
     /// Sets the opacity of the [`Image`].
     pub fn opacity(mut self, opacity: impl Into<f32>) -> Self {
         self.opacity = opacity.into();
+        self
+    }
+
+    /// When set to `true`, the renderer will block until the image is
+    /// ready to display to prevent flickering. Defaults to `false`.
+    pub fn load_blocking(mut self, load_blocking: bool) -> Self {
+        self.load_blocking = load_blocking;
         self
     }
 }

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -182,6 +182,10 @@ where
     }
 
     fn draw_image(&mut self, image: Image<A::Handle>, bounds: Rectangle, clip_bounds: Rectangle) {
+        if image.load_blocking {
+            let _ = self.load_image(&image.handle);
+        }
+
         delegate!(
             self,
             renderer,

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -366,6 +366,10 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
+        if image.load_blocking {
+            let _ = self.load_image(&image.handle);
+        }
+
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -795,6 +795,10 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
+        if image.load_blocking {
+            let _ = self.load_image(&image.handle);
+        }
+
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -66,6 +66,7 @@ pub struct Image<Handle = image::Handle> {
     opacity: f32,
     scale: f32,
     expand: bool,
+    load_blocking: bool,
 }
 
 impl<Handle> Image<Handle> {
@@ -83,6 +84,7 @@ impl<Handle> Image<Handle> {
             opacity: 1.0,
             scale: 1.0,
             expand: false,
+            load_blocking: false,
         }
     }
 
@@ -175,6 +177,13 @@ impl<Handle> Image<Handle> {
         self.border_radius = border_radius.into();
         self
     }
+
+    /// When set to `true`, the renderer will block until the image is
+    /// ready to display to prevent flickering. Defaults to `false`.
+    pub fn load_blocking(mut self, load_blocking: bool) -> Self {
+        self.load_blocking = load_blocking;
+        self
+    }
 }
 
 /// Computes the layout of an [`Image`].
@@ -188,10 +197,17 @@ pub fn layout<Renderer, Handle>(
     content_fit: ContentFit,
     rotation: Rotation,
     expand: bool,
+    load_blocking: bool,
 ) -> layout::Node
 where
     Renderer: image::Renderer<Handle = Handle>,
 {
+    // When load_blocking is true, ensure the image is loaded synchronously
+    // before measuring so that `measure_image` returns the correct dimensions
+    if load_blocking {
+        let _ = renderer.load_image(handle);
+    }
+
     // The raw w/h of the underlying image
     let image_size = crop(renderer.measure_image(handle).unwrap_or_default(), region);
 
@@ -315,6 +331,7 @@ pub fn draw<Renderer, Handle>(
     rotation: Rotation,
     opacity: f32,
     scale: f32,
+    load_blocking: bool,
 ) where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone,
@@ -330,6 +347,7 @@ pub fn draw<Renderer, Handle>(
             filter_method,
             rotation: rotation.radians(),
             opacity,
+            load_blocking,
         },
         drawing_bounds,
         bounds,
@@ -364,6 +382,7 @@ where
             self.content_fit,
             self.rotation,
             self.expand,
+            self.load_blocking,
         )
     }
 
@@ -388,6 +407,7 @@ where
             self.rotation,
             self.opacity,
             self.scale,
+            self.load_blocking,
         );
     }
 }

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -334,6 +334,7 @@ where
                         filter_method: self.filter_method,
                         rotation: Radians(0.0),
                         opacity: 1.0,
+                        load_blocking: false,
                     },
                     drawing_bounds,
                     *viewport - translation,


### PR DESCRIPTION
Problem: Asynchronous image loading introduced here https://github.com/iced-rs/iced/pull/3092 causes images to not render immediately, which is a big problem for applications that need to seamlessly change images. The `image::allocate` task that was added to address that problem is cumbersome to use and clutters up the application logic. For an immediate mode renderer like Iced, immediate image rendering should work without jumping through any hoops.

Solution: Add a <s>feature flag "instant-images"</s> method to the image widget to disable asynchronous image loading. <s>The fix is based on this commit https://github.com/iced-rs/iced/commit/5216253998cadc29b0933ac4f30a8101b423941a which does the same thing for wasm32, but toggles it with a feature rather than an architecture.</s>