### PR TITLE
Fix canvas ghosting in the wgpu renderer

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -293,13 +293,13 @@ impl Renderer {
         for layer in self.layers.iter() {
             let clip_bounds = layer.bounds * scale_factor;
 
-            if physical_bounds
+            let Some(layer_bounds) = physical_bounds
                 .intersection(&clip_bounds)
                 .and_then(Rectangle::snap)
-                .is_none()
-            {
+                .map(Rectangle::<f32>::from)
+            else {
                 continue;
-            }
+            };
 
             if !layer.quads.is_empty() {
                 let prepare_span = debug::prepare(debug::Primitive::Quad);
@@ -326,6 +326,7 @@ impl Renderer {
                     &mut self.staging_belt,
                     encoder,
                     &layer.triangles,
+                    layer_bounds,
                     Transformation::scale(scale_factor),
                     viewport.physical_size(),
                 );

--- a/wgpu/src/shader/triangle.wgsl
+++ b/wgpu/src/shader/triangle.wgsl
@@ -1,5 +1,19 @@
 struct Globals {
     transform: mat4x4<f32>,
+    clip_bounds: vec4<f32>,
 }
 
 @group(0) @binding(0) var<uniform> globals: Globals;
+
+fn discard_if_clipped(position: vec4<f32>) {
+    let pixel = position.xy;
+
+    if (
+        pixel.x < globals.clip_bounds.x ||
+        pixel.y < globals.clip_bounds.y ||
+        pixel.x >= globals.clip_bounds.z ||
+        pixel.y >= globals.clip_bounds.w
+    ) {
+        discard;
+    }
+}

--- a/wgpu/src/shader/triangle/gradient.wgsl
+++ b/wgpu/src/shader/triangle/gradient.wgsl
@@ -86,6 +86,8 @@ fn gradient(
 
 @fragment
 fn gradient_fs_main(input: GradientVertexOutput) -> @location(0) vec4<f32> {
+    discard_if_clipped(input.position);
+
     let colors = array<vec4<f32>, 8>(
         unpack_color(input.colors_1.xy),
         unpack_color(input.colors_1.zw),

--- a/wgpu/src/shader/triangle/solid.wgsl
+++ b/wgpu/src/shader/triangle/solid.wgsl
@@ -20,5 +20,7 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
 
 @fragment
 fn solid_fs_main(input: SolidVertexOutput) -> @location(0) vec4<f32> {
+    discard_if_clipped(input.position);
+
     return input.color;
 }

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -31,6 +31,7 @@ pub enum Item {
 struct Upload {
     layer: Layer,
     transformation: Transformation,
+    bounds: Rectangle,
     version: usize,
     batch: Arc<[Mesh]>,
 }
@@ -62,12 +63,16 @@ impl Storage {
         gradient: &gradient::Pipeline,
         cache: &mesh::Cache,
         new_transformation: Transformation,
+        new_bounds: Rectangle,
+        screen_transformation: Transformation,
     ) {
         match self.uploads.entry(cache.id()) {
             hash_map::Entry::Occupied(entry) => {
                 let upload = entry.into_mut();
 
-                if upload.version != cache.version() || upload.transformation != new_transformation
+                if upload.version != cache.version()
+                    || upload.transformation != new_transformation
+                    || upload.bounds != new_bounds
                 {
                     if !cache.is_empty() {
                         upload.layer.prepare(
@@ -78,12 +83,15 @@ impl Storage {
                             gradient,
                             cache.batch(),
                             new_transformation,
+                            new_bounds,
+                            screen_transformation,
                         );
                     }
 
                     upload.batch = cache.batch().clone();
                     upload.version = cache.version();
                     upload.transformation = new_transformation;
+                    upload.bounds = new_bounds;
                 }
             }
             hash_map::Entry::Vacant(entry) => {
@@ -97,12 +105,15 @@ impl Storage {
                     gradient,
                     cache.batch(),
                     new_transformation,
+                    new_bounds,
+                    screen_transformation,
                 );
 
                 let _ = entry.insert(Upload {
                     layer,
                     transformation: new_transformation,
-                    version: 0,
+                    bounds: new_bounds,
+                    version: cache.version(),
                     batch: cache.batch().clone(),
                 });
 
@@ -155,14 +166,15 @@ impl State {
         belt: &mut wgpu::util::StagingBelt,
         encoder: &mut wgpu::CommandEncoder,
         items: &[Item],
+        bounds: Rectangle,
         scale: Transformation,
         target_size: Size<u32>,
     ) {
         let projection =
             if let Some((state, pipeline)) = self.msaa.as_mut().zip(pipeline.msaa.as_ref()) {
-                state.prepare(device, encoder, belt, pipeline, target_size) * scale
+                state.prepare(device, encoder, belt, pipeline, target_size)
             } else {
-                Transformation::orthographic(target_size.width, target_size.height) * scale
+                Transformation::orthographic(target_size.width, target_size.height)
             };
 
         for item in items {
@@ -171,6 +183,8 @@ impl State {
                     transformation,
                     meshes,
                 } => {
+                    let screen_transformation = scale * *transformation;
+
                     if self.layers.len() <= self.prepare_layer {
                         self.layers
                             .push(Layer::new(device, &pipeline.solid, &pipeline.gradient));
@@ -184,7 +198,9 @@ impl State {
                         &pipeline.solid,
                         &pipeline.gradient,
                         meshes,
-                        projection * *transformation,
+                        projection * screen_transformation,
+                        bounds,
+                        screen_transformation,
                     );
 
                     self.prepare_layer += 1;
@@ -193,6 +209,8 @@ impl State {
                     transformation,
                     cache,
                 } => {
+                    let screen_transformation = scale * *transformation;
+
                     self.storage.prepare(
                         device,
                         encoder,
@@ -200,7 +218,9 @@ impl State {
                         &pipeline.solid,
                         &pipeline.gradient,
                         cache,
-                        projection * *transformation,
+                        projection * screen_transformation,
+                        bounds,
+                        screen_transformation,
                     );
                 }
             }
@@ -359,6 +379,8 @@ impl Layer {
         gradient: &gradient::Pipeline,
         meshes: &[Mesh],
         transformation: Transformation,
+        bounds: Rectangle,
+        screen_transformation: Transformation,
     ) {
         // Count the total amount of vertices & indices we need to handle
         let count = mesh::attribute_count_of(meshes);
@@ -394,19 +416,24 @@ impl Layer {
         let mut index_offset = 0;
 
         for mesh in meshes {
-            let clip_bounds = mesh.clip_bounds() * transformation;
-            let snap_distance = clip_bounds
+            let transformed_clip_bounds = mesh.clip_bounds() * transformation;
+            let snap_distance = transformed_clip_bounds
                 .snap()
                 .map(|snapped_bounds| {
                     Point::new(snapped_bounds.x as f32, snapped_bounds.y as f32)
-                        - clip_bounds.position()
+                        - transformed_clip_bounds.position()
                 })
                 .unwrap_or(Vector::ZERO);
+
+            let clip_bounds = bounds
+                .intersection(&(mesh.clip_bounds() * screen_transformation))
+                .unwrap_or_default();
 
             let uniforms = Uniforms::new(
                 transformation
                     * mesh.transformation()
                     * Transformation::translate(snap_distance.x, snap_distance.y),
+                clip_bounds,
             );
 
             let indices = mesh.indices();
@@ -579,16 +606,23 @@ fn multisample_state(antialiasing: Option<Antialiasing>) -> wgpu::MultisampleSta
 #[repr(C)]
 pub struct Uniforms {
     transform: [f32; 16],
+    clip_bounds: [f32; 4],
     /// Uniform values must be 256-aligned;
     /// see: [`wgpu::Limits`] `min_uniform_buffer_offset_alignment`.
-    _padding: [f32; 48],
+    _padding: [f32; 44],
 }
 
 impl Uniforms {
-    pub fn new(transform: Transformation) -> Self {
+    pub fn new(transform: Transformation, clip_bounds: Rectangle) -> Self {
         Self {
             transform: transform.into(),
-            _padding: [0.0; 48],
+            clip_bounds: [
+                clip_bounds.x,
+                clip_bounds.y,
+                clip_bounds.x + clip_bounds.width,
+                clip_bounds.y + clip_bounds.height,
+            ],
+            _padding: [0.0; 44],
         }
     }
 

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -142,6 +142,25 @@ impl Pipeline {
         let targets = self.targets.read().expect("Read MSAA targets");
         let targets = targets.as_ref().unwrap();
 
+        {
+            let _clear_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("iced_wgpu.triangle.resolve.clear_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &targets.resolve,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("iced_wgpu.triangle.render_pass"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -131,12 +131,11 @@ impl Compositor {
 
                 log::info!("Available alpha modes: {alpha_modes:#?}");
 
-                let preferred_alpha =
-                    if alpha_modes.contains(&wgpu::CompositeAlphaMode::PreMultiplied) {
-                        wgpu::CompositeAlphaMode::PreMultiplied
-                    } else {
-                        wgpu::CompositeAlphaMode::Auto
-                    };
+                let preferred_alpha = if alpha_modes.contains(&wgpu::CompositeAlphaMode::Opaque) {
+                    wgpu::CompositeAlphaMode::Opaque
+                } else {
+                    wgpu::CompositeAlphaMode::Auto
+                };
 
                 format.zip(Some(preferred_alpha))
             })


### PR DESCRIPTION
This PR fixes stale `iced::widget::canvas` pixels that can remain visible after a canvas is resized, clipped, hidden, or covered by another layer.

The issue was observed with the `wgpu` renderer on **`Red Hat 8 and Red Hat 9`**. The same application did not reproduce it on the macOS / CentOS 7 systems used for comparison. Layout, hit testing, scrollbars, and widget sizing were correct; only the rendered pixels were stale.

## Reproduction
<details>
<summary>Repro Demo, RedHat 8</summary>

```rust
use iced::mouse;
use iced::time::{self, milliseconds};
use iced::widget::canvas::{self, Canvas, Geometry, Path, Stroke, stroke};
use iced::widget::{button, column, container, row, stack, text};
use iced::{
    Alignment, Color, Element, Fill, Length, Point, Rectangle, Renderer, Size, Subscription, Task,
    Theme,
};

use std::time::Instant;

pub fn main() -> iced::Result {
    iced::application(Ghosting::new, Ghosting::update, Ghosting::view)
        .subscription(Ghosting::subscription)
        .title(Ghosting::title)
        .theme(Ghosting::theme)
        .run()
}

struct Ghosting {
    started: Instant,
    left_width: f32,
    right_width: f32,
    show_dialog: bool,
}

#[derive(Debug, Clone, Copy)]
enum Message {
    Tick(Instant),
    ToggleDialog,
}

impl Ghosting {
    fn new() -> (Self, Task<Message>) {
        (
            Self {
                started: Instant::now(),
                left_width: 220.0,
                right_width: 220.0,
                show_dialog: false,
            },
            Task::none(),
        )
    }

    fn update(&mut self, message: Message) {
        match message {
            Message::Tick(now) => {
                let elapsed = now.duration_since(self.started);
                let seconds = elapsed.as_secs_f32();
                let phase = (seconds * std::f32::consts::TAU / 3.0).sin() * 0.5 + 0.5;

                self.left_width = 80.0 + 340.0 * phase;
                self.right_width = 80.0 + 340.0 * (1.0 - phase);
            }
            Message::ToggleDialog => {
                self.show_dialog = !self.show_dialog;
            }
        }
    }

    fn subscription(&self) -> Subscription<Message> {
        time::every(milliseconds(16)).map(Message::Tick)
    }

    fn title(&self) -> String {
        format!(
            "Canvas Ghosting (dialog {})",
            if self.show_dialog { "on" } else { "off" }
        )
    }

    fn theme(&self) -> Theme {
        Theme::Light
    }

    fn view(&self) -> Element<'_, Message> {
        let content = column![
            row![
                text(format!("Left {:.0}px", self.left_width)).width(120),
                text(format!("Right {:.0}px", self.right_width)).width(120),
                button("Toggle dialog").on_press(Message::ToggleDialog),
            ]
            .spacing(12)
            .align_y(Alignment::Center)
            .padding(6),
            row![
                side_panel("Left", self.left_width, Color::from_rgb(0.06, 0.47, 0.29)),
                Canvas::new(CircuitCanvas).width(Fill).height(Fill),
                side_panel("Right", self.right_width, Color::from_rgb(0.53, 0.11, 0.19)),
            ]
            .height(Fill),
        ]
        .width(Fill)
        .height(Fill);

        if self.show_dialog {
            let dialog = container(
                column![
                    text("Canvas Dialog").size(18),
                    Canvas::new(PlotCanvas)
                        .width(Fill)
                        .height(Length::Fixed(240.0)),
                    text("Text below the canvas must stay visible"),
                ]
                .spacing(8),
            )
            .width(Length::Fixed(640.0))
            .padding(8)
            .style(container::rounded_box);

            stack![
                content,
                container(dialog)
                    .width(Fill)
                    .height(Fill)
                    .center_x(Fill)
                    .center_y(Fill),
            ]
            .width(Fill)
            .height(Fill)
            .into()
        } else {
            content.into()
        }
    }
}

fn side_panel<'a>(title: &'static str, width: f32, color: Color) -> Element<'a, Message> {
    container(
        column![
            text(title).size(28),
            text("ordinary UI"),
            text("no canvas pixels should appear here"),
        ]
        .spacing(8)
        .align_x(Alignment::Center),
    )
    .width(Length::Fixed(width))
    .height(Fill)
    .center_x(Length::Fixed(width))
    .center_y(Fill)
    .style(move |_| container::Style {
        background: Some(color.into()),
        text_color: Some(Color::WHITE),
        ..container::Style::default()
    })
    .into()
}

struct CircuitCanvas;

impl<Message> canvas::Program<Message> for CircuitCanvas {
    type State = ();

    fn draw(
        &self,
        _state: &Self::State,
        renderer: &Renderer,
        _theme: &Theme,
        bounds: Rectangle,
        _cursor: mouse::Cursor,
    ) -> Vec<Geometry> {
        let mut frame = canvas::Frame::new(renderer, bounds.size());
        let size = frame.size();
        let background = Path::rectangle(Point::ORIGIN, size);

        frame.fill(&background, Color::from_rgb(0.02, 0.03, 0.06));
        draw_grid(&mut frame, size);
        draw_traces(
            &mut frame,
            size,
            Color::from_rgb(0.15, 0.86, 0.95),
            Color::from_rgb(0.95, 0.20, 0.88),
        );
        draw_blocks(&mut frame, Color::from_rgb(0.96, 0.74, 0.10));

        vec![frame.into_geometry()]
    }
}

struct PlotCanvas;

impl<Message> canvas::Program<Message> for PlotCanvas {
    type State = ();

    fn draw(
        &self,
        _state: &Self::State,
        renderer: &Renderer,
        _theme: &Theme,
        bounds: Rectangle,
        _cursor: mouse::Cursor,
    ) -> Vec<Geometry> {
        let mut frame = canvas::Frame::new(renderer, bounds.size());
        let size = frame.size();
        frame.fill_rectangle(Point::ORIGIN, size, Color::from_rgb(0.96, 0.97, 0.99));
        draw_plot_grid(&mut frame, size);
        draw_plot_lines(&mut frame, size);
        vec![frame.into_geometry()]
    }
}

fn draw_grid(frame: &mut canvas::Frame, size: Size) {
    let stroke = Stroke {
        width: 1.0,
        style: stroke::Style::Solid(Color::from_rgba(0.65, 0.75, 0.85, 0.35)),
        ..Stroke::default()
    };

    for x in (0..=size.width as usize).step_by(40) {
        frame.stroke(
            &Path::line(Point::new(x as f32, 0.0), Point::new(x as f32, size.height)),
            stroke,
        );
    }

    for y in (0..=size.height as usize).step_by(40) {
        frame.stroke(
            &Path::line(Point::new(0.0, y as f32), Point::new(size.width, y as f32)),
            stroke,
        );
    }
}

fn draw_traces(frame: &mut canvas::Frame, size: Size, a: Color, b: Color) {
    for offset in (-900..=900).step_by(110) {
        for (shift, color) in [(0.0, a), (size.height * 0.9, b)] {
            frame.stroke(
                &Path::line(
                    Point::new(offset as f32 + shift, 0.0),
                    Point::new(offset as f32 + size.height * 0.8 - shift, size.height),
                ),
                Stroke {
                    width: 3.0,
                    style: stroke::Style::Solid(color),
                    ..Stroke::default()
                },
            );
        }
    }
}

fn draw_blocks(frame: &mut canvas::Frame, color: Color) {
    for index in 0..8 {
        let x = 80.0 + index as f32 * 96.0;
        let y = if index % 2 == 0 { 150.0 } else { 380.0 };
        let block = Path::rectangle(Point::new(x, y), Size::new(54.0, 34.0));

        frame.fill(&block, Color::from_rgb(0.14, 0.17, 0.20));
        frame.stroke(
            &block,
            Stroke {
                width: 2.0,
                style: stroke::Style::Solid(color),
                ..Stroke::default()
            },
        );
    }
}

fn draw_plot_grid(frame: &mut canvas::Frame, size: Size) {
    let stroke = Stroke {
        width: 1.0,
        style: stroke::Style::Solid(Color::from_rgba(0.12, 0.16, 0.22, 0.25)),
        ..Stroke::default()
    };

    for x in (0..=size.width as usize).step_by(50) {
        frame.stroke(
            &Path::line(Point::new(x as f32, 0.0), Point::new(x as f32, size.height)),
            stroke,
        );
    }

    for y in (0..=size.height as usize).step_by(50) {
        frame.stroke(
            &Path::line(Point::new(0.0, y as f32), Point::new(size.width, y as f32)),
            stroke,
        );
    }
}

fn draw_plot_lines(frame: &mut canvas::Frame, size: Size) {
    for (offset, color) in [
        (0.0, Color::from_rgb(0.10, 0.44, 0.95)),
        (42.0, Color::from_rgb(0.88, 0.27, 0.20)),
    ] {
        let path = Path::new(|builder| {
            builder.move_to(Point::new(0.0, size.height * 0.70 + offset * 0.1));
            for step in 0..=18 {
                let t = step as f32 / 18.0;
                let x = t * size.width;
                let y =
                    size.height * (0.52 - 0.22 * (t * std::f32::consts::TAU * 1.6).sin()) + offset;
                builder.line_to(Point::new(x, y));
            }
        });

        frame.stroke(
            &path,
            Stroke {
                width: 3.0,
                style: stroke::Style::Solid(color),
                ..Stroke::default()
            },
        );
    }
}

```
</details>
Before:

https://github.com/user-attachments/assets/69ff0a18-6702-41cc-9298-bcab61bf44ba

Now:

https://github.com/user-attachments/assets/48a5cf00-247d-4406-bc0f-62a3d9c8af53

## Root Cause

The problem was in the `iced_wgpu` triangle rendering path, not in application layout or individual canvas widgets.

The MSAA triangle pipeline reuses an intermediate resolve texture. When a previous frame rendered a larger canvas, pixels could remain in untouched parts of that reused texture. A later frame with a smaller canvas or different clip bounds could then composite those stale pixels into the final frame.

Cached triangle uploads also need to account for the active clip bounds. The same mesh content can be valid under one clip and invalid under another.

## Fix

- Clear the MSAA triangle resolve texture to transparent before each triangle render pass.
- Carry active clip bounds through triangle uniforms and discard out-of-bounds fragments in the solid and gradient triangle shaders.
- Include active bounds in cached triangle upload state so cached meshes are re-prepared when clip bounds change.
- Record the current mesh cache version when creating a cached upload, avoiding an unnecessary re-prepare on the next frame.
- Prefer an opaque window surface alpha mode when the platform supports it, avoiding unnecessary compositor blending for normal opaque application windows.

Together, these changes make clipping and target reuse explicit in the renderer, so applications do not need widget-specific background clearing workarounds to hide stale canvas pixels.