### PR TITLE
Make sure we trim image/svg caches after rendering.

### DIFF
--- a/vello_cpu/src/lib.rs
+++ b/vello_cpu/src/lib.rs
@@ -348,6 +348,11 @@ impl Renderer {
             renderer.pop_clip_path();
         }
 
+        #[cfg(feature = "image")]
+        self.raster.trim_cache();
+        #[cfg(feature = "svg")]
+        self.vector.trim_cache();
+
         self.text.trim_cache();
     }
 }


### PR DESCRIPTION
Previously image/vector resources were leaking.