### PR TITLE
fix(svg): parse in-memory SVG with leading whitespace

### DIFF
--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -11,6 +11,23 @@ use std::fs;
 use std::panic;
 use std::sync::Arc;
 
+/// Parses raw in-memory SVG bytes into a [`usvg::Tree`].
+///
+/// `usvg`'s XML parser rejects an `<?xml ?>` declaration that is preceded by
+/// any whitespace, so a formatted, multi-line SVG string fails to load while
+/// the very same SVG compressed onto a single line succeeds. We trim the
+/// leading whitespace of uncompressed data so both parse. gzip-compressed data
+/// (identified by its magic number) is handed to `usvg` untouched, as it knows
+/// how to decompress it.
+fn parse_bytes(bytes: &[u8], options: &usvg::Options) -> Option<usvg::Tree> {
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        return usvg::Tree::from_data(bytes, options).ok();
+    }
+
+    let contents = std::str::from_utf8(bytes).ok()?;
+    usvg::Tree::from_str(contents.trim_start(), options).ok()
+}
+
 #[derive(Debug)]
 pub struct Pipeline {
     cache: RefCell<Cache>,
@@ -106,10 +123,10 @@ impl Cache {
 
         if let hash_map::Entry::Vacant(entry) = self.trees.entry(id) {
             let svg = match handle.data() {
-                Data::Path(path) => fs::read_to_string(path)
-                    .ok()
-                    .and_then(|contents| usvg::Tree::from_str(&contents, &options).ok()),
-                Data::Bytes(bytes) => usvg::Tree::from_data(bytes, &options).ok(),
+                Data::Path(path) => fs::read_to_string(path).ok().and_then(|contents| {
+                    usvg::Tree::from_str(contents.trim_start(), &options).ok()
+                }),
+                Data::Bytes(bytes) => parse_bytes(bytes, &options),
             };
 
             let _ = entry.insert(svg);

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -44,6 +44,23 @@ pub struct Cache {
 
 type ColorFilter = Option<[u8; 4]>;
 
+/// Parses raw in-memory SVG bytes into a [`usvg::Tree`].
+///
+/// `usvg`'s XML parser rejects an `<?xml ?>` declaration that is preceded by
+/// any whitespace, so a formatted, multi-line SVG string fails to load while
+/// the very same SVG compressed onto a single line succeeds. We trim the
+/// leading whitespace of uncompressed data so both parse. gzip-compressed data
+/// (identified by its magic number) is handed to `usvg` untouched, as it knows
+/// how to decompress it.
+fn parse_bytes(bytes: &[u8], options: &usvg::Options) -> Option<usvg::Tree> {
+    if bytes.starts_with(&[0x1f, 0x8b]) {
+        return usvg::Tree::from_data(bytes, options).ok();
+    }
+
+    let contents = std::str::from_utf8(bytes).ok()?;
+    usvg::Tree::from_str(contents.trim_start(), options).ok()
+}
+
 impl Cache {
     /// Load svg
     pub fn load(&mut self, handle: &svg::Handle) -> &Svg {
@@ -71,13 +88,12 @@ impl Cache {
         let svg = match handle.data() {
             svg::Data::Path(path) => fs::read_to_string(path)
                 .ok()
-                .and_then(|contents| usvg::Tree::from_str(&contents, &options).ok())
+                .and_then(|contents| usvg::Tree::from_str(contents.trim_start(), &options).ok())
                 .map(Svg::Loaded)
                 .unwrap_or(Svg::NotFound),
-            svg::Data::Bytes(bytes) => match usvg::Tree::from_data(bytes, &options) {
-                Ok(tree) => Svg::Loaded(tree),
-                Err(_) => Svg::NotFound,
-            },
+            svg::Data::Bytes(bytes) => parse_bytes(bytes, &options)
+                .map(Svg::Loaded)
+                .unwrap_or(Svg::NotFound),
         };
 
         self.should_trim = true;


### PR DESCRIPTION
`svg::Handle::from_memory` failed to parse a valid SVG string whenever any whitespace (newline, space, tab, CR) preceded the `<?xml ?>` declaration — e.g. a Rust raw string that starts on its own line. `usvg`'s XML parser rejects a declaration that is not at the very start of the document, so the same SVG worked only when compressed onto a single line or loaded via `include_bytes!` (whose file simply started with `<?xml`).

Both renderers now parse uncompressed in-memory bytes via `usvg::Tree::from_str` after `trim_start()`, mirroring the file-path branch (likewise trimmed for consistency). gzip-compressed data is still handed to `usvg::Tree::from_data` untouched.

Closes #3357

Created by Claude