### PR TITLE
Consistent `Widget::diff` logic

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -6,7 +6,7 @@ use crate::widget;
 use crate::widget::tree::{self, Tree};
 use crate::{Border, Color, Event, Layout, Length, Rectangle, Shell, Size, Vector, Widget};
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 
 /// A generic [`Widget`].
 ///
@@ -225,6 +225,30 @@ impl<'a, Message, Theme, Renderer> Borrow<dyn Widget<Message, Theme, Renderer> +
     }
 }
 
+impl<'a, Message, Theme, Renderer> Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
+    for &mut Element<'a, Message, Theme, Renderer>
+{
+    fn borrow(&self) -> &(dyn Widget<Message, Theme, Renderer> + 'a) {
+        self.widget.borrow()
+    }
+}
+
+impl<'a, Message, Theme, Renderer> BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
+    for Element<'a, Message, Theme, Renderer>
+{
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
+        self.widget.borrow_mut()
+    }
+}
+
+impl<'a, Message, Theme, Renderer> BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
+    for &mut Element<'a, Message, Theme, Renderer>
+{
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
+        self.widget.borrow_mut()
+    }
+}
+
 struct Map<'a, A, B, Theme, Renderer> {
     widget: Box<dyn Widget<A, Theme, Renderer> + 'a>,
     mapper: Box<dyn Fn(A) -> B + 'a>,
@@ -259,20 +283,12 @@ where
         self.widget.state()
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.widget.children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         self.widget.diff(tree);
     }
 
     fn size(&self) -> Size<Length> {
         self.widget.size()
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.widget.size_hint()
     }
 
     fn layout(
@@ -385,10 +401,6 @@ where
         self.element.widget.size()
     }
 
-    fn size_hint(&self) -> Size<Length> {
-        self.element.widget.size_hint()
-    }
-
     fn tag(&self) -> tree::Tag {
         self.element.widget.tag()
     }
@@ -397,11 +409,7 @@ where
         self.element.widget.state()
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.element.widget.children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         self.element.widget.diff(tree);
     }
 

