### PR TITLE
bump glam to `0.33`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.25.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+checksum = "898f5a568a84989b6c0f8caa50a93074b97dbdc58fc6d9543157bb4562758933"
 dependencies = [
  "bytemuck",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,6 @@ dependencies = [
  "bytemuck",
  "cryoglyph",
  "futures",
- "glam",
  "guillotiere",
  "iced_debug",
  "iced_graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ cargo-hot = { version = "0.1", package = "cargo-hot-protocol" }
 cosmic-text = "0.19"
 cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "53ba3e879539d19ed8162942126a977ec896cc3b" }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-glam = "0.25"
+glam = "0.33"
 guillotiere = "0.6"
 half = "2.2"
 image = { version = "0.25", default-features = false }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -33,7 +33,6 @@ iced_graphics.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
 futures.workspace = true
-glam.workspace = true
 cryoglyph.workspace = true
 guillotiere.workspace = true
 log.workspace = true


### PR DESCRIPTION
the API is identical and all tests pass. `glam` isn't used in `iced_wgpu`, so I took the liberty of removing it from there.