### PR TITLE
`transition` widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ version = "0.15.0-dev"
 dependencies = [
  "iced_highlighter",
  "iced_renderer",
+ "iced_runtime",
  "log",
  "num-traits",
  "ouroboros",

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -129,6 +129,13 @@ where
     }
 }
 
+impl Animation<f32> {
+    /// Projects the [`Animation`] into an interpolated value at the given [`Instant`].
+    pub fn interpolate(&self, at: Instant) -> f32 {
+        self.interpolate_with(std::convert::identity, at)
+    }
+}
+
 impl Animation<bool> {
     /// Projects the [`Animation`] into an interpolated value at the given [`Instant`]; using the
     /// `start` and `end` values as the origin and destination keyframes.

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -351,7 +351,6 @@ fn responsive_<'a>() -> Element<'a, Message> {
             .width(size.width / 4.0)
             .height(size.width / 4.0)
             .style(container::bordered_box)
-            .into()
         })
         .width(Shrink)
         .height(Shrink),
@@ -365,7 +364,6 @@ fn responsive_<'a>() -> Element<'a, Message> {
             .width(size.width)
             .height(size.height)
             .style(container::bordered_box)
-            .into()
         })
         .width(Shrink)
         .height(Shrink)

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,7 +1,7 @@
-use iced::Element;
 use iced::widget::{
-    center, center_x, checkbox, column, progress_bar, row, slider, vertical_slider,
+    center, center_x, checkbox, column, progress_bar, row, slider, transition, vertical_slider,
 };
+use iced::{Animation, Element};
 
 pub fn main() -> iced::Result {
     iced::run(Progress::update, Progress::view)
@@ -28,7 +28,17 @@ impl Progress {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let bar = progress_bar(0.0..=100.0, self.value).vertical(self.is_vertical);
+        let bar = transition(
+            self.value,
+            || Animation::new(0.).quick(),
+            |animation, at| {
+                progress_bar(
+                    0.0..=100.0,
+                    animation.interpolate_with(std::convert::identity, at),
+                )
+                .vertical(self.is_vertical)
+            },
+        );
 
         column![
             if self.is_vertical {

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,3 +1,4 @@
+use iced::animation;
 use iced::widget::{
     center, center_x, checkbox, column, progress_bar, row, slider, transition, vertical_slider,
 };
@@ -30,7 +31,11 @@ impl Progress {
     fn view(&self) -> Element<'_, Message> {
         let bar = transition(
             self.value,
-            || Animation::new(0.).quick(),
+            || {
+                Animation::new(0.)
+                    .slow()
+                    .easing(animation::Easing::EaseOutBounce)
+            },
             |animation, at| {
                 progress_bar(
                     0.0..=100.0,
@@ -45,7 +50,7 @@ impl Progress {
                 center(
                     row![
                         bar,
-                        vertical_slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01)
+                        vertical_slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01),
                     ]
                     .spacing(20),
                 )

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -37,11 +37,7 @@ impl Progress {
                     .easing(animation::Easing::EaseOutBounce)
             },
             |animation, at| {
-                progress_bar(
-                    0.0..=100.0,
-                    animation.interpolate_with(std::convert::identity, at),
-                )
-                .vertical(self.is_vertical)
+                progress_bar(0.0..=100.0, animation.interpolate(at)).vertical(self.is_vertical)
             },
         );
 

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -28,13 +28,13 @@ impl Progress {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let bar = progress_bar(0.0..=100.0, self.value);
+        let bar = progress_bar(0.0..=100.0, self.value).vertical(self.is_vertical);
 
         column![
             if self.is_vertical {
                 center(
                     row![
-                        bar.vertical(),
+                        bar,
                         vertical_slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01)
                     ]
                     .spacing(20),

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -30,6 +30,7 @@ advanced = []
 
 [dependencies]
 iced_renderer.workspace = true
+iced_runtime.workspace = true
 
 num-traits.workspace = true
 log.workspace = true

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -4,7 +4,6 @@ use crate::checkbox::{self, Checkbox};
 use crate::combo_box::{self, ComboBox};
 use crate::container::{self, Container};
 use crate::core;
-use crate::core::animation::{self, Animation};
 use crate::core::theme;
 use crate::core::time::Instant;
 use crate::core::widget::operation::{self, Operation};
@@ -24,7 +23,7 @@ use crate::text_editor::{self, TextEditor};
 use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
 use crate::tooltip::{self, Tooltip};
-use crate::transition::Transition;
+use crate::transition::{self, Transition};
 use crate::vertical_slider::{self, VerticalSlider};
 use crate::{Column, Grid, MouseArea, Pin, Responsive, Row, Sensor, Space, Stack, Themer};
 
@@ -2064,18 +2063,39 @@ where
 
 /// Creates a new [`Transition`].
 ///
-/// The `init` closure will be used to initialize the [`Animation`].
+/// The `init` closure will be used to initialize an implementor of [`Program`]. This is normally
+/// an [`Animation`](crate::core::Animation), but you can implement [`Program`] on your own types
+/// as well.
 ///
-/// The `view` closure will receive the [`Animation`] and an [`Instant`], which can be used for interpolating values.
-/// This will be called every frame until the given `target_value` is reached.
-pub fn transition<'a, Message, Theme, Renderer, I>(
-    init: impl Fn() -> Animation<I> + 'a,
-    target_value: I,
-    view: impl Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
-) -> Transition<'a, Message, Theme, Renderer, Animation<I>>
+/// The `view` closure will receive the [`Program`] and the current [`Instant`], which can be used for interpolating values.
+/// When the `value` changes, this will be called every frame, until the [`Program`] stops animating.
+///
+/// [`Program`]: transition::Program
+///
+/// # Example
+///
+/// Here is how you could implement a smooth progress bar:
+///
+/// ```
+/// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::core::Animation; }
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+/// use iced::widget::{transition, progress_bar};
+/// use iced::Animation;
+///
+/// fn smooth_progress_bar<'a, Message: 'a>(progress: f32) -> Element<'a, Message> {
+///     transition(progress, || Animation::new(0.).quick(), |animation, now| {
+///         progress_bar(0.0..=1.0, animation.interpolate_with(std::convert::identity, now)).into()
+///     }).into()
+/// }
+/// ```
+pub fn transition<'a, Message, Theme, Renderer, P>(
+    value: P::Value,
+    init: impl Fn() -> P + 'a,
+    view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+) -> Transition<'a, Message, Theme, Renderer, P>
 where
     Renderer: core::Renderer,
-    I: animation::Float + Clone + Copy + PartialEq + 'static,
+    P: transition::Program,
 {
-    Transition::new(init, target_value, view)
+    Transition::new(init, value, view)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -2070,7 +2070,7 @@ pub fn transition<'a, Message, Theme, Renderer, I>(
     init: impl Fn() -> Animation<I> + 'a,
     target_value: I,
     view: impl Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
-) -> Transition<'a, Message, Theme, Renderer, I>
+) -> Transition<'a, Message, Theme, Renderer, Animation<I>>
 where
     Renderer: core::Renderer,
     I: animation::Float + Clone + Copy + PartialEq + 'static,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -2062,10 +2062,12 @@ where
     Responsive::new(f)
 }
 
-/// Creates a new [`Transition`] widget with a closure to initialize the [`Animation`],
-/// a value to transition to, and another closure to produce its contents.
+/// Creates a new [`Transition`].
 ///
-/// TODO
+/// The `init` closure will be used to initialize the [`Animation`].
+///
+/// The `view` closure will receive the [`Animation`] and an [`Instant`], which can be used for interpolating values.
+/// This will be called every frame until the given `target_value` is reached.
 pub fn transition<'a, Message, Theme, Renderer, I>(
     init: impl Fn() -> Animation<I> + 'a,
     target_value: I,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -2068,18 +2068,19 @@ where
 ///
 /// fn smooth_progress_bar<'a, Message: 'a>(progress: f32) -> Element<'a, Message> {
 ///     transition(progress, || Animation::new(0.).quick(), |animation, now| {
-///         progress_bar(0.0..=1.0, animation.interpolate_with(std::convert::identity, now)).into()
+///         progress_bar(0.0..=1.0, animation.interpolate_with(std::convert::identity, now))
 ///     }).into()
 /// }
 /// ```
-pub fn transition<'a, Message, Theme, Renderer, P>(
+pub fn transition<'a, Message, Theme, Renderer, P, E>(
     value: P::Value,
     init: impl Fn() -> P + 'a,
-    view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+    view: impl Fn(&P, Instant) -> E + 'a,
 ) -> Transition<'a, Message, Theme, Renderer, P>
 where
     Renderer: core::Renderer,
     P: transition::Program,
+    E: Into<Element<'a, Message, Theme, Renderer>>,
 {
     Transition::new(init, value, view)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -2036,11 +2036,12 @@ where
 /// The `view` closure will receive the maximum available space for
 /// the [`Responsive`] during layout. You can use this [`Size`] to
 /// conditionally build the contents.
-pub fn responsive<'a, Message, Theme, Renderer>(
-    f: impl Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a,
+pub fn responsive<'a, Message, Theme, Renderer, E>(
+    f: impl Fn(Size) -> E + 'a,
 ) -> Responsive<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
+    E: Into<Element<'a, Message, Theme, Renderer>>,
 {
     Responsive::new(f)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -4,7 +4,9 @@ use crate::checkbox::{self, Checkbox};
 use crate::combo_box::{self, ComboBox};
 use crate::container::{self, Container};
 use crate::core;
+use crate::core::animation::{self, Animation};
 use crate::core::theme;
+use crate::core::time::Instant;
 use crate::core::widget::operation::{self, Operation};
 use crate::core::window;
 use crate::core::{Element, Length, Size, Widget};
@@ -22,6 +24,7 @@ use crate::text_editor::{self, TextEditor};
 use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
 use crate::tooltip::{self, Tooltip};
+use crate::transition::Transition;
 use crate::vertical_slider::{self, VerticalSlider};
 use crate::{Column, Grid, MouseArea, Pin, Responsive, Row, Sensor, Space, Stack, Themer};
 
@@ -2057,4 +2060,20 @@ where
     Renderer: core::Renderer,
 {
     Responsive::new(f)
+}
+
+/// Creates a new [`Transition`] widget with a closure to initialize the [`Animation`],
+/// a value to transition to, and another closure to produce its contents.
+///
+/// TODO
+pub fn transition<'a, Message, Theme, Renderer, I>(
+    init: impl Fn() -> Animation<I> + 'a,
+    target_value: I,
+    view: impl Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+) -> Transition<'a, Message, Theme, Renderer, I>
+where
+    Renderer: core::Renderer,
+    I: animation::Float + Clone + Copy + PartialEq + 'static,
+{
+    Transition::new(init, target_value, view)
 }

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -41,6 +41,7 @@ pub mod text_editor;
 pub mod text_input;
 pub mod toggler;
 pub mod tooltip;
+pub mod transition;
 pub mod vertical_slider;
 
 mod helpers;

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -101,8 +101,8 @@ where
     /// Turns the [`ProgressBar`] into a vertical [`ProgressBar`].
     ///
     /// By default, a [`ProgressBar`] is horizontal.
-    pub fn vertical(mut self) -> Self {
-        self.is_vertical = true;
+    pub fn vertical(mut self, vertical: bool) -> Self {
+        self.is_vertical = vertical;
         self
     }
 

--- a/widget/src/responsive.rs
+++ b/widget/src/responsive.rs
@@ -28,9 +28,12 @@ where
     /// The `view` closure will receive the maximum available space for
     /// the [`Responsive`] during layout. You can use this [`Size`] to
     /// conditionally build the contents.
-    pub fn new(view: impl Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a) -> Self {
+    pub fn new<E>(view: impl Fn(Size) -> E + 'a) -> Self
+    where
+        E: Into<Element<'a, Message, Theme, Renderer>>,
+    {
         Self {
-            view: Box::new(view),
+            view: Box::new(move |size| view(size).into()),
             width: Length::Fill,
             height: Length::Fill,
             content: Element::new(space()),

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -9,7 +9,7 @@ use crate::core::renderer;
 use crate::core::shell;
 use crate::core::time::Instant;
 use crate::core::widget::{self, Operation, Tree, tree};
-use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
+use crate::core::{self, Element, Event, Length, Point, Rectangle, Shell, Size, Vector, Widget};
 use crate::space;
 
 /// The logic of a [`Transition`].
@@ -49,6 +49,9 @@ where
     view: Box<dyn Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
     on_finish: Option<Box<dyn Fn() -> Message + 'a>>,
     element: Element<'a, Message, Theme, Renderer>,
+    next_element: Option<Element<'a, Message, Theme, Renderer>>,
+    last_limits: layout::Limits,
+    new_layout: Option<layout::Node>,
     key: Key,
     id: Option<widget::Id>,
     value: P::Value,
@@ -78,6 +81,9 @@ where
             view: Box::new(move |program, at| view(program, at).into()),
             on_finish: None,
             element: Element::new(space()),
+            next_element: None,
+            new_layout: None,
+            last_limits: layout::Limits::new(Size::ZERO, Size::ZERO),
             key: Key::default(),
             id: None,
             value,
@@ -160,6 +166,7 @@ where
             instant: Instant::now(),
             key: self.key,
             should_reset: false,
+            size: None,
         })
     }
 
@@ -178,7 +185,12 @@ where
             *should_reset = false;
         }
 
-        self.element = (self.view)(animation, *instant);
+        if let Some(next_element) = self.next_element.take() {
+            self.element = next_element;
+        } else {
+            self.element = (self.view)(animation, *instant);
+        }
+
         tree.diff_children(std::slice::from_mut(&mut self.element));
     }
 
@@ -188,6 +200,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        self.last_limits = *limits;
+        self.new_layout = None;
+
         self.element
             .as_widget_mut()
             .layout(&mut tree.children[0], renderer, &limits.loose())
@@ -208,36 +223,62 @@ where
                 animation,
                 instant,
                 should_reset,
+                size,
                 ..
             } = tree.state.downcast_mut();
 
-            let was_animating = animation.is_animating(*instant);
-
-            if *should_reset {
-                *animation = (self.init)();
-                *should_reset = false;
-            }
-
-            *instant = *redraw;
-            animation.go(self.value, *instant);
-
-            let is_animating = animation.is_animating(*instant);
-            let just_finished = was_animating && !is_animating;
-
-            if is_animating || just_finished {
-                shell.invalidate_layout_with(shell::Diff::Perform);
+            if instant == redraw {
                 shell.request_redraw();
-            }
+            } else {
+                let was_animating = animation.is_animating(*instant);
 
-            if just_finished && let Some(on_finish) = &self.on_finish {
-                shell.publish(on_finish());
+                if *should_reset {
+                    *animation = (self.init)();
+                    *should_reset = false;
+                }
+
+                *instant = *redraw;
+                animation.go(self.value, *instant);
+
+                let is_animating = animation.is_animating(*instant);
+                let just_finished = was_animating && !is_animating;
+
+                if is_animating || just_finished {
+                    let size = *size;
+
+                    let mut new = (self.view)(animation, *instant);
+                    tree.diff_children(&mut [new.as_widget_mut()]);
+
+                    let new_size = new.as_widget().size();
+
+                    if size != Some(new_size) {
+                        self.next_element = Some(new);
+                        shell.invalidate_layout_with(shell::Diff::Perform);
+
+                        let state = tree.state.downcast_mut::<State<P>>();
+                        state.size = Some(new_size);
+                    } else {
+                        self.element = new;
+                        self.new_layout = Some(self.element.as_widget_mut().layout(
+                            &mut tree.children[0],
+                            renderer,
+                            &self.last_limits,
+                        ));
+                    }
+
+                    shell.request_redraw();
+                }
+
+                if just_finished && let Some(on_finish) = &self.on_finish {
+                    shell.publish(on_finish());
+                }
             }
         }
 
         self.element.as_widget_mut().update(
             &mut tree.children[0],
             event,
-            layout,
+            self::layout(layout, &self.new_layout),
             cursor,
             renderer,
             shell,
@@ -260,7 +301,7 @@ where
             renderer,
             theme,
             style,
-            layout,
+            self::layout(layout, &self.new_layout),
             cursor,
             viewport,
         );
@@ -276,7 +317,7 @@ where
     ) -> mouse::Interaction {
         self.element.as_widget().mouse_interaction(
             &tree.children[0],
-            layout,
+            self::layout(layout, &self.new_layout),
             cursor,
             viewport,
             renderer,
@@ -290,6 +331,8 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
+        let layout = self::layout(layout, &self.new_layout);
+
         let mut should_reset = ShouldReset(false);
         operation.custom(self.id.as_ref(), layout.bounds(), &mut should_reset);
 
@@ -312,7 +355,7 @@ where
     ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         self.element.as_widget_mut().overlay(
             &mut tree.children[0],
-            layout,
+            self::layout(layout, &self.new_layout),
             renderer,
             viewport,
             translation,
@@ -338,6 +381,7 @@ struct State<P: Program> {
     instant: Instant,
     key: Key,
     should_reset: bool,
+    size: Option<Size<Length>>,
 }
 
 #[derive(Default, Clone, Copy, Hash, PartialEq, Eq)]
@@ -386,4 +430,11 @@ pub fn reset_raw(id: impl Into<widget::Id>) -> impl Operation {
     }
 
     Reset(id.into())
+}
+
+fn layout<'a>(current: Layout<'a>, animated: &'a Option<layout::Node>) -> Layout<'a> {
+    animated
+        .as_ref()
+        .map(|new_layout| Layout::with_offset(current.position() - Point::ORIGIN, new_layout))
+        .unwrap_or(current)
 }

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -1,0 +1,342 @@
+//! A widget to make animated views.
+//!
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use iced_renderer::core::widget::tree;
+
+use crate::core::animation::{Animation, Float};
+use crate::core::layout::{self, Layout};
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::time::Instant;
+use crate::core::widget::{self, Operation, Tree};
+use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
+use crate::space;
+
+/// TODO
+pub struct Transition<'a, Message, Theme, Renderer, I>
+where
+    I: Float + Clone + Copy + PartialEq + 'static,
+{
+    init: Box<dyn Fn() -> Animation<I> + 'a>,
+    view: Box<dyn Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
+    element: Element<'a, Message, Theme, Renderer>,
+    width: Length,
+    height: Length,
+    key: Key,
+    id: Option<widget::Id>,
+    target_value: I,
+}
+
+impl<'a, Message, Theme, Renderer, I> Transition<'a, Message, Theme, Renderer, I>
+where
+    Renderer: core::Renderer,
+    I: Float + Clone + Copy + PartialEq + 'static,
+{
+    /// TODO
+    pub fn new(
+        init: impl Fn() -> Animation<I> + 'a,
+        target_value: I,
+        view: impl Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+    ) -> Self {
+        Self {
+            init: Box::new(init),
+            view: Box::new(view),
+            width: Length::Fill,
+            height: Length::Fill,
+            element: Element::new(space()),
+            key: Key::default(),
+            id: None,
+            target_value,
+        }
+    }
+
+    /// Sets the width of the [`Transition`].
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the height of the [`Transition`].
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    /// Sets the [`Id`] of the [`Transition`].
+    ///
+    /// The [`Id`] can subsequently be used to reset the [`Animation`] via [`reset`].
+    pub fn id(mut self, id: impl Into<widget::Id>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Sets the key of the [`Transition`] widget for continuity.
+    ///
+    /// Changing the key will reset the [`Animation`].
+    pub fn key(mut self, key: impl Hash) -> Self {
+        self.key = Key::new(key);
+        self
+    }
+}
+
+impl<Message, Theme, Renderer, I> Widget<Message, Theme, Renderer>
+    for Transition<'_, Message, Theme, Renderer, I>
+where
+    Renderer: core::Renderer,
+    I: Float + Clone + Copy + PartialEq + 'static,
+{
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State<I>>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State {
+            animation: (self.init)(),
+            instant: Instant::now(),
+            key: self.key,
+            should_reset: false,
+            target_value: self.target_value,
+        })
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        let State::<I> {
+            animation,
+            key: old_key,
+            should_reset,
+            ..
+        } = tree.state.downcast_mut();
+
+        if *old_key != self.key {
+            *old_key = self.key;
+            *animation = (self.init)();
+            *should_reset = false;
+        }
+
+        // Diff is deferred to layout
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let State::<I> {
+            animation, instant, ..
+        } = tree.state.downcast_ref();
+
+        self.element = (self.view)(animation, *instant);
+        let limits = limits.width(self.width).height(self.height);
+
+        tree.diff_children(std::slice::from_ref(&self.element));
+
+        let node =
+            self.element
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, &limits.loose());
+
+        let size = limits.resolve(self.width, self.height, node.size());
+
+        layout::Node::with_children(size, vec![node])
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.element.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            shell,
+            viewport,
+        );
+
+        let State::<I> {
+            animation,
+            instant,
+            should_reset,
+            target_value,
+            ..
+        } = tree.state.downcast_mut();
+
+        let mut target_changed = *target_value != self.target_value;
+
+        if let core::Event::Window(core::window::Event::RedrawRequested(redraw)) = event {
+            if *should_reset {
+                *animation = (self.init)();
+                *should_reset = false;
+            }
+
+            if target_changed {
+                *target_value = self.target_value;
+                target_changed = false;
+            }
+
+            *instant = *redraw;
+            animation.go_mut(self.target_value, *instant);
+        }
+
+        if animation.is_animating(*instant) || *should_reset || target_changed {
+            shell.invalidate_layout();
+            shell.request_redraw();
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.element.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            style,
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.element.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation,
+    ) {
+        let State::<I> { should_reset, .. } = tree.state.downcast_mut();
+        let mut should_reset_new = ShouldReset(*should_reset);
+
+        operation.custom(self.id.as_ref(), layout.bounds(), &mut should_reset_new);
+        *should_reset = should_reset_new.0;
+
+        self.element.as_widget_mut().operate(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            operation,
+        );
+    }
+
+    fn overlay<'a>(
+        &'a mut self,
+        tree: &'a mut Tree,
+        layout: Layout<'a>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
+        self.element.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer, I> From<Transition<'a, Message, Theme, Renderer, I>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: core::Renderer + 'a,
+    I: Float + Clone + Copy + PartialEq + 'static,
+{
+    fn from(transition: Transition<'a, Message, Theme, Renderer, I>) -> Self {
+        Self::new(transition)
+    }
+}
+
+struct State<I>
+where
+    I: Float + Clone + Copy + PartialEq + 'static,
+{
+    animation: Animation<I>,
+    instant: Instant,
+    key: Key,
+    should_reset: bool,
+    target_value: I,
+}
+
+#[derive(Default, Clone, Copy, Hash, PartialEq, Eq)]
+struct Key(u64);
+
+impl Key {
+    fn new(data: impl Hash) -> Self {
+        let mut hasher = DefaultHasher::new();
+        data.hash(&mut hasher);
+        Self(hasher.finish())
+    }
+}
+
+struct ShouldReset(bool);
+
+/// Reset the [`Animation`] state of the [`Transition`] widget.
+pub fn reset(id: impl Into<widget::Id>) -> impl Operation {
+    struct Reset(widget::Id);
+
+    impl Operation for Reset {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<()>)) {
+            operate(self)
+        }
+
+        fn custom(
+            &mut self,
+            id: Option<&widget::Id>,
+            _bounds: Rectangle,
+            state: &mut dyn std::any::Any,
+        ) {
+            if id == Some(&self.0)
+                && let Some(ShouldReset(should_reset)) = state.downcast_mut()
+            {
+                *should_reset = true;
+            }
+        }
+    }
+
+    Reset(id.into())
+}

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -191,16 +191,16 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
-        let State::<P> {
-            animation,
-            instant,
-            should_reset,
-            ..
-        } = tree.state.downcast_mut();
-
-        let was_animating = animation.is_animating(*instant);
-
         if let core::Event::Window(core::window::Event::RedrawRequested(redraw)) = event {
+            let State::<P> {
+                animation,
+                instant,
+                should_reset,
+                ..
+            } = tree.state.downcast_mut();
+
+            let was_animating = animation.is_animating(*instant);
+
             if *should_reset {
                 *animation = (self.init)();
                 *should_reset = false;
@@ -208,14 +208,14 @@ where
 
             *instant = *redraw;
             animation.tick(self.target_value, *instant);
-        }
 
-        let is_animating = animation.is_animating(*instant);
-        let just_finished = was_animating && !is_animating;
+            let is_animating = animation.is_animating(*instant);
+            let just_finished = was_animating && !is_animating;
 
-        if is_animating || *should_reset || just_finished {
-            shell.invalidate_layout();
-            shell.request_redraw();
+            if is_animating || just_finished {
+                shell.invalidate_layout();
+                shell.request_redraw();
+            }
         }
 
         self.element.as_widget_mut().update(

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -213,10 +213,7 @@ where
         let is_animating = animation.is_animating(*instant);
         let just_finished = was_animating && !is_animating;
 
-        if is_animating || *should_reset {
-            shell.invalidate_layout();
-            shell.request_redraw();
-        } else if just_finished {
+        if is_animating || *should_reset || just_finished {
             shell.invalidate_layout();
             shell.request_redraw();
         }
@@ -357,7 +354,7 @@ pub fn reset_raw(id: impl Into<widget::Id>) -> impl Operation {
 
     impl Operation for Reset {
         fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<()>)) {
-            operate(self)
+            operate(self);
         }
 
         fn custom(

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -49,8 +49,6 @@ where
     view: Box<dyn Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
     on_finish: Option<Box<dyn Fn() -> Message + 'a>>,
     element: Element<'a, Message, Theme, Renderer>,
-    width: Length,
-    height: Length,
     key: Key,
     id: Option<widget::Id>,
     value: P::Value,
@@ -76,25 +74,11 @@ where
             init: Box::new(init),
             view: Box::new(view),
             on_finish: None,
-            width: Length::Fill,
-            height: Length::Fill,
             element: Element::new(space()),
             key: Key::default(),
             id: None,
             value,
         }
-    }
-
-    /// Sets the width of the [`Transition`].
-    pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
-        self
-    }
-
-    /// Sets the height of the [`Transition`].
-    pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
-        self
     }
 
     /// Sets the [`widget::Id`] of the [`Transition`].
@@ -160,10 +144,7 @@ where
     P: Program,
 {
     fn size(&self) -> Size<Length> {
-        Size {
-            width: self.width,
-            height: self.height,
-        }
+        self.element.as_widget().size()
     }
 
     fn tag(&self) -> tree::Tag {
@@ -204,16 +185,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-
-        let node =
-            self.element
-                .as_widget_mut()
-                .layout(&mut tree.children[0], renderer, &limits.loose());
-
-        let size = limits.resolve(self.width, self.height, node.size());
-
-        layout::Node::with_children(size, vec![node])
+        self.element
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, &limits.loose())
     }
 
     fn update(
@@ -260,7 +234,7 @@ where
         self.element.as_widget_mut().update(
             &mut tree.children[0],
             event,
-            layout.children().next().unwrap(),
+            layout,
             cursor,
             renderer,
             shell,
@@ -283,7 +257,7 @@ where
             renderer,
             theme,
             style,
-            layout.children().next().unwrap(),
+            layout,
             cursor,
             viewport,
         );
@@ -299,7 +273,7 @@ where
     ) -> mouse::Interaction {
         self.element.as_widget().mouse_interaction(
             &tree.children[0],
-            layout.children().next().unwrap(),
+            layout,
             cursor,
             viewport,
             renderer,
@@ -320,12 +294,9 @@ where
             tree.state.downcast_mut::<State<P>>().should_reset = true;
         }
 
-        self.element.as_widget_mut().operate(
-            &mut tree.children[0],
-            layout.children().next().unwrap(),
-            renderer,
-            operation,
-        );
+        self.element
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
     }
 
     fn overlay<'a>(
@@ -338,7 +309,7 @@ where
     ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         self.element.as_widget_mut().overlay(
             &mut tree.children[0],
-            layout.children().next().unwrap(),
+            layout,
             renderer,
             viewport,
             translation,

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -342,8 +342,17 @@ impl Key {
 
 struct ShouldReset(bool);
 
-/// Reset the [`Animation`] state of the [`Transition`] widget.
-pub fn reset(id: impl Into<widget::Id>) -> impl Operation {
+/// Reset the [`Animation`] of a [`Transition`].
+pub fn reset<Message>(id: impl Into<widget::Id>) -> iced_runtime::Task<Message>
+where
+    Message: iced_runtime::futures::MaybeSend + 'static,
+{
+    let id = id.into();
+    iced_runtime::task::widget(reset_raw(id)).discard()
+}
+
+/// An [`Operation`] to reset the [`Animation`] of a [`Transition`].
+pub fn reset_raw(id: impl Into<widget::Id>) -> impl Operation {
     struct Reset(widget::Id);
 
     impl Operation for Reset {

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -102,7 +102,6 @@ where
             instant: Instant::now(),
             key: self.key,
             should_reset: false,
-            target_value: self.target_value,
         })
     }
 
@@ -162,22 +161,15 @@ where
             animation,
             instant,
             should_reset,
-            target_value,
             ..
         } = tree.state.downcast_mut();
 
-        let mut target_changed = *target_value != self.target_value;
         let was_animating = animation.is_animating(*instant);
 
         if let core::Event::Window(core::window::Event::RedrawRequested(redraw)) = event {
             if *should_reset {
                 *animation = (self.init)();
                 *should_reset = false;
-            }
-
-            if target_changed {
-                *target_value = self.target_value;
-                target_changed = false;
             }
 
             *instant = *redraw;
@@ -187,7 +179,7 @@ where
         let is_animating = animation.is_animating(*instant);
         let just_finished = was_animating && !is_animating;
 
-        if is_animating || *should_reset || target_changed {
+        if is_animating || *should_reset {
             shell.invalidate_layout();
             shell.request_redraw();
         } else if just_finished {
@@ -304,7 +296,6 @@ where
     instant: Instant,
     key: Key,
     should_reset: bool,
-    target_value: I,
 }
 
 #[derive(Default, Clone, Copy, Hash, PartialEq, Eq)]

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -1,5 +1,4 @@
 //! A widget to make animated views.
-//!
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use crate::core::animation::{Animation, Float};
@@ -12,15 +11,18 @@ use crate::core::widget::{self, Operation, Tree, tree};
 use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
 use crate::space;
 
-/// TODO
+/// The logic of a [`Transition`].
+///
+/// A [`Program`] can be used to group several [`Animation`]s when used with [`grouped`].
 pub trait Program: 'static {
-    /// TODO
+    /// The type of value the [`Program`] transitions its state to.
     type Target: Copy + 'static;
 
-    /// TODO
+    /// Transitions the [`Program`] from its current state
+    /// towards the target value at the given time.
     fn tick(&mut self, target: Self::Target, now: Instant);
 
-    /// TODO
+    /// Returns true if the [`Program`] is currently in progress.
     fn is_animating(&self, now: Instant) -> bool;
 }
 
@@ -39,7 +41,7 @@ where
     }
 }
 
-/// TODO
+/// A widget that can be used to animate its contents.
 pub struct Transition<'a, Message, Theme, Renderer, P>
 where
     P: Program,
@@ -59,7 +61,12 @@ where
     Renderer: core::Renderer,
     P: Program,
 {
-    /// TODO
+    /// Creates a new [`Transition`].
+    ///
+    /// The `init` closure will be used to initialize an animation.
+    ///
+    /// The `view` closure will receive the animation and an [`Instant`], which can be used for interpolating values.
+    /// This will be called every frame until the given `target_value` is reached.
     pub fn new(
         init: impl Fn() -> P + 'a,
         target_value: P::Target,
@@ -89,9 +96,9 @@ where
         self
     }
 
-    /// Sets the [`Id`] of the [`Transition`].
+    /// Sets the [`widget::Id`] of the [`Transition`].
     ///
-    /// The [`Id`] can subsequently be used to reset the [`Animation`] via [`reset`].
+    /// The [`widget::Id`] can subsequently be used to reset the [`Animation`] via [`reset`].
     pub fn id(mut self, id: impl Into<widget::Id>) -> Self {
         self.id = Some(id.into());
         self
@@ -361,7 +368,9 @@ pub fn reset(id: impl Into<widget::Id>) -> impl Operation {
     Reset(id.into())
 }
 
-/// TODO
+/// Creates a new [`Transition`] widget with a custom [`Program`].
+///
+/// This can be useful if you need to use multiple [`Animation`]s without resorting to nesting [`Transition`]s.
 pub fn grouped<'a, Message, Theme, Renderer, P>(
     init: impl Fn() -> P + 'a,
     target_value: P::Target,

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -65,14 +65,17 @@ where
     ///
     /// The `view` closure will receive the animation and an [`Instant`], which can be used for interpolating values.
     /// This will be called every frame until the given `value` is reached.
-    pub fn new(
+    pub fn new<E>(
         init: impl Fn() -> P + 'a,
         value: P::Value,
-        view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
-    ) -> Self {
+        view: impl Fn(&P, Instant) -> E + 'a,
+    ) -> Self
+    where
+        E: Into<Element<'a, Message, Theme, Renderer>>,
+    {
         Self {
             init: Box::new(init),
-            view: Box::new(view),
+            view: Box::new(move |program, at| view(program, at).into()),
             on_finish: None,
             element: Element::new(space()),
             key: Key::default(),

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -2,15 +2,13 @@
 //!
 use std::hash::{DefaultHasher, Hash, Hasher};
 
-use iced_renderer::core::widget::tree;
-
 use crate::core::animation::{Animation, Float};
 use crate::core::layout::{self, Layout};
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::time::Instant;
-use crate::core::widget::{self, Operation, Tree};
+use crate::core::widget::{self, Operation, Tree, tree};
 use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
 use crate::space;
 
@@ -160,16 +158,6 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
-        self.element.as_widget_mut().update(
-            &mut tree.children[0],
-            event,
-            layout.children().next().unwrap(),
-            cursor,
-            renderer,
-            shell,
-            viewport,
-        );
-
         let State::<I> {
             animation,
             instant,
@@ -179,6 +167,7 @@ where
         } = tree.state.downcast_mut();
 
         let mut target_changed = *target_value != self.target_value;
+        let was_animating = animation.is_animating(*instant);
 
         if let core::Event::Window(core::window::Event::RedrawRequested(redraw)) = event {
             if *should_reset {
@@ -195,10 +184,26 @@ where
             animation.go_mut(self.target_value, *instant);
         }
 
-        if animation.is_animating(*instant) || *should_reset || target_changed {
+        let is_animating = animation.is_animating(*instant);
+        let just_finished = was_animating && !is_animating;
+
+        if is_animating || *should_reset || target_changed {
+            shell.invalidate_layout();
+            shell.request_redraw();
+        } else if just_finished {
             shell.invalidate_layout();
             shell.request_redraw();
         }
+
+        self.element.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            shell,
+            viewport,
+        );
     }
 
     fn draw(

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -12,15 +12,13 @@ use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, 
 use crate::space;
 
 /// The logic of a [`Transition`].
-///
-/// A [`Program`] can be used to group several [`Animation`]s when used with [`grouped`].
 pub trait Program: 'static {
-    /// The type of value the [`Program`] transitions its state to.
-    type Target: Copy + 'static;
+    /// The type of value that the [`Program`] animates.
+    type Value: Copy + 'static;
 
-    /// Transitions the [`Program`] from its current state
-    /// towards the target value at the given time.
-    fn tick(&mut self, target: Self::Target, now: Instant);
+    /// Transitions the [`Program`] from its current state towards the given value at
+    /// the given time.
+    fn go(&mut self, value: Self::Value, now: Instant);
 
     /// Returns true if the [`Program`] is currently in progress.
     fn is_animating(&self, now: Instant) -> bool;
@@ -30,10 +28,10 @@ impl<I> Program for Animation<I>
 where
     I: Float + Clone + Copy + PartialEq + 'static,
 {
-    type Target = I;
+    type Value = I;
 
-    fn tick(&mut self, target: Self::Target, now: Instant) {
-        self.go_mut(target, now);
+    fn go(&mut self, value: Self::Value, now: Instant) {
+        self.go_mut(value, now);
     }
 
     fn is_animating(&self, now: Instant) -> bool {
@@ -54,7 +52,7 @@ where
     height: Length,
     key: Key,
     id: Option<widget::Id>,
-    target_value: P::Target,
+    value: P::Value,
 }
 
 impl<'a, Message, Theme, Renderer, P> Transition<'a, Message, Theme, Renderer, P>
@@ -67,10 +65,10 @@ where
     /// The `init` closure will be used to initialize an animation.
     ///
     /// The `view` closure will receive the animation and an [`Instant`], which can be used for interpolating values.
-    /// This will be called every frame until the given `target_value` is reached.
+    /// This will be called every frame until the given `value` is reached.
     pub fn new(
         init: impl Fn() -> P + 'a,
-        target_value: P::Target,
+        value: P::Value,
         view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
     ) -> Self {
         Self {
@@ -82,7 +80,7 @@ where
             element: Element::new(space()),
             key: Key::default(),
             id: None,
-            target_value,
+            value,
         }
     }
 
@@ -248,7 +246,7 @@ where
             }
 
             *instant = *redraw;
-            animation.tick(self.target_value, *instant);
+            animation.go(self.value, *instant);
 
             let is_animating = animation.is_animating(*instant);
             let just_finished = was_animating && !is_animating;
@@ -418,19 +416,4 @@ pub fn reset_raw(id: impl Into<widget::Id>) -> impl Operation {
     }
 
     Reset(id.into())
-}
-
-/// Creates a new [`Transition`] widget with a custom [`Program`].
-///
-/// This can be useful if you need to use multiple [`Animation`]s without resorting to nesting [`Transition`]s.
-pub fn grouped<'a, Message, Theme, Renderer, P>(
-    init: impl Fn() -> P + 'a,
-    target_value: P::Target,
-    view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
-) -> Transition<'a, Message, Theme, Renderer, P>
-where
-    Renderer: core::Renderer,
-    P: Program,
-{
-    Transition::new(init, target_value, view)
 }

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -6,6 +6,7 @@ use crate::core::layout::{self, Layout};
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
+use crate::core::shell;
 use crate::core::time::Instant;
 use crate::core::widget::{self, Operation, Tree, tree};
 use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
@@ -178,11 +179,12 @@ where
         })
     }
 
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let State::<P> {
             animation,
             key: old_key,
             should_reset,
+            instant,
             ..
         } = tree.state.downcast_mut();
 
@@ -192,7 +194,8 @@ where
             *should_reset = false;
         }
 
-        // Diff is deferred to layout
+        self.element = (self.view)(animation, *instant);
+        tree.diff_children(std::slice::from_mut(&mut self.element));
     }
 
     fn layout(
@@ -201,14 +204,7 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let State::<P> {
-            animation, instant, ..
-        } = tree.state.downcast_ref();
-
-        self.element = (self.view)(animation, *instant);
         let limits = limits.width(self.width).height(self.height);
-
-        tree.diff_children(std::slice::from_ref(&self.element));
 
         let node =
             self.element
@@ -252,7 +248,7 @@ where
             let just_finished = was_animating && !is_animating;
 
             if is_animating || just_finished {
-                shell.invalidate_layout();
+                shell.invalidate_layout_with(shell::Diff::Perform);
                 shell.request_redraw();
             }
 

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -13,30 +13,57 @@ use crate::core::{self, Element, Event, Length, Rectangle, Shell, Size, Vector, 
 use crate::space;
 
 /// TODO
-pub struct Transition<'a, Message, Theme, Renderer, I>
+pub trait Program: 'static {
+    /// TODO
+    type Target: Copy + 'static;
+
+    /// TODO
+    fn tick(&mut self, target: Self::Target, now: Instant);
+
+    /// TODO
+    fn is_animating(&self, now: Instant) -> bool;
+}
+
+impl<I> Program for Animation<I>
 where
     I: Float + Clone + Copy + PartialEq + 'static,
 {
-    init: Box<dyn Fn() -> Animation<I> + 'a>,
-    view: Box<dyn Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
+    type Target = I;
+
+    fn tick(&mut self, target: Self::Target, now: Instant) {
+        self.go_mut(target, now);
+    }
+
+    fn is_animating(&self, now: Instant) -> bool {
+        self.is_animating(now)
+    }
+}
+
+/// TODO
+pub struct Transition<'a, Message, Theme, Renderer, P>
+where
+    P: Program,
+{
+    init: Box<dyn Fn() -> P + 'a>,
+    view: Box<dyn Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
     element: Element<'a, Message, Theme, Renderer>,
     width: Length,
     height: Length,
     key: Key,
     id: Option<widget::Id>,
-    target_value: I,
+    target_value: P::Target,
 }
 
-impl<'a, Message, Theme, Renderer, I> Transition<'a, Message, Theme, Renderer, I>
+impl<'a, Message, Theme, Renderer, P> Transition<'a, Message, Theme, Renderer, P>
 where
     Renderer: core::Renderer,
-    I: Float + Clone + Copy + PartialEq + 'static,
+    P: Program,
 {
     /// TODO
     pub fn new(
-        init: impl Fn() -> Animation<I> + 'a,
-        target_value: I,
-        view: impl Fn(&Animation<I>, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+        init: impl Fn() -> P + 'a,
+        target_value: P::Target,
+        view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
     ) -> Self {
         Self {
             init: Box::new(init),
@@ -79,11 +106,11 @@ where
     }
 }
 
-impl<Message, Theme, Renderer, I> Widget<Message, Theme, Renderer>
-    for Transition<'_, Message, Theme, Renderer, I>
+impl<Message, Theme, Renderer, P> Widget<Message, Theme, Renderer>
+    for Transition<'_, Message, Theme, Renderer, P>
 where
     Renderer: core::Renderer,
-    I: Float + Clone + Copy + PartialEq + 'static,
+    P: Program,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -93,7 +120,7 @@ where
     }
 
     fn tag(&self) -> tree::Tag {
-        tree::Tag::of::<State<I>>()
+        tree::Tag::of::<State<P>>()
     }
 
     fn state(&self) -> tree::State {
@@ -106,7 +133,7 @@ where
     }
 
     fn diff(&self, tree: &mut Tree) {
-        let State::<I> {
+        let State::<P> {
             animation,
             key: old_key,
             should_reset,
@@ -128,7 +155,7 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let State::<I> {
+        let State::<P> {
             animation, instant, ..
         } = tree.state.downcast_ref();
 
@@ -157,7 +184,7 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
-        let State::<I> {
+        let State::<P> {
             animation,
             instant,
             should_reset,
@@ -173,7 +200,7 @@ where
             }
 
             *instant = *redraw;
-            animation.go_mut(self.target_value, *instant);
+            animation.tick(self.target_value, *instant);
         }
 
         let is_animating = animation.is_animating(*instant);
@@ -243,7 +270,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
-        let State::<I> { should_reset, .. } = tree.state.downcast_mut();
+        let State::<P> { should_reset, .. } = tree.state.downcast_mut();
         let mut should_reset_new = ShouldReset(*should_reset);
 
         operation.custom(self.id.as_ref(), layout.bounds(), &mut should_reset_new);
@@ -275,24 +302,21 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer, I> From<Transition<'a, Message, Theme, Renderer, I>>
+impl<'a, Message, Theme, Renderer, P> From<Transition<'a, Message, Theme, Renderer, P>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a,
     Renderer: core::Renderer + 'a,
-    I: Float + Clone + Copy + PartialEq + 'static,
+    P: Program,
 {
-    fn from(transition: Transition<'a, Message, Theme, Renderer, I>) -> Self {
+    fn from(transition: Transition<'a, Message, Theme, Renderer, P>) -> Self {
         Self::new(transition)
     }
 }
 
-struct State<I>
-where
-    I: Float + Clone + Copy + PartialEq + 'static,
-{
-    animation: Animation<I>,
+struct State<P: Program> {
+    animation: P,
     instant: Instant,
     key: Key,
     should_reset: bool,
@@ -335,4 +359,17 @@ pub fn reset(id: impl Into<widget::Id>) -> impl Operation {
     }
 
     Reset(id.into())
+}
+
+/// TODO
+pub fn grouped<'a, Message, Theme, Renderer, P>(
+    init: impl Fn() -> P + 'a,
+    target_value: P::Target,
+    view: impl Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a,
+) -> Transition<'a, Message, Theme, Renderer, P>
+where
+    Renderer: core::Renderer,
+    P: Program,
+{
+    Transition::new(init, target_value, view)
 }

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -274,11 +274,12 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
-        let State::<P> { should_reset, .. } = tree.state.downcast_mut();
-        let mut should_reset_new = ShouldReset(*should_reset);
+        let mut should_reset = ShouldReset(false);
+        operation.custom(self.id.as_ref(), layout.bounds(), &mut should_reset);
 
-        operation.custom(self.id.as_ref(), layout.bounds(), &mut should_reset_new);
-        *should_reset = should_reset_new.0;
+        if should_reset.0 {
+            tree.state.downcast_mut::<State<P>>().should_reset = true;
+        }
 
         self.element.as_widget_mut().operate(
             &mut tree.children[0],

--- a/widget/src/transition.rs
+++ b/widget/src/transition.rs
@@ -48,6 +48,7 @@ where
 {
     init: Box<dyn Fn() -> P + 'a>,
     view: Box<dyn Fn(&P, Instant) -> Element<'a, Message, Theme, Renderer> + 'a>,
+    on_finish: Option<Box<dyn Fn() -> Message + 'a>>,
     element: Element<'a, Message, Theme, Renderer>,
     width: Length,
     height: Length,
@@ -75,6 +76,7 @@ where
         Self {
             init: Box::new(init),
             view: Box::new(view),
+            on_finish: None,
             width: Length::Fill,
             height: Length::Fill,
             element: Element::new(space()),
@@ -109,6 +111,45 @@ where
     /// Changing the key will reset the [`Animation`].
     pub fn key(mut self, key: impl Hash) -> Self {
         self.key = Key::new(key);
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Transition`] has finished animating.
+    ///
+    /// Note that if an [`Animation`] is set to loop forever, the message will never be produced!
+    pub fn on_finish(self, on_finish: Message) -> Self
+    where
+        Message: Clone + 'a,
+    {
+        self.on_finish_maybe(on_finish)
+    }
+
+    /// Sets the message that will be produced when the [`Transition`] has finished animating, if [`Some`].
+    ///
+    /// Note that if an [`Animation`] is set to loop forever, the message will never be produced!
+    pub fn on_finish_maybe(mut self, on_finish: impl Into<Option<Message>>) -> Self
+    where
+        Message: Clone + 'a,
+    {
+        self.on_finish = on_finish
+            .into()
+            .map(|on_finish| Box::new(move || on_finish.clone()) as _);
+
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Transition`] has finished animating.
+    ///
+    /// This is analogous to [`Transition::on_finish`], but using a closure to produce
+    /// the message.
+    ///
+    /// This closure will only be called when the [`Transition`] has actually finished animating and,
+    /// therefore, this method is useful to reduce overhead if creating the resulting
+    /// message is slow.
+    ///
+    /// Note that if an [`Animation`] is set to loop forever, the message will never be produced!
+    pub fn on_finish_with(mut self, on_finish: impl Fn() -> Message + 'a) -> Self {
+        self.on_finish = Some(Box::new(on_finish));
         self
     }
 }
@@ -215,6 +256,10 @@ where
             if is_animating || just_finished {
                 shell.invalidate_layout();
                 shell.request_redraw();
+            }
+
+            if just_finished && let Some(on_finish) = &self.on_finish {
+                shell.publish(on_finish());
             }
         }
 


### PR DESCRIPTION
This pr introduces a new `transition` widget to help make animated views much more ergonomic to implement.

The current approach to adding animations requires storing some `Animation<T>` in app state, subscribing to window redraws via `window::frames` and then updating the animation.

Furthermore, since interpolating a value *also* requires `Instant`, if you're not using `application::timed`, it's fairly common to store `Instant` in app state, often-times in multiple places, or even bundled together with `Animation<T>` in another struct.

The plumbing can get quite cumbersome if you want to animate several parts of your app. It's not the kind that could be made easier with helper functions.


# API Rundown

The `transition` function is quite simple:

```rust
// somewhere in view code...
let animated_widget = transition(init, target_value, view);
```

* `init` - A closure to initialize the animation.
* `target_value` - the value the animation will transition to.
* `view` - A closure that takes `Animation` and `Instant` to produce an element. This gets called every frame until the animation is complete.

## Example
A `transition` widget can be used to make the `progress_bar` smooth:

```rust
use std::convert::identity;
use std::time::Duration;

use iced::widget::{column, progress_bar, slider, transition};
use iced::{Animation, Center, Element};

pub fn main() -> iced::Result {
    iced::run(Progress::update, Progress::view)
}

#[derive(Default)]
struct Progress {
    slider: f32,
}

#[derive(Debug, Clone, Copy)]
enum Message {
    Slider(f32),
}

impl Progress {
    fn update(&mut self, message: Message) {
        match message {
            Message::Slider(s) => self.slider = s,
        }
    }

    fn view(&self) -> Element<'_, Message> {
        column![
            slider(0.0..=1.0, self.slider, Message::Slider).step(0.1),
            transition(init, self.slider, move |animate, instant| {
                progress_bar(0.0..=1.0, animate.interpolate_with(identity, instant)).into()
            })
        ]
        .padding(20)
        .align_x(Center)
        .into()
    }
}

fn init() -> Animation<f32> {
    Animation::new(0.)
        .duration(Duration::from_secs_f32(0.4))
        .easing(iced::animation::Easing::EaseOut)
}
```

https://github.com/user-attachments/assets/6757f35a-08a3-4e54-ac6f-3cb6861854b9

# Grouping Multiple Animations

Eventually, there will be a point where we may want to apply several animations to different parts of the same widget/view. You could nest multiple `transition` widgets, but that gets horrible quickly.

To remediate this, I've introduced a `transition::grouped` helper.

The API is the same as before:

```rust
transition::grouped(init, target_value, view);
```

The only difference is that `init` can return any type so long as it implements `transition::Program`:

```rust
trait Program: 'static {
  type Target: Copy + 'static;
  
  fn tick(&mut self, target_value: Self::Target, now: Instant);
  
  fn is_animating(&self, now: Instant) -> bool;
}
```

It's the implementor's responsibility to ensure that every animation used is updated properly. Consequently, this approach makes it fairly easy to forget to call `.go_mut` and `.is_animating` for every animation we add.

Admittedly, this part could do with more work. We could explore using closures for `tick` and `is_animating` to permit borrowing from app state instead of traits.

## Example
Let's update our smooth progress bar so that it turns green when it reaches 100% and let's also make it pulse.

```rust
use std::convert::identity;
use std::time::Duration;

use iced::widget::{column, progress_bar, slider, transition};
use iced::{Animation, Center, Element};

pub fn main() -> iced::Result {
    iced::run(Slider::update, Slider::view)
}

#[derive(Default)]
struct Slider {
    slider: f32,
}

#[derive(Debug, Clone, Copy)]
enum Message {
    Slider(f32),
}

impl Slider {
    fn update(&mut self, message: Message) {
        match message {
            Message::Slider(s) => self.slider = s,
        }
    }

    fn view(&self) -> Element<'_, Message> {
        column![
            slider(0.0..=1.0, self.slider, Message::Slider).step(0.1),
            transition::grouped(
                Animations::init,
                (self.slider, self.slider == 1.0),
                move |animate, instant| {
                    let color = animate.color.interpolate(0.0, 1.0, instant);
                    let pulse = animate.pulse.interpolate(0.0, 1.0, instant);
                    let progress = animate.progress.interpolate_with(identity, instant);

                    progress_bar(0.0..=1.0, progress)
                        .style(move |t| {
                            let primary_style = progress_bar::primary(t);

                            let positive = t.palette().success.base.color;
                            let base = t.palette().primary.base.color;

                            progress_bar::Style {
                                bar: base.mix(positive, color).into(),
                                border: iced::Border {
                                    width: pulse * 4.0,
                                    ..primary_style.border
                                },
                                ..primary_style
                            }
                        })
                        .into()
                }
            )
        ]
        .padding(20)
        .align_x(Center)
        .into()
    }
}

struct Animations {
    progress: Animation<f32>,
    color: Animation<bool>,
    pulse: Animation<bool>,
}

impl Animations {
    fn init() -> Self {
        Self {
            progress: Animation::new(0.)
                .duration(Duration::from_secs_f32(0.4))
                .easing(iced::animation::Easing::EaseOut),
            color: Animation::new(false)
                .duration(Duration::from_secs_f32(0.3))
                .easing(iced::animation::Easing::EaseInCubic),
            pulse: Animation::new(false)
                .duration(Duration::from_secs_f32(0.2))
                .easing(iced::animation::Easing::EaseIn)
                .auto_reverse()
                .repeat_forever(),
        }
    }
}

impl transition::Program for Animations {
    type Target = (f32, bool);

    fn tick(&mut self, (progress, is_complete): Self::Target, now: std::time::Instant) {
        self.progress.go_mut(progress, now);
        self.color.go_mut(is_complete, now);
        self.pulse.go_mut(true, now);
    }

    fn is_animating(&self, now: std::time::Instant) -> bool {
        self.progress.is_animating(now)
            || self.color.is_animating(now)
            || self.pulse.is_animating(now)
    }
}
```

https://github.com/user-attachments/assets/9d4020a5-ffe6-47f4-8a4f-add6ed694352

# Resetting an Animation
The animation can be reset under 3 circumstances:

* The widget tree changes.
* `.key(value)` is added, and `value` changes.
* Returning `transition::reset(id)` to the runtime, given that the widget is given matching IDs.

I personally haven't found a use case where I would need to explicitly reset the internal state, but since we no longer directly control the Animation, this could be useful.

# Limitations (so far)
* The Animation provided by the view closure has a shorter lifetime, therefore it cannot be passed directly to styling closures. You'll need to interpolate the value beforehand.
* Buttons will appear `Disabled` when it's animated since they don't store `Status` in the widget tree.
* Complex animations are uncharted territory.

# Testing
I haven't done anything non-trivial with this widget yet, so there's plenty of room for more testing and exploration.