--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -50,7 +50,7 @@ impl Limits {
     /// Applies a width constraint to the current [`Limits`].
     pub fn width(mut self, width: impl Into<Length>) -> Limits {
         match width.into() {
-            Length::Shrink | Length::Intrinsic => {
+            Length::Shrink | Length::Fit => {
                 self.compression.width = true;
             }
             Length::Fixed(amount) => {
@@ -69,7 +69,7 @@ impl Limits {
     /// Applies a height constraint to the current [`Limits`].
     pub fn height(mut self, height: impl Into<Length>) -> Limits {
         match height.into() {
-            Length::Shrink | Length::Intrinsic => {
+            Length::Shrink | Length::Fit => {
                 self.compression.height = true;
             }
             Length::Fixed(amount) => {

--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -50,7 +50,7 @@ impl Limits {
     /// Applies a width constraint to the current [`Limits`].
     pub fn width(mut self, width: impl Into<Length>) -> Limits {
         match width.into() {
-            Length::Shrink => {
+            Length::Shrink | Length::Intrinsic => {
                 self.compression.width = true;
             }
             Length::Fixed(amount) => {
@@ -69,7 +69,7 @@ impl Limits {
     /// Applies a height constraint to the current [`Limits`].
     pub fn height(mut self, height: impl Into<Length>) -> Limits {
         match height.into() {
-            Length::Shrink => {
+            Length::Shrink | Length::Intrinsic => {
                 self.compression.height = true;
             }
             Length::Fixed(amount) => {

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -15,12 +15,12 @@ pub enum Length {
     /// `Length::Fill` is equivalent to `Length::FillPortion(1)`.
     FillPortion(u16),
 
-    /// Fill the least amount of space
+    /// Fill the least amount of space; compressing contents if possible.
     Shrink,
 
     /// Fill the minimum amount of space based on the intrinsic size of the
     /// element; normally defined by its contents.
-    Intrinsic,
+    Fit,
 
     /// Fill a fixed amount of space
     Fixed(f32),
@@ -36,7 +36,7 @@ impl Length {
         match self {
             Length::Fill => 1,
             Length::FillPortion(factor) => *factor,
-            Length::Shrink | Length::Intrinsic | Length::Fixed(_) => 0,
+            Length::Shrink | Length::Fit | Length::Fixed(_) => 0,
         }
     }
 
@@ -46,9 +46,9 @@ impl Length {
         self.fill_factor() != 0
     }
 
-    /// Returns `true` if the [`Length`] is [`Intrinsic`](Self::Intrinsic).
-    pub fn is_intrinsic(&self) -> bool {
-        matches!(self, Self::Intrinsic)
+    /// Returns `true` if the [`Length`] is [`Fit`](Self::Fit).
+    pub fn is_fit(&self) -> bool {
+        matches!(self, Self::Fit)
     }
 
     /// Returns the "fluid" variant of the [`Length`].
@@ -59,7 +59,7 @@ impl Length {
     pub fn fluid(&self) -> Self {
         match self {
             Length::Fill | Length::FillPortion(_) => Length::Fill,
-            Length::Shrink | Length::Intrinsic | Length::Fixed(_) => Length::Shrink,
+            Length::Shrink | Length::Fit | Length::Fixed(_) => Length::Shrink,
         }
     }
 
@@ -68,7 +68,7 @@ impl Length {
     #[inline]
     pub fn enclose(self, other: Length) -> Self {
         match (self, other) {
-            (Length::Intrinsic, Length::Fill | Length::FillPortion(_)) => other,
+            (Length::Fit, Length::Fill | Length::FillPortion(_)) => other,
             _ => self,
         }
     }

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -18,6 +18,10 @@ pub enum Length {
     /// Fill the least amount of space
     Shrink,
 
+    /// Fill the minimum amount of space based on the intrinsic size of the
+    /// element; normally defined by its contents.
+    Intrinsic,
+
     /// Fill a fixed amount of space
     Fixed(f32),
 }
@@ -32,8 +36,7 @@ impl Length {
         match self {
             Length::Fill => 1,
             Length::FillPortion(factor) => *factor,
-            Length::Shrink => 0,
-            Length::Fixed(_) => 0,
+            Length::Shrink | Length::Intrinsic | Length::Fixed(_) => 0,
         }
     }
 
@@ -41,6 +44,11 @@ impl Length {
     /// [`Length::FillPortion`].
     pub fn is_fill(&self) -> bool {
         self.fill_factor() != 0
+    }
+
+    /// Returns `true` if the [`Length`] is [`Intrinsic`](Self::Intrinsic).
+    pub fn is_intrinsic(&self) -> bool {
+        matches!(self, Self::Intrinsic)
     }
 
     /// Returns the "fluid" variant of the [`Length`].
@@ -51,7 +59,7 @@ impl Length {
     pub fn fluid(&self) -> Self {
         match self {
             Length::Fill | Length::FillPortion(_) => Length::Fill,
-            Length::Shrink | Length::Fixed(_) => Length::Shrink,
+            Length::Shrink | Length::Intrinsic | Length::Fixed(_) => Length::Shrink,
         }
     }
 
@@ -60,7 +68,7 @@ impl Length {
     #[inline]
     pub fn enclose(self, other: Length) -> Self {
         match (self, other) {
-            (Length::Shrink, Length::Fill | Length::FillPortion(_)) => other,
+            (Length::Intrinsic, Length::Fill | Length::FillPortion(_)) => other,
             _ => self,
         }
     }

--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -20,7 +20,7 @@ pub struct Shell<'a, Message> {
     event_status: event::Status,
     redraw_request: window::RedrawRequest,
     input_method: InputMethod,
-    is_layout_invalid: bool,
+    is_layout_invalid: Option<Diff>,
     are_widgets_invalid: bool,
     clipboard: Clipboard,
 }
@@ -34,7 +34,7 @@ impl<'a, Message> Shell<'a, Message> {
             waker,
             event_status: event::Status::Ignored,
             redraw_request: window::RedrawRequest::Wait,
-            is_layout_invalid: false,
+            is_layout_invalid: None,
             are_widgets_invalid: false,
             input_method: InputMethod::Disabled,
             clipboard: Clipboard {
@@ -159,7 +159,7 @@ impl<'a, Message> Shell<'a, Message> {
 
     /// Returns whether the current layout is invalid or not.
     #[must_use]
-    pub fn is_layout_invalid(&self) -> bool {
+    pub fn is_layout_invalid(&self) -> Option<Diff> {
         self.is_layout_invalid
     }
 
@@ -167,16 +167,19 @@ impl<'a, Message> Shell<'a, Message> {
     ///
     /// The shell will relayout the application widgets.
     pub fn invalidate_layout(&mut self) {
-        self.is_layout_invalid = true;
+        self.invalidate_layout_with(Diff::Skip);
+    }
+
+    /// Invalidates the current application layout with the following [`Diff`] strategy.
+    pub fn invalidate_layout_with(&mut self, diff: Diff) {
+        self.is_layout_invalid = Some(diff);
     }
 
     /// Triggers the given function if the layout is invalid, cleaning it in the
     /// process.
-    pub fn revalidate_layout(&mut self, f: impl FnOnce()) {
-        if self.is_layout_invalid {
-            self.is_layout_invalid = false;
-
-            f();
+    pub fn revalidate_layout(&mut self, f: impl FnOnce(Diff)) {
+        if let Some(diff) = self.is_layout_invalid.take() {
+            f(diff);
         }
     }
 
@@ -201,7 +204,11 @@ impl<'a, Message> Shell<'a, Message> {
     pub fn merge<B>(&mut self, mut other: Shell<'_, B>, f: impl Fn(B) -> Message) {
         self.messages.extend(other.messages.drain(..).map(f));
 
-        self.is_layout_invalid = self.is_layout_invalid || other.is_layout_invalid;
+        self.is_layout_invalid = match (self.is_layout_invalid, other.is_layout_invalid) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            _ => self.is_layout_invalid.or(other.is_layout_invalid),
+        };
+
         self.are_widgets_invalid = self.are_widgets_invalid || other.are_widgets_invalid;
         self.redraw_request = self.redraw_request.min(other.redraw_request);
         self.event_status = self.event_status.merge(other.event_status);
@@ -243,4 +250,13 @@ impl std::fmt::Debug for Waker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Waker").finish()
     }
+}
+
+/// The diffing strategy to follow when invalidating some layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Diff {
+    /// Skips the diffing step.
+    Skip,
+    /// Performs diffing again before layouting.
+    Perform,
 }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -41,14 +41,6 @@ where
     /// Returns the [`Size`] of the [`Widget`] in lengths.
     fn size(&self) -> Size<Length>;
 
-    /// Returns a [`Size`] hint for laying out the [`Widget`].
-    ///
-    /// This hint may be used by some widget containers to adjust their sizing strategy
-    /// during construction.
-    fn size_hint(&self) -> Size<Length> {
-        self.size()
-    }
-
     /// Returns the [`layout::Node`] of the [`Widget`].
     ///
     /// This [`layout::Node`] is used by the runtime to compute the [`Layout`] of the
@@ -86,13 +78,8 @@ where
         tree::State::None
     }
 
-    /// Returns the state [`Tree`] of the children of the [`Widget`].
-    fn children(&self) -> Vec<Tree> {
-        Vec::new()
-    }
-
     /// Reconciles the [`Widget`] with the provided [`Tree`].
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         tree.children.clear();
     }
 
@@ -145,5 +132,19 @@ where
         _translation: Vector,
     ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         None
+    }
+
+    /// Returns the width of the widget in [`Length`].
+    ///
+    /// This should match the `width` returned by [`size`](Self::size).
+    fn width(&self) -> Length {
+        self.size().width
+    }
+
+    /// Returns the height of the widget in [`Length`].
+    ///
+    /// This should match the `height` returned by [`size`](Self::size).
+    fn height(&self) -> Length {
+        self.size().height
     }
 }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -133,18 +133,4 @@ where
     ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         None
     }
-
-    /// Returns the width of the widget in [`Length`].
-    ///
-    /// This should match the `width` returned by [`size`](Self::size).
-    fn width(&self) -> Length {
-        self.size().width
-    }
-
-    /// Returns the height of the widget in [`Length`].
-    ///
-    /// This should match the `height` returned by [`size`](Self::size).
-    fn height(&self) -> Length {
-        self.size().height
-    }
 }

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -123,6 +123,12 @@ pub fn diff_children_custom_with_search<T>(
 
     if current_children.is_empty() {
         current_children.extend(new_children.iter().map(new_state));
+
+        // TODO: Merge loop with extend logic (?)
+        for (child_state, new) in current_children.iter_mut().zip(new_children.iter_mut()) {
+            diff(child_state, new);
+        }
+
         return;
     }
 

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -2,7 +2,7 @@
 use crate::Widget;
 
 use std::any::{self, Any};
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 use std::fmt;
 
 /// A persistent state widget tree.
@@ -42,7 +42,7 @@ impl Tree {
         Self {
             tag: widget.tag(),
             state: widget.state(),
-            children: widget.children(),
+            children: Vec::new(),
         }
     }
 
@@ -56,27 +56,27 @@ impl Tree {
     /// [`Widget::diff`]: crate::Widget::diff
     pub fn diff<'a, Message, Theme, Renderer>(
         &mut self,
-        new: impl Borrow<dyn Widget<Message, Theme, Renderer> + 'a>,
+        mut new: impl BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>,
     ) where
         Renderer: crate::Renderer,
     {
-        if self.tag == new.borrow().tag() {
-            new.borrow().diff(self);
-        } else {
-            *self = Self::new(new);
+        if self.tag != new.borrow().tag() {
+            *self = Self::new(new.borrow());
         }
+
+        new.borrow_mut().diff(self);
     }
 
     /// Reconciles the children of the tree with the provided list of widgets.
     pub fn diff_children<'a, Message, Theme, Renderer>(
         &mut self,
-        new_children: &[impl Borrow<dyn Widget<Message, Theme, Renderer> + 'a>],
+        new_children: &mut [impl BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>],
     ) where
         Renderer: crate::Renderer,
     {
         self.diff_children_custom(
             new_children,
-            |tree, widget| tree.diff(widget.borrow()),
+            |tree, widget| tree.diff(widget.borrow_mut()),
             |widget| Self::new(widget.borrow()),
         );
     }
@@ -85,21 +85,21 @@ impl Tree {
     /// logic both for diffing and creating new widget state.
     pub fn diff_children_custom<T>(
         &mut self,
-        new_children: &[T],
-        diff: impl Fn(&mut Tree, &T),
+        new_children: &mut [T],
+        diff: impl Fn(&mut Tree, &mut T),
         new_state: impl Fn(&T) -> Self,
     ) {
         if self.children.len() > new_children.len() {
             self.children.truncate(new_children.len());
         }
 
-        for (child_state, new) in self.children.iter_mut().zip(new_children.iter()) {
-            diff(child_state, new);
-        }
-
         if self.children.len() < new_children.len() {
             self.children
                 .extend(new_children[self.children.len()..].iter().map(new_state));
+        }
+
+        for (child_state, new) in self.children.iter_mut().zip(new_children.iter_mut()) {
+            diff(child_state, new);
         }
     }
 }
@@ -111,8 +111,8 @@ impl Tree {
 /// `maybe_changed` closure.
 pub fn diff_children_custom_with_search<T>(
     current_children: &mut Vec<Tree>,
-    new_children: &[T],
-    diff: impl Fn(&mut Tree, &T),
+    new_children: &mut [T],
+    diff: impl Fn(&mut Tree, &mut T),
     maybe_changed: impl Fn(usize) -> bool,
     new_state: impl Fn(&T) -> Tree,
 ) {
@@ -174,7 +174,7 @@ pub fn diff_children_custom_with_search<T>(
     }
 
     // TODO: Merge loop with extend logic (?)
-    for (child_state, new) in current_children.iter_mut().zip(new_children.iter()) {
+    for (child_state, new) in current_children.iter_mut().zip(new_children.iter_mut()) {
         diff(child_state, new);
     }
 }

--- a/examples/loupe/src/main.rs
+++ b/examples/loupe/src/main.rs
@@ -81,12 +81,8 @@ mod loupe {
             self.content.as_widget().state()
         }
 
-        fn children(&self) -> Vec<widget::Tree> {
-            self.content.as_widget().children()
-        }
-
-        fn diff(&self, tree: &mut widget::Tree) {
-            self.content.as_widget().diff(tree);
+        fn diff(&mut self, tree: &mut widget::Tree) {
+            self.content.as_widget_mut().diff(tree);
         }
 
         fn size(&self) -> Size<Length> {

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -301,13 +301,7 @@ mod toast {
             widget::tree::State::new(Vec::<Option<Instant>>::new())
         }
 
-        fn children(&self) -> Vec<Tree> {
-            std::iter::once(Tree::new(&self.content))
-                .chain(self.toasts.iter().map(Tree::new))
-                .collect()
-        }
-
-        fn diff(&self, tree: &mut Tree) {
+        fn diff(&mut self, tree: &mut Tree) {
             let instants = tree.state.downcast_mut::<Vec<Option<Instant>>>();
 
             // Invalidating removed instants to None allows us to remove
@@ -326,8 +320,8 @@ mod toast {
             }
 
             tree.diff_children(
-                &std::iter::once(&self.content)
-                    .chain(self.toasts.iter())
+                &mut std::iter::once(&mut self.content)
+                    .chain(&mut self.toasts)
                     .collect::<Vec<_>>(),
             );
         }

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -104,7 +104,7 @@ where
         let mut root = root.into();
 
         let Cache { mut state } = cache;
-        state.diff(root.as_widget());
+        state.diff(root.as_widget_mut());
 
         let base = root.as_widget_mut().layout(
             &mut state,

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -234,8 +234,15 @@ where
                 input_method.merge(shell.input_method());
                 clipboard.merge(shell.clipboard_mut());
 
-                if shell.is_layout_invalid() {
+                if let Some(diff) = shell.is_layout_invalid() {
                     drop(maybe_overlay);
+
+                    match diff {
+                        shell::Diff::Perform => {
+                            self.root.as_widget_mut().diff(&mut self.state);
+                        }
+                        shell::Diff::Skip => {}
+                    }
 
                     self.base = self.root.as_widget_mut().layout(
                         &mut self.state,
@@ -261,7 +268,7 @@ where
 
                     overlay = maybe_overlay.as_mut().unwrap();
 
-                    shell.revalidate_layout(|| {
+                    shell.revalidate_layout(|_diff| {
                         layout = overlay.layout(renderer, bounds);
                         has_layout_changed = true;
                     });
@@ -337,8 +344,15 @@ where
                 input_method.merge(shell.input_method());
                 clipboard.merge(shell.clipboard_mut());
 
-                shell.revalidate_layout(|| {
+                shell.revalidate_layout(|diff| {
                     has_layout_changed = true;
+
+                    match diff {
+                        shell::Diff::Perform => {
+                            self.root.as_widget_mut().diff(&mut self.state);
+                        }
+                        shell::Diff::Skip => {}
+                    }
 
                     self.base = self.root.as_widget_mut().layout(
                         &mut self.state,

--- a/tester/src/recorder.rs
+++ b/tester/src/recorder.rs
@@ -62,20 +62,12 @@ where
         })
     }
 
-    fn children(&self) -> Vec<widget::Tree> {
-        vec![widget::Tree::new(&self.content)]
-    }
-
-    fn diff(&self, tree: &mut tree::Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content));
+    fn diff(&mut self, tree: &mut tree::Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
     }
 
     fn size(&self) -> Size<Length> {
         self.content.as_widget().size()
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.content.as_widget().size_hint()
     }
 
     fn update(

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -75,8 +75,8 @@ where
 {
     content: Element<'a, Message, Theme, Renderer>,
     on_press: Option<OnPress<'a, Message>>,
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     padding: Padding,
     clip: bool,
     class: Theme::Class<'a>,
@@ -109,8 +109,8 @@ where
         Button {
             content,
             on_press: None,
-            width: None,
-            height: None,
+            width: Length::Intrinsic,
+            height: Length::Intrinsic,
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),
@@ -120,13 +120,13 @@ where
 
     /// Sets the width of the [`Button`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Button`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -214,12 +214,16 @@ where
 
     fn diff(&mut self, tree: &mut Tree) {
         tree.diff_children(std::slice::from_mut(&mut self.content));
+
+        let size = self.content.as_widget().size();
+        self.width = self.width.enclose(size.width);
+        self.height = self.height.enclose(size.height);
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 
@@ -229,15 +233,7 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let width = self
-            .width
-            .unwrap_or_else(|| self.content.as_widget().width());
-
-        let height = self
-            .height
-            .unwrap_or_else(|| self.content.as_widget().height());
-
-        layout::padded(limits, width, height, self.padding, |limits| {
+        layout::padded(limits, self.width, self.height, self.padding, |limits| {
             self.content
                 .as_widget_mut()
                 .layout(&mut tree.children[0], renderer, limits)

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -75,8 +75,8 @@ where
 {
     content: Element<'a, Message, Theme, Renderer>,
     on_press: Option<OnPress<'a, Message>>,
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     padding: Padding,
     clip: bool,
     class: Theme::Class<'a>,
@@ -105,13 +105,12 @@ where
     /// Creates a new [`Button`] with the given content.
     pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let content = content.into();
-        let size = content.as_widget().size_hint();
 
         Button {
             content,
             on_press: None,
-            width: size.width.fluid(),
-            height: size.height.fluid(),
+            width: None,
+            height: None,
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),
@@ -121,13 +120,13 @@ where
 
     /// Sets the width of the [`Button`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Button`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
@@ -213,18 +212,14 @@ where
         tree::State::new(State::default())
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![Tree::new(&self.content)]
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content));
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -234,7 +229,15 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        layout::padded(limits, self.width, self.height, self.padding, |limits| {
+        let width = self
+            .width
+            .unwrap_or_else(|| self.content.as_widget().width());
+
+        let height = self
+            .height
+            .unwrap_or_else(|| self.content.as_widget().height());
+
+        layout::padded(limits, width, height, self.padding, |limits| {
             self.content
                 .as_widget_mut()
                 .layout(&mut tree.children[0], renderer, limits)

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -109,8 +109,8 @@ where
         Button {
             content,
             on_press: None,
-            width: Length::Intrinsic,
-            height: Length::Intrinsic,
+            width: Length::Fit,
+            height: Length::Fit,
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -34,8 +34,8 @@ use crate::core::{
 pub struct Column<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     max_width: f32,
     align: Alignment,
     clip: bool,
@@ -70,8 +70,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: None,
-            height: None,
+            width: Length::Intrinsic,
+            height: Length::Intrinsic,
             max_width: f32::INFINITY,
             align: Alignment::Start,
             clip: false,
@@ -97,13 +97,13 @@ where
 
     /// Sets the width of the [`Column`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Column`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -183,39 +183,21 @@ where
     fn diff(&mut self, tree: &mut Tree) {
         tree.diff_children(&mut self.children);
 
-        let inherit_width = self.width.is_none();
-        let inherit_height = self.height.is_none();
-
-        if inherit_width || inherit_height {
-            let mut width = self.width.unwrap_or(Length::Shrink);
-            let mut height = self.height.unwrap_or(Length::Shrink);
-
+        if self.width.is_intrinsic() || self.height.is_intrinsic() {
             for child in &self.children {
                 let size = child.as_widget().size();
 
-                if inherit_width {
-                    width = width.enclose(size.width);
-                }
+                self.width = self.width.enclose(size.width);
 
-                if inherit_height {
-                    height = height.enclose(size.height);
-                }
-            }
-
-            if inherit_width {
-                self.width = Some(width);
-            }
-
-            if inherit_height {
-                self.height = Some(height);
+                self.height = self.height.enclose(size.height);
             }
         }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -70,8 +70,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Intrinsic,
-            height: Length::Intrinsic,
+            width: Length::Fit,
+            height: Length::Fit,
             max_width: f32::INFINITY,
             align: Alignment::Start,
             clip: false,
@@ -183,7 +183,7 @@ where
     fn diff(&mut self, tree: &mut Tree) {
         tree.diff_children(&mut self.children);
 
-        if self.width.is_intrinsic() || self.height.is_intrinsic() {
+        if self.width.is_fit() || self.height.is_fit() {
             for child in &self.children {
                 let size = child.as_widget().size();
 

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -34,8 +34,8 @@ use crate::core::{
 pub struct Column<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     max_width: f32,
     align: Alignment,
     clip: bool,
@@ -66,18 +66,12 @@ where
     }
 
     /// Creates a [`Column`] from an already allocated [`Vec`].
-    ///
-    /// Keep in mind that the [`Column`] will not inspect the [`Vec`], which means
-    /// it won't automatically adapt to the sizing strategy of its contents.
-    ///
-    /// If any of the children have a [`Length::Fill`] strategy, you will need to
-    /// call [`Column::width`] or [`Column::height`] accordingly.
     pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: None,
+            height: None,
             max_width: f32::INFINITY,
             align: Alignment::Start,
             clip: false,
@@ -103,13 +97,13 @@ where
 
     /// Sets the width of the [`Column`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Column`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
@@ -135,11 +129,9 @@ where
     /// Adds an element to the [`Column`].
     pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
-        let child_size = child.as_widget().size_hint();
+        let child_size = child.as_widget().size();
 
         if !child_size.is_void() {
-            self.width = self.width.enclose(child_size.width);
-            self.height = self.height.enclose(child_size.height);
             self.children.push(child);
         }
 
@@ -188,18 +180,42 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.children.iter().map(Tree::new).collect()
-    }
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+        let inherit_width = self.width.is_none();
+        let inherit_height = self.height.is_none();
+
+        if inherit_width || inherit_height {
+            let mut width = self.width.unwrap_or(Length::Shrink);
+            let mut height = self.height.unwrap_or(Length::Shrink);
+
+            for child in &self.children {
+                let size = child.as_widget().size();
+
+                if inherit_width {
+                    width = width.enclose(size.width);
+                }
+
+                if inherit_height {
+                    height = height.enclose(size.height);
+                }
+            }
+
+            if inherit_width {
+                self.width = Some(width);
+            }
+
+            if inherit_height {
+                self.height = Some(height);
+            }
+        }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -209,14 +225,15 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
         let limits = limits.max_width(self.max_width);
 
         layout::flex::resolve(
             layout::flex::Axis::Vertical,
             renderer,
             &limits,
-            self.width,
-            self.height,
+            size.width,
+            size.height,
             self.padding,
             self.spacing,
             self.align,
@@ -383,11 +400,7 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.column.children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         self.column.diff(tree);
     }
 
@@ -401,9 +414,10 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
         let limits = limits
-            .width(self.column.width)
-            .height(self.column.height)
+            .width(size.width)
+            .height(size.height)
             .shrink(self.column.padding);
 
         let child_limits = limits.loose();
@@ -502,7 +516,7 @@ where
             }
         }
 
-        let size = limits.resolve(self.column.width, self.column.height, intrinsic_size);
+        let size = limits.resolve(size.width, size.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.column.padding), children)
     }

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -188,7 +188,6 @@ where
                 let size = child.as_widget().size();
 
                 self.width = self.width.enclose(size.width);
-
                 self.height = self.height.enclose(size.height);
             }
         }

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -206,15 +206,14 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
         let limits = limits.max_width(self.max_width);
 
         layout::flex::resolve(
             layout::flex::Axis::Vertical,
             renderer,
             &limits,
-            size.width,
-            size.height,
+            self.width,
+            self.height,
             self.padding,
             self.spacing,
             self.align,
@@ -395,10 +394,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
         let limits = limits
-            .width(size.width)
-            .height(size.height)
+            .width(self.column.width)
+            .height(self.column.height)
             .shrink(self.column.padding);
 
         let child_limits = limits.loose();
@@ -497,7 +495,7 @@ where
             }
         }
 
-        let size = limits.resolve(size.width, size.height, intrinsic_size);
+        let size = limits.resolve(self.column.width, self.column.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.column.padding), children)
     }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -529,12 +529,8 @@ where
         })
     }
 
-    fn children(&self) -> Vec<widget::Tree> {
-        vec![widget::Tree::new(&self.text_input as &dyn Widget<_, _, _>)]
-    }
-
-    fn diff(&self, _tree: &mut widget::Tree) {
-        // do nothing so the children don't get cleared
+    fn diff(&mut self, tree: &mut widget::Tree) {
+        tree.diff_children(&mut [&mut self.text_input as &mut dyn Widget<_, _, _>]);
     }
 
     fn update(

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -85,8 +85,8 @@ where
         Container {
             id: None,
             padding: Padding::ZERO,
-            width: Length::Intrinsic,
-            height: Length::Intrinsic,
+            width: Length::Fit,
+            height: Length::Fit,
             max_width: f32::INFINITY,
             max_height: f32::INFINITY,
             horizontal_alignment: alignment::Horizontal::Left,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -248,12 +248,10 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
-
         layout(
             limits,
-            size.width,
-            size.height,
+            self.width,
+            self.height,
             self.max_width,
             self.max_height,
             self.padding,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -62,8 +62,8 @@ where
 {
     id: Option<widget::Id>,
     padding: Padding,
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     max_width: f32,
     max_height: f32,
     horizontal_alignment: alignment::Horizontal,
@@ -81,13 +81,12 @@ where
     /// Creates a [`Container`] with the given content.
     pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let content = content.into();
-        let size = content.as_widget().size_hint();
 
         Container {
             id: None,
             padding: Padding::ZERO,
-            width: size.width.fluid(),
-            height: size.height.fluid(),
+            width: None,
+            height: None,
             max_width: f32::INFINITY,
             max_height: f32::INFINITY,
             horizontal_alignment: alignment::Horizontal::Left,
@@ -112,13 +111,13 @@ where
 
     /// Sets the width of the [`Container`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Container`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
@@ -228,18 +227,14 @@ where
         self.content.as_widget().state()
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.content.as_widget().children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        self.content.as_widget().diff(tree);
+    fn diff(&mut self, tree: &mut Tree) {
+        self.content.as_widget_mut().diff(tree);
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -249,10 +244,12 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
+
         layout(
             limits,
-            self.width,
-            self.height,
+            size.width,
+            size.height,
             self.max_width,
             self.max_height,
             self.padding,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -62,8 +62,8 @@ where
 {
     id: Option<widget::Id>,
     padding: Padding,
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     max_width: f32,
     max_height: f32,
     horizontal_alignment: alignment::Horizontal,
@@ -85,8 +85,8 @@ where
         Container {
             id: None,
             padding: Padding::ZERO,
-            width: None,
-            height: None,
+            width: Length::Intrinsic,
+            height: Length::Intrinsic,
             max_width: f32::INFINITY,
             max_height: f32::INFINITY,
             horizontal_alignment: alignment::Horizontal::Left,
@@ -111,13 +111,13 @@ where
 
     /// Sets the width of the [`Container`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Container`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -229,12 +229,16 @@ where
 
     fn diff(&mut self, tree: &mut Tree) {
         self.content.as_widget_mut().diff(tree);
+
+        let size = self.content.as_widget().size();
+        self.width = self.width.enclose(size.width);
+        self.height = self.height.enclose(size.height);
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 

--- a/widget/src/float.rs
+++ b/widget/src/float.rs
@@ -93,20 +93,12 @@ where
         self.content.as_widget().state()
     }
 
-    fn children(&self) -> Vec<tree::Tree> {
-        self.content.as_widget().children()
-    }
-
-    fn diff(&self, tree: &mut widget::Tree) {
-        self.content.as_widget().diff(tree);
+    fn diff(&mut self, tree: &mut widget::Tree) {
+        self.content.as_widget_mut().diff(tree);
     }
 
     fn size(&self) -> Size<Length> {
         self.content.as_widget().size()
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.content.as_widget().size_hint()
     }
 
     fn layout(

--- a/widget/src/grid.rs
+++ b/widget/src/grid.rs
@@ -140,12 +140,8 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.children.iter().map(Tree::new).collect()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
     }
 
     fn size(&self) -> Size<Length> {

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -603,20 +603,12 @@ where
             self.content.as_widget().state()
         }
 
-        fn children(&self) -> Vec<Tree> {
-            self.content.as_widget().children()
-        }
-
-        fn diff(&self, tree: &mut Tree) {
-            self.content.as_widget().diff(tree);
+        fn diff(&mut self, tree: &mut Tree) {
+            self.content.as_widget_mut().diff(tree);
         }
 
         fn size(&self) -> Size<Length> {
             self.content.as_widget().size()
-        }
-
-        fn size_hint(&self) -> Size<Length> {
-            self.content.as_widget().size_hint()
         }
 
         fn layout(
@@ -755,20 +747,12 @@ where
             tree::Tag::of::<Tag>()
         }
 
-        fn children(&self) -> Vec<Tree> {
-            vec![Tree::new(&self.base), Tree::new(&self.top)]
-        }
-
-        fn diff(&self, tree: &mut Tree) {
-            tree.diff_children(&[&self.base, &self.top]);
+        fn diff(&mut self, tree: &mut Tree) {
+            tree.diff_children(&mut [&mut self.base, &mut self.top]);
         }
 
         fn size(&self) -> Size<Length> {
             self.base.as_widget().size()
-        }
-
-        fn size_hint(&self) -> Size<Length> {
-            self.base.as_widget().size_hint()
         }
 
         fn layout(

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -134,13 +134,12 @@ where
         child: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         let child = child.into();
-        let child_size = child.as_widget().size_hint();
 
-        self.width = self.width.enclose(child_size.width);
-        self.height = self.height.enclose(child_size.height);
+        if !child.as_widget().size().is_void() {
+            self.keys.push(key);
+            self.children.push(child);
+        }
 
-        self.keys.push(key);
-        self.children.push(child);
         self
     }
 
@@ -201,11 +200,7 @@ where
         })
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.children.iter().map(Tree::new).collect()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let Tree {
             state, children, ..
         } = tree;
@@ -214,8 +209,8 @@ where
 
         tree::diff_children_custom_with_search(
             children,
-            &self.children,
-            |tree, child| child.as_widget().diff(tree),
+            &mut self.children,
+            |tree, child| child.as_widget_mut().diff(tree),
             |index| {
                 self.keys.get(index).or_else(|| self.keys.last()).copied()
                     != Some(state.keys[index])

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -64,8 +64,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: Length::Fit,
+            height: Length::Fit,
             max_width: f32::INFINITY,
             align_items: Alignment::Start,
             keys,
@@ -220,6 +220,15 @@ where
 
         if state.keys != self.keys {
             state.keys.clone_from(&self.keys);
+        }
+
+        if self.width.is_fit() || self.height.is_fit() {
+            for child in &self.children {
+                let size = child.as_widget().size();
+
+                self.width = self.width.enclose(size.width);
+                self.height = self.height.enclose(size.height);
+            }
         }
     }
 

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -107,11 +107,7 @@ where
         tree::State::new(Internal { element, hash })
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.with_element(|element| vec![Tree::new(element.as_widget())])
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let current = tree
             .state
             .downcast_mut::<Internal<Message, Theme, Renderer>>();
@@ -128,25 +124,17 @@ where
 
             let element = (self.view)(&self.dependency).into();
             current.element = Rc::new(RefCell::new(Some(element)));
-
-            (*self.element.borrow_mut()) = Some(current.element.clone());
-            self.with_element(|element| {
-                tree.diff_children(std::slice::from_ref(&element.as_widget()));
-            });
-        } else {
-            (*self.element.borrow_mut()) = Some(current.element.clone());
         }
+
+        (*self.element.borrow_mut()) = Some(current.element.clone());
+
+        self.with_element_mut(|element| {
+            tree.diff_children(std::slice::from_mut(&mut element.as_widget_mut()));
+        });
     }
 
     fn size(&self) -> Size<Length> {
         self.with_element(|element| element.as_widget().size())
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        Size {
-            width: Length::Shrink,
-            height: Length::Shrink,
-        }
     }
 
     fn layout(

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -314,7 +314,7 @@ where
             shell.capture_event();
         }
 
-        local_shell.revalidate_layout(|| shell.invalidate_layout());
+        local_shell.revalidate_layout(|diff| shell.invalidate_layout_with(diff));
         shell.request_redraw_at(local_shell.redraw_request());
         shell.request_input_method(local_shell.input_method());
         shell.clipboard_mut().merge(local_shell.clipboard_mut());
@@ -581,7 +581,7 @@ where
             shell.capture_event();
         }
 
-        local_shell.revalidate_layout(|| shell.invalidate_layout());
+        local_shell.revalidate_layout(|diff| shell.invalidate_layout_with(diff));
         shell.request_redraw_at(local_shell.redraw_request());
         shell.request_input_method(local_shell.input_method());
         shell.clipboard_mut().merge(local_shell.clipboard_mut());

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -132,13 +132,13 @@ where
     Renderer: renderer::Renderer,
 {
     fn diff_self(&self) {
-        self.with_element(|element| {
+        self.with_element_mut(|element| {
             self.tree
                 .borrow_mut()
                 .borrow_mut()
                 .as_mut()
                 .unwrap()
-                .diff_children(std::slice::from_ref(&element));
+                .diff_children(std::slice::from_mut(element));
         });
     }
 
@@ -257,11 +257,7 @@ where
         tree::State::new(state)
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![]
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let tree = tree.state.downcast_ref::<Rc<RefCell<Option<Tree>>>>();
         *self.tree.borrow_mut() = tree.clone();
         self.rebuild_element_if_necessary();
@@ -269,15 +265,6 @@ where
 
     fn size(&self) -> Size<Length> {
         self.with_element(|element| element.as_widget().size())
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.state
-            .borrow()
-            .as_ref()
-            .expect("Borrow instance state")
-            .borrow_component()
-            .size_hint()
     }
 
     fn layout(

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -163,12 +163,8 @@ where
         tree::State::new(State::default())
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![Tree::new(&self.content)]
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content));
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
     }
 
     fn size(&self) -> Size<Length> {

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -210,7 +210,7 @@ where
             class,
         } = menu;
 
-        let list = Scrollable::new(List {
+        let mut list = Scrollable::new(List {
             options,
             hovered_option,
             to_string,
@@ -226,7 +226,7 @@ where
         })
         .height(menu_height);
 
-        state.tree.diff(&list as &dyn Widget<_, _, _>);
+        state.tree.diff(&mut list as &mut dyn Widget<_, _, _>);
 
         Self {
             position,

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -355,11 +355,7 @@ where
         tree::State::new(Memory::default())
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.contents.iter().map(Content::state).collect()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let Memory { order, .. } = tree.state.downcast_ref();
 
         // `Pane` always increments and is iterated by Ord so new
@@ -382,7 +378,7 @@ where
         });
 
         tree.diff_children_custom(
-            &self.contents,
+            &mut self.contents,
             |state, content| content.diff(state),
             Content::state,
         );

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -77,13 +77,13 @@ where
         }
     }
 
-    pub(super) fn diff(&self, tree: &mut Tree) {
+    pub(super) fn diff(&mut self, tree: &mut Tree) {
         if tree.children.len() == 2 {
-            if let Some(title_bar) = self.title_bar.as_ref() {
+            if let Some(title_bar) = &mut self.title_bar {
                 title_bar.diff(&mut tree.children[1]);
             }
 
-            tree.children[0].diff(&self.body);
+            tree.children[0].diff(&mut self.body);
         } else {
             *tree = self.state();
         }

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -112,20 +112,20 @@ where
         }
     }
 
-    pub(super) fn diff(&self, tree: &mut Tree) {
-        if tree.children.len() == 3 {
-            if let Some(controls) = self.controls.as_ref() {
-                if let Some(compact) = controls.compact.as_ref() {
-                    tree.children[2].diff(compact);
-                }
-
-                tree.children[1].diff(&controls.full);
-            }
-
-            tree.children[0].diff(&self.content);
-        } else {
+    pub(super) fn diff(&mut self, tree: &mut Tree) {
+        if tree.children.len() != 3 {
             *tree = self.state();
         }
+
+        if let Some(controls) = &mut self.controls {
+            if let Some(compact) = &mut controls.compact {
+                tree.children[2].diff(compact);
+            }
+
+            tree.children[1].diff(&mut controls.full);
+        }
+
+        tree.children[0].diff(&mut self.content);
     }
 
     /// Draws the [`TitleBar`] with the provided [`Renderer`] and [`Layout`].

--- a/widget/src/pin.rs
+++ b/widget/src/pin.rs
@@ -119,12 +119,8 @@ where
         self.content.as_widget().state()
     }
 
-    fn children(&self) -> Vec<widget::Tree> {
-        self.content.as_widget().children()
-    }
-
-    fn diff(&self, tree: &mut widget::Tree) {
-        self.content.as_widget().diff(tree);
+    fn diff(&mut self, tree: &mut widget::Tree) {
+        self.content.as_widget_mut().diff(tree);
     }
 
     fn size(&self) -> Size<Length> {

--- a/widget/src/responsive.rs
+++ b/widget/src/responsive.rs
@@ -55,7 +55,7 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
 {
-    fn diff(&self, _tree: &mut Tree) {
+    fn diff(&mut self, _tree: &mut Tree) {
         // Diff is deferred to layout
     }
 
@@ -76,7 +76,7 @@ where
         let size = limits.max();
 
         self.content = (self.view)(size);
-        tree.diff_children(std::slice::from_ref(&self.content));
+        tree.diff_children(std::slice::from_mut(&mut self.content));
 
         let node =
             self.content

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -34,8 +34,8 @@ use crate::core::{
 pub struct Row<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     align: Alignment,
     clip: bool,
     children: Vec<Element<'a, Message, Theme, Renderer>>,
@@ -75,8 +75,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: None,
-            height: None,
+            width: Length::Intrinsic,
+            height: Length::Intrinsic,
             align: Alignment::Start,
             clip: false,
             children,
@@ -101,13 +101,13 @@ where
 
     /// Sets the width of the [`Row`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Row`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -181,39 +181,20 @@ where
     fn diff(&mut self, tree: &mut Tree) {
         tree.diff_children(&mut self.children);
 
-        let inherit_width = self.width.is_none();
-        let inherit_height = self.height.is_none();
-
-        if inherit_width || inherit_height {
-            let mut width = self.width.unwrap_or(Length::Shrink);
-            let mut height = self.height.unwrap_or(Length::Shrink);
-
+        if self.width.is_intrinsic() || self.height.is_intrinsic() {
             for child in &self.children {
                 let size = child.as_widget().size();
 
-                if inherit_width {
-                    width = width.enclose(size.width);
-                }
-
-                if inherit_height {
-                    height = height.enclose(size.height);
-                }
-            }
-
-            if inherit_width {
-                self.width = Some(width);
-            }
-
-            if inherit_height {
-                self.height = Some(height);
+                self.width = self.width.enclose(size.width);
+                self.height = self.height.enclose(size.height);
             }
         }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -34,8 +34,8 @@ use crate::core::{
 pub struct Row<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     align: Alignment,
     clip: bool,
     children: Vec<Element<'a, Message, Theme, Renderer>>,
@@ -75,8 +75,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: None,
+            height: None,
             align: Alignment::Start,
             clip: false,
             children,
@@ -101,13 +101,13 @@ where
 
     /// Sets the width of the [`Row`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Row`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
@@ -127,11 +127,9 @@ where
     /// Adds an [`Element`] to the [`Row`].
     pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
-        let child_size = child.as_widget().size_hint();
+        let child_size = child.as_widget().size();
 
         if !child_size.is_void() {
-            self.width = self.width.enclose(child_size.width);
-            self.height = self.height.enclose(child_size.height);
             self.children.push(child);
         }
 
@@ -180,18 +178,42 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.children.iter().map(Tree::new).collect()
-    }
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+        let inherit_width = self.width.is_none();
+        let inherit_height = self.height.is_none();
+
+        if inherit_width || inherit_height {
+            let mut width = self.width.unwrap_or(Length::Shrink);
+            let mut height = self.height.unwrap_or(Length::Shrink);
+
+            for child in &self.children {
+                let size = child.as_widget().size();
+
+                if inherit_width {
+                    width = width.enclose(size.width);
+                }
+
+                if inherit_height {
+                    height = height.enclose(size.height);
+                }
+            }
+
+            if inherit_width {
+                self.width = Some(width);
+            }
+
+            if inherit_height {
+                self.height = Some(height);
+            }
+        }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -201,12 +223,14 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
+
         layout::flex::resolve(
             layout::flex::Axis::Horizontal,
             renderer,
             limits,
-            self.width,
-            self.height,
+            size.width,
+            size.height,
             self.padding,
             self.spacing,
             self.align,
@@ -372,11 +396,7 @@ impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.row.children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         self.row.diff(tree);
     }
 
@@ -390,9 +410,11 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
+
         let limits = limits
-            .width(self.row.width)
-            .height(self.row.height)
+            .width(size.width)
+            .height(size.height)
             .shrink(self.row.padding);
 
         let child_limits = limits.loose();
@@ -489,7 +511,7 @@ where
             }
         }
 
-        let size = limits.resolve(self.row.width, self.row.height, intrinsic_size);
+        let size = limits.resolve(size.width, size.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.row.padding), children)
     }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -204,14 +204,12 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
-
         layout::flex::resolve(
             layout::flex::Axis::Horizontal,
             renderer,
             limits,
-            size.width,
-            size.height,
+            self.width,
+            self.height,
             self.padding,
             self.spacing,
             self.align,
@@ -391,11 +389,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
-
         let limits = limits
-            .width(size.width)
-            .height(size.height)
+            .width(self.row.width)
+            .height(self.row.height)
             .shrink(self.row.padding);
 
         let child_limits = limits.loose();
@@ -492,7 +488,7 @@ where
             }
         }
 
-        let size = limits.resolve(size.width, size.height, intrinsic_size);
+        let size = limits.resolve(self.row.width, self.row.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.row.padding), children)
     }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -75,8 +75,8 @@ where
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Intrinsic,
-            height: Length::Intrinsic,
+            width: Length::Fit,
+            height: Length::Fit,
             align: Alignment::Start,
             clip: false,
             children,
@@ -181,7 +181,7 @@ where
     fn diff(&mut self, tree: &mut Tree) {
         tree.diff_children(&mut self.children);
 
-        if self.width.is_intrinsic() || self.height.is_intrinsic() {
+        if self.width.is_fit() || self.height.is_fit() {
             for child in &self.children {
                 let size = child.as_widget().size();
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -411,13 +411,11 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
-
         let mut layout = |right_padding, bottom_padding| {
             layout::padded(
                 limits,
-                size.width,
-                size.height,
+                self.width,
+                self.height,
                 Padding {
                     right: right_padding,
                     bottom: bottom_padding,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -96,8 +96,8 @@ where
     ) -> Self {
         Scrollable {
             id: None,
-            width: Length::Intrinsic,
-            height: Length::Intrinsic,
+            width: Length::Fit,
+            height: Length::Fit,
             direction: direction.into(),
             auto_scroll: false,
             content: content.into(),

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -69,8 +69,8 @@ where
     Renderer: text::Renderer,
 {
     id: Option<widget::Id>,
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     direction: Direction,
     auto_scroll: bool,
     content: Element<'a, Message, Theme, Renderer>,
@@ -96,8 +96,8 @@ where
     ) -> Self {
         Scrollable {
             id: None,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: None,
+            height: None,
             direction: direction.into(),
             auto_scroll: false,
             content: content.into(),
@@ -105,21 +105,6 @@ where
             class: Theme::default(),
             last_status: None,
         }
-        .enclose()
-    }
-
-    fn enclose(mut self) -> Self {
-        let size_hint = self.content.as_widget().size_hint();
-
-        if self.direction.horizontal().is_none() {
-            self.width = self.width.enclose(size_hint.width);
-        }
-
-        if self.direction.vertical().is_none() {
-            self.height = self.height.enclose(size_hint.height);
-        }
-
-        self
     }
 
     /// Makes the [`Scrollable`] scroll horizontally, with default [`Scrollbar`] settings.
@@ -130,7 +115,7 @@ where
     /// Sets the [`Direction`] of the [`Scrollable`].
     pub fn direction(mut self, direction: impl Into<Direction>) -> Self {
         self.direction = direction.into();
-        self.enclose()
+        self
     }
 
     /// Sets the [`widget::Id`] of the [`Scrollable`].
@@ -141,13 +126,13 @@ where
 
     /// Sets the width of the [`Scrollable`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Scrollable`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
@@ -399,18 +384,24 @@ where
         tree::State::new(State::new())
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![Tree::new(&self.content)]
-    }
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content));
+        let size = self.content.as_widget().size();
+
+        if self.width.is_none() || self.direction.horizontal().is_none() {
+            self.width = Some(size.width);
+        }
+
+        if self.height.is_none() || self.direction.vertical().is_none() {
+            self.height = Some(size.height);
+        }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -420,11 +411,13 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
+        let size = self.size();
+
         let mut layout = |right_padding, bottom_padding| {
             layout::padded(
                 limits,
-                self.width,
-                self.height,
+                size.width,
+                size.height,
                 Padding {
                     right: right_padding,
                     bottom: bottom_padding,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -69,8 +69,8 @@ where
     Renderer: text::Renderer,
 {
     id: Option<widget::Id>,
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     direction: Direction,
     auto_scroll: bool,
     content: Element<'a, Message, Theme, Renderer>,
@@ -96,8 +96,8 @@ where
     ) -> Self {
         Scrollable {
             id: None,
-            width: None,
-            height: None,
+            width: Length::Intrinsic,
+            height: Length::Intrinsic,
             direction: direction.into(),
             auto_scroll: false,
             content: content.into(),
@@ -126,13 +126,13 @@ where
 
     /// Sets the width of the [`Scrollable`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Scrollable`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -389,19 +389,19 @@ where
 
         let size = self.content.as_widget().size();
 
-        if self.width.is_none() || self.direction.horizontal().is_none() {
-            self.width = Some(size.width);
+        if self.direction.horizontal().is_none() {
+            self.width = self.width.enclose(size.width);
         }
 
-        if self.height.is_none() || self.direction.vertical().is_none() {
-            self.height = Some(size.height);
+        if self.direction.vertical().is_none() {
+            self.height = self.height.enclose(size.height);
         }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 

--- a/widget/src/sensor.rs
+++ b/widget/src/sensor.rs
@@ -157,12 +157,8 @@ where
         })
     }
 
-    fn children(&self) -> Vec<Tree> {
-        vec![Tree::new(&self.content)]
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&[&self.content]);
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content));
     }
 
     fn update(
@@ -255,10 +251,6 @@ where
 
     fn size(&self) -> Size<Length> {
         self.content.as_widget().size()
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.content.as_widget().size_hint()
     }
 
     fn layout(

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -18,8 +18,8 @@ use crate::core::{Element, Event, Layout, Length, Rectangle, Shell, Size, Vector
 /// Keep in mind that too much layering will normally produce bad UX as well as
 /// introduce certain rendering overhead. Use this widget sparingly!
 pub struct Stack<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
-    width: Length,
-    height: Length,
+    width: Option<Length>,
+    height: Option<Length>,
     children: Vec<Element<'a, Message, Theme, Renderer>>,
     clip: bool,
     base_layer: usize,
@@ -49,16 +49,10 @@ where
     }
 
     /// Creates a [`Stack`] from an already allocated [`Vec`].
-    ///
-    /// Keep in mind that the [`Stack`] will not inspect the [`Vec`], which means
-    /// it won't automatically adapt to the sizing strategy of its contents.
-    ///
-    /// If any of the children have a [`Length::Fill`] strategy, you will need to
-    /// call [`Stack::width`] or [`Stack::height`] accordingly.
     pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: None,
+            height: None,
             children,
             clip: false,
             base_layer: 0,
@@ -67,27 +61,22 @@ where
 
     /// Sets the width of the [`Stack`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
+        self.width = Some(width.into());
         self
     }
 
     /// Sets the height of the [`Stack`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = height.into();
+        self.height = Some(height.into());
         self
     }
 
     /// Adds an element on top of the [`Stack`].
     pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
-        let child_size = child.as_widget().size_hint();
+        let child_size = child.as_widget().size();
 
         if !child_size.is_void() {
-            if self.children.is_empty() {
-                self.width = self.width.enclose(child_size.width);
-                self.height = self.height.enclose(child_size.height);
-            }
-
             self.children.push(child);
         }
 
@@ -134,18 +123,26 @@ impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
-    fn children(&self) -> Vec<Tree> {
-        self.children.iter().map(Tree::new).collect()
-    }
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(&mut self.children);
 
-    fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children);
+        if let Some(base) = self.children.get(self.base_layer) {
+            let size = base.as_widget().size();
+
+            if self.width.is_none() {
+                self.width = Some(size.width);
+            }
+
+            if self.height.is_none() {
+                self.height = Some(size.height);
+            }
+        }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width,
-            height: self.height,
+            width: self.width.unwrap_or(Length::Shrink),
+            height: self.height.unwrap_or(Length::Shrink),
         }
     }
 
@@ -155,10 +152,11 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
+        let size = self.size();
+        let limits = limits.width(size.width).height(size.height);
 
         if self.children.len() <= self.base_layer {
-            return layout::Node::new(limits.resolve(self.width, self.height, Size::ZERO));
+            return layout::Node::new(limits.resolve(size.width, size.height, Size::ZERO));
         }
 
         let base = self.children[self.base_layer].as_widget_mut().layout(
@@ -167,7 +165,7 @@ where
             &limits,
         );
 
-        let size = limits.resolve(self.width, self.height, base.size());
+        let size = limits.resolve(size.width, size.height, base.size());
         let limits = layout::Limits::new(Size::ZERO, size);
 
         let (under, above) = self.children.split_at_mut(self.base_layer);

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -18,8 +18,8 @@ use crate::core::{Element, Event, Layout, Length, Rectangle, Shell, Size, Vector
 /// Keep in mind that too much layering will normally produce bad UX as well as
 /// introduce certain rendering overhead. Use this widget sparingly!
 pub struct Stack<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
-    width: Option<Length>,
-    height: Option<Length>,
+    width: Length,
+    height: Length,
     children: Vec<Element<'a, Message, Theme, Renderer>>,
     clip: bool,
     base_layer: usize,
@@ -51,8 +51,8 @@ where
     /// Creates a [`Stack`] from an already allocated [`Vec`].
     pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
-            width: None,
-            height: None,
+            width: Length::Fit,
+            height: Length::Fit,
             children,
             clip: false,
             base_layer: 0,
@@ -61,13 +61,13 @@ where
 
     /// Sets the width of the [`Stack`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = Some(width.into());
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Stack`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
-        self.height = Some(height.into());
+        self.height = height.into();
         self
     }
 
@@ -129,20 +129,15 @@ where
         if let Some(base) = self.children.get(self.base_layer) {
             let size = base.as_widget().size();
 
-            if self.width.is_none() {
-                self.width = Some(size.width);
-            }
-
-            if self.height.is_none() {
-                self.height = Some(size.height);
-            }
+            self.width = self.width.enclose(size.width);
+            self.height = self.height.enclose(size.height);
         }
     }
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: self.width.unwrap_or(Length::Shrink),
-            height: self.height.unwrap_or(Length::Shrink),
+            width: self.width,
+            height: self.height,
         }
     }
 
@@ -152,11 +147,10 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = self.size();
-        let limits = limits.width(size.width).height(size.height);
+        let limits = limits.width(self.width).height(self.height);
 
         if self.children.len() <= self.base_layer {
-            return layout::Node::new(limits.resolve(size.width, size.height, Size::ZERO));
+            return layout::Node::new(limits.resolve(self.width, self.height, Size::ZERO));
         }
 
         let base = self.children[self.base_layer].as_widget_mut().layout(
@@ -165,7 +159,7 @@ where
             &limits,
         );
 
-        let size = limits.resolve(size.width, size.height, base.size());
+        let size = limits.resolve(self.width, self.height, base.size());
         let limits = layout::Limits::new(Size::ZERO, size);
 
         let (under, above) = self.children.split_at_mut(self.base_layer);

--- a/widget/src/table.rs
+++ b/widget/src/table.rs
@@ -88,7 +88,7 @@ where
         let columns = columns.into_iter();
         let rows = rows.into_iter();
 
-        let mut width = Length::Shrink;
+        let mut width = Length::Intrinsic;
         let mut cells = Vec::with_capacity(columns.size_hint().0 * (1 + rows.size_hint().0));
 
         let (mut columns, views): (Vec<_>, Vec<_>) = columns
@@ -125,7 +125,7 @@ where
             columns,
             cells,
             width,
-            height: Length::Shrink,
+            height: Length::Intrinsic,
             padding_x: 10.0,
             padding_y: 5.0,
             separator_x: 1.0,

--- a/widget/src/table.rs
+++ b/widget/src/table.rs
@@ -89,8 +89,6 @@ where
         let rows = rows.into_iter();
 
         let mut width = Length::Shrink;
-        let mut height = Length::Shrink;
-
         let mut cells = Vec::with_capacity(columns.size_hint().0 * (1 + rows.size_hint().0));
 
         let (mut columns, views): (Vec<_>, Vec<_>) = columns
@@ -110,28 +108,24 @@ where
             })
             .collect();
 
-        for row in rows {
-            for view in &views {
-                let cell = view(row.clone());
-                let size_hint = cell.as_widget().size_hint();
-
-                height = height.enclose(size_hint.height);
-
-                cells.push(cell);
-            }
-        }
-
         if width == Length::Shrink
             && let Some(first) = columns.first_mut()
         {
             first.width = Length::Fill;
         }
 
+        for row in rows {
+            for view in &views {
+                let cell = view(row.clone());
+                cells.push(cell);
+            }
+        }
+
         Self {
             columns,
             cells,
             width,
-            height,
+            height: Length::Shrink,
             padding_x: 10.0,
             padding_y: 5.0,
             separator_x: 1.0,
@@ -214,15 +208,14 @@ where
         })
     }
 
-    fn children(&self) -> Vec<widget::Tree> {
-        self.cells
-            .iter()
-            .map(|cell| widget::Tree::new(cell.as_widget()))
-            .collect()
-    }
+    fn diff(&mut self, tree: &mut widget::Tree) {
+        tree.diff_children(&mut self.cells);
 
-    fn diff(&self, tree: &mut widget::Tree) {
-        tree.diff_children(&self.cells);
+        for cell in &self.cells {
+            let size = cell.as_widget().size();
+
+            self.height = self.height.enclose(size.height);
+        }
     }
 
     fn layout(

--- a/widget/src/table.rs
+++ b/widget/src/table.rs
@@ -88,7 +88,7 @@ where
         let columns = columns.into_iter();
         let rows = rows.into_iter();
 
-        let mut width = Length::Intrinsic;
+        let mut width = Length::Fit;
         let mut cells = Vec::with_capacity(columns.size_hint().0 * (1 + rows.size_hint().0));
 
         let (mut columns, views): (Vec<_>, Vec<_>) = columns
@@ -125,7 +125,7 @@ where
             columns,
             cells,
             width,
-            height: Length::Intrinsic,
+            height: Length::Fit,
             padding_x: 10.0,
             padding_y: 5.0,
             separator_x: 1.0,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -627,7 +627,7 @@ where
             Length::Fill | Length::FillPortion(_) | Length::Fixed(_) => {
                 layout::Node::new(limits.max())
             }
-            Length::Shrink => {
+            Length::Shrink | Length::Intrinsic => {
                 let min_bounds = internal.editor.min_bounds();
 
                 layout::Node::new(

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -627,7 +627,7 @@ where
             Length::Fill | Length::FillPortion(_) | Length::Fixed(_) => {
                 layout::Node::new(limits.max())
             }
-            Length::Shrink | Length::Intrinsic => {
+            Length::Shrink | Length::Fit => {
                 let min_bounds = internal.editor.min_bounds();
 
                 layout::Node::new(

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -603,7 +603,7 @@ where
         tree::State::new(State::<Renderer::Paragraph>::new())
     }
 
-    fn diff(&self, tree: &mut Tree) {
+    fn diff(&mut self, tree: &mut Tree) {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
         // Stop pasting if input becomes disabled

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -70,12 +70,8 @@ where
         self.content.as_widget().state()
     }
 
-    fn children(&self) -> Vec<Tree> {
-        self.content.as_widget().children()
-    }
-
-    fn diff(&self, tree: &mut Tree) {
-        self.content.as_widget().diff(tree);
+    fn diff(&mut self, tree: &mut Tree) {
+        self.content.as_widget_mut().diff(tree);
     }
 
     fn size(&self) -> Size<Length> {

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -152,15 +152,8 @@ where
     Theme: container::Catalog,
     Renderer: text::Renderer,
 {
-    fn children(&self) -> Vec<widget::Tree> {
-        vec![
-            widget::Tree::new(&self.content),
-            widget::Tree::new(&self.tooltip),
-        ]
-    }
-
-    fn diff(&self, tree: &mut widget::Tree) {
-        tree.diff_children(&[self.content.as_widget(), self.tooltip.as_widget()]);
+    fn diff(&mut self, tree: &mut widget::Tree) {
+        tree.diff_children(&mut [self.content.as_widget_mut(), self.tooltip.as_widget_mut()]);
     }
 
     fn state(&self) -> widget::tree::State {
@@ -173,10 +166,6 @@ where
 
     fn size(&self) -> Size<Length> {
         self.content.as_widget().size()
-    }
-
-    fn size_hint(&self) -> Size<Length> {
-        self.content.as_widget().size_hint()
     }
 
     fn layout(


### PR DESCRIPTION
This PR changes the `Widget` trait to call `diff` logic consistently after every `view` with a mutable `self`.

Effectively, this makes the `diff` method a lot more powerful; since it can now be used to run initialization logic in a consistent way.

For instance, sizing inheritance has been moved from widget tree construction to the `diff` method. This allows dynamic widgets like `component` (and the upcoming `transition` in #3344) to properly report their final size, since they now have a chance to access persistent state.

However, given that now sizing inheritance is done after widget construction, we need a way to differentiate between `Shrink` and the default "inherited sizing" strategy of containers. This prompted the introduction of a new `Length` variant called `Fit`.

Using `Fit` should be a no-op in most cases, since it's the default sizing strategy of most widgets. However, `Fit` will become quite useful soon.

Furthermore, since `diff` is now called after every `view`, the `children` method in `Widget` becomes redundant. We can simply initialize `Tree::children` as an empty `Vec` and let `diff` do the rest–removing the need to keep both `children` and `diff` logic synchronized.

Finally, since sizing inheritance can be properly done during `diff`, we can also get rid of the `size_hint` hack.

Lots of things clicking into place here!