### PR TITLE
Set resolution limits as defined by adapter for non-wasm32

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -148,7 +148,10 @@ impl Compositor {
         let limits = [wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())];
 
         #[cfg(not(target_arch = "wasm32"))]
-        let limits = [wgpu::Limits::default(), wgpu::Limits::downlevel_defaults()];
+        let limits = [
+            wgpu::Limits::default().using_resolution(adapter.limits()),
+            wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits()),
+        ];
 
         let limits = limits.into_iter().map(|limits| wgpu::Limits {
             max_bind_groups: 2,


### PR DESCRIPTION
As of wgpu 29 update we've been hitting the following panic on Apple Silicon.

thread 'main' (15199) panicked at <snip>/wgpu-29.0.3/src/backend/wgpu_core.rs:3879:18:
wgpu error: Validation Error

Caused by:
In Surface::configure
Surface width and height must be within the maximum supported texture size. Requested was (2060, 1528), maximum extent for either dimension is 2048.

A similar issue can be found upstream https://github.com/gfx-rs/wgpu/issues/4576
and the comment recommends setting the resolution given the adapter limits.

We do that already for the wasm32 target, so all this does is extending it
to all targets.
