### PR TITLE
Add `PowerPreference` setting to control GPU adapter selection

### DIFF
--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -129,7 +129,7 @@ pub enum PowerPreference {
     /// The backend will prefer lower-power adapters over higher-power ones. Recommended for most applications.
     LowPower,
 
-    /// The backend will prefer adapters that are higher performance. Use only in usecases with high, graphic-intensive workloads
+    /// The backend will prefer adapters that are higher performance. Use only in use cases with high, graphic-intensive workloads
     HighPerformance,
 }
 

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -120,16 +120,19 @@ impl fmt::Display for Api {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
-/// The power-usage preference for adapters
+#[derive(Debug, Clone, PartialEq, Copy, Default)]
+/// The power-usage preference for graphics adapters.
 pub enum PowerPreference {
-    /// No preference in which adapter wgpu should choose.
-    NoPreference,
+    /// No power preference in which adapter should be chosen.
+    ///
+    /// This is the default.
+    #[default]
+    None,
 
-    /// The backend will prefer lower-power adapters over higher-power ones. Recommended for most applications.
+    /// The backend will prefer low power adapters over high performance ones.
     LowPower,
 
-    /// The backend will prefer adapters that are higher performance. Use only in use cases with high, graphic-intensive workloads
+    /// The backend will prefer adapters that are high performance.
     HighPerformance,
 }
 
@@ -138,8 +141,13 @@ pub enum PowerPreference {
 pub struct Settings {
     /// The graphical backend to use.
     ///
-    /// It defaults to [`Backend::Best`].
+    /// By default, it is [`Backend::Best`].
     pub backend: Backend,
+
+    /// The [`PowerPreference`] of the backend.
+    ///
+    /// By default, it is [`PowerPreference::None`].
+    pub power_preference: PowerPreference,
 
     /// If set to true, the renderer will try to perform antialiasing for some
     /// primitives.
@@ -154,11 +162,6 @@ pub struct Settings {
     ///
     /// By default, it is `true`.
     pub vsync: bool,
-
-    /// The [`PowerPreference`] of the backend.
-    ///
-    /// Defaults to `PowerPreference::NoPreference`
-    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -167,7 +170,7 @@ impl Default for Settings {
             backend: Backend::Best,
             antialiasing: true,
             vsync: true,
-            power_preference: PowerPreference::NoPreference,
+            power_preference: PowerPreference::None,
         }
     }
 }

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -120,6 +120,19 @@ impl fmt::Display for Api {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Copy)]
+/// The power-usage preference for adapters
+pub enum PowerPreference {
+    /// No preference in which adapter wgpu should choose.
+    NoPreference,
+
+    /// The backend will prefer lower-power adapters over higher-power ones. Recommended for most applications.
+    LowPower,
+
+    /// The backend will prefer adapters that are higher performance. Use only in usecases with high, graphic-intensive workloads
+    HighPerformance,
+}
+
 /// The settings usted to configure a [`Backend`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct Settings {
@@ -141,6 +154,11 @@ pub struct Settings {
     ///
     /// By default, it is `true`.
     pub vsync: bool,
+
+    /// The [`PowerPreference`] of the backend.
+    ///
+    /// Defaults to `PowerPreference::NoPreference`
+    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -149,6 +167,7 @@ impl Default for Settings {
             backend: Backend::Best,
             antialiasing: true,
             vsync: true,
+            power_preference: PowerPreference::NoPreference,
         }
     }
 }
@@ -159,6 +178,7 @@ impl From<&crate::Settings> for Settings {
             backend: settings.backend.clone(),
             antialiasing: settings.antialiasing,
             vsync: settings.vsync,
+            power_preference: settings.power_preference,
         }
     }
 }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -1,5 +1,5 @@
 //! Configure your application.
-use crate::backend::PowerPreference;
+use crate::backend;
 use crate::renderer;
 use crate::{Backend, Font, Pixels};
 
@@ -24,13 +24,18 @@ pub struct Settings {
 
     /// The text size that will be used by default.
     ///
-    /// The default value is `16.0`.
+    /// By default, it is `16.0`.
     pub default_text_size: Pixels,
 
     /// The graphical backend to use.
     ///
-    /// It defaults to [`Backend::Best`].
+    /// By default, it is [`Backend::Best`].
     pub backend: Backend,
+
+    /// The [`PowerPreference`](backend::PowerPreference) of the backend.
+    ///
+    /// By default, it is [`backend::PowerPreference::None`].
+    pub power_preference: backend::PowerPreference,
 
     /// If set to true, the renderer will try to perform antialiasing for some
     /// primitives.
@@ -47,11 +52,6 @@ pub struct Settings {
     ///
     /// By default, it is enabled.
     pub vsync: bool,
-
-    /// The [`PowerPreference`] of the backend.
-    ///
-    /// Defaults to `PowerPreference::NoPreference`
-    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -64,9 +64,9 @@ impl Default for Settings {
             default_font: renderer.default_font,
             default_text_size: renderer.default_text_size,
             backend: Backend::default(),
+            power_preference: backend::PowerPreference::None,
             antialiasing: true,
             vsync: true,
-            power_preference: PowerPreference::NoPreference,
         }
     }
 }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -1,4 +1,5 @@
 //! Configure your application.
+use crate::backend::PowerPreference;
 use crate::renderer;
 use crate::{Backend, Font, Pixels};
 
@@ -46,6 +47,11 @@ pub struct Settings {
     ///
     /// By default, it is enabled.
     pub vsync: bool,
+
+    /// The [`PowerPreference`] of the backend.
+    ///
+    /// Defaults to `PowerPreference::NoPreference`
+    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -60,6 +66,7 @@ impl Default for Settings {
             backend: Backend::default(),
             antialiasing: true,
             vsync: true,
+            power_preference: PowerPreference::NoPreference,
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -30,6 +30,7 @@
 //!     ]
 //! }
 //! ```
+use crate::backend;
 use crate::message;
 use crate::program::{self, Program};
 use crate::shell;
@@ -39,7 +40,6 @@ use crate::{
     Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Task, Theme,
 };
 
-use iced_core::backend::PowerPreference;
 use iced_debug as debug;
 
 use std::borrow::Cow;
@@ -338,8 +338,8 @@ impl<P: Program> Application<P> {
         }
     }
 
-    /// Sets the [`Settings::power_preference`] of the [`Application`]
-    pub fn power_preference(self, power_preference: PowerPreference) -> Self {
+    /// Sets the [`backend::PowerPreference`] of the [`Application`].
+    pub fn power_preference(self, power_preference: backend::PowerPreference) -> Self {
         Self {
             settings: Settings {
                 power_preference,

--- a/src/application.rs
+++ b/src/application.rs
@@ -39,6 +39,7 @@ use crate::{
     Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Task, Theme,
 };
 
+use iced_core::backend::PowerPreference;
 use iced_debug as debug;
 
 use std::borrow::Cow;
@@ -332,6 +333,17 @@ impl<P: Program> Application<P> {
             window: window::Settings {
                 level,
                 ..self.window
+            },
+            ..self
+        }
+    }
+
+    /// Sets the [`Settings::power_preference`] of the [`Application`]
+    pub fn power_preference(self, power_preference: PowerPreference) -> Self {
+        Self {
+            settings: Settings {
+                power_preference,
+                ..self.settings
             },
             ..self
         }

--- a/src/application.rs
+++ b/src/application.rs
@@ -37,7 +37,8 @@ use crate::shell;
 use crate::theme;
 use crate::window;
 use crate::{
-    Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Task, Theme,
+    Backend, Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Task,
+    Theme,
 };
 
 use iced_debug as debug;
@@ -333,6 +334,17 @@ impl<P: Program> Application<P> {
             window: window::Settings {
                 level,
                 ..self.window
+            },
+            ..self
+        }
+    }
+
+    /// Sets the [`Backend`] of the [`Application`].
+    pub fn backend(self, backend: Backend) -> Self {
+        Self {
+            settings: Settings {
+                backend,
+                ..self.settings
             },
             ..self
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,7 @@ pub mod backend {
 
 pub use application::Application;
 pub use backend::Backend;
+pub use backend::PowerPreference;
 pub use daemon::Daemon;
 pub use error::Error;
 pub use event::Event;

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -1,6 +1,7 @@
 //! Connect a window with a renderer.
+
 use crate::core::Color;
-use crate::core::backend;
+use crate::core::backend::{self, PowerPreference};
 use crate::core::renderer;
 use crate::graphics::color;
 use crate::graphics::compositor;
@@ -82,9 +83,14 @@ impl Compositor {
             .create_surface(wgpu::SurfaceTarget::Window(Box::new(compatible_window)))
             .ok();
 
+        let power_preference = match settings.power_preference {
+            PowerPreference::NoPreference => wgpu::PowerPreference::None,
+            PowerPreference::LowPower => wgpu::PowerPreference::LowPower,
+            PowerPreference::HighPerformance => wgpu::PowerPreference::HighPerformance,
+        };
+
         let adapter_options = wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::from_env()
-                .unwrap_or(wgpu::PowerPreference::HighPerformance),
+            power_preference: wgpu::PowerPreference::from_env().unwrap_or(power_preference),
             compatible_surface: compatible_surface.as_ref(),
             force_fallback_adapter: false,
         };
@@ -378,6 +384,11 @@ pub struct Settings {
     ///
     /// By default, it is `None`.
     pub antialiasing: Option<Antialiasing>,
+
+    /// The power-usage preference for hardware adapters
+    ///
+    /// By default, it is `NoPreference` (i.e. no preference in adapter)
+    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -386,6 +397,7 @@ impl Default for Settings {
             present_mode: wgpu::PresentMode::AutoVsync,
             backends: wgpu::Backends::all(),
             antialiasing: None,
+            power_preference: PowerPreference::NoPreference,
         }
     }
 }
@@ -413,6 +425,7 @@ impl From<backend::Settings> for Settings {
             },
             antialiasing: settings.antialiasing.then_some(Antialiasing::MSAAx4),
             backends,
+            power_preference: settings.power_preference,
         }
     }
 }

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -1,7 +1,6 @@
 //! Connect a window with a renderer.
-
 use crate::core::Color;
-use crate::core::backend::{self, PowerPreference};
+use crate::core::backend;
 use crate::core::renderer;
 use crate::graphics::color;
 use crate::graphics::compositor;
@@ -84,9 +83,9 @@ impl Compositor {
             .ok();
 
         let power_preference = match settings.power_preference {
-            PowerPreference::NoPreference => wgpu::PowerPreference::None,
-            PowerPreference::LowPower => wgpu::PowerPreference::LowPower,
-            PowerPreference::HighPerformance => wgpu::PowerPreference::HighPerformance,
+            backend::PowerPreference::None => wgpu::PowerPreference::None,
+            backend::PowerPreference::LowPower => wgpu::PowerPreference::LowPower,
+            backend::PowerPreference::HighPerformance => wgpu::PowerPreference::HighPerformance,
         };
 
         let adapter_options = wgpu::RequestAdapterOptions {
@@ -380,15 +379,15 @@ pub struct Settings {
     /// The graphics backends to use.
     pub backends: wgpu::Backends,
 
+    /// The power-usage preference for graphics adapters.
+    ///
+    /// By default, it is [`backend::PowerPreference::None`].
+    pub power_preference: backend::PowerPreference,
+
     /// The antialiasing strategy that will be used for triangle primitives.
     ///
     /// By default, it is `None`.
     pub antialiasing: Option<Antialiasing>,
-
-    /// The power-usage preference for hardware adapters
-    ///
-    /// By default, it is `NoPreference` (i.e. no preference in adapter)
-    pub power_preference: PowerPreference,
 }
 
 impl Default for Settings {
@@ -396,8 +395,8 @@ impl Default for Settings {
         Settings {
             present_mode: wgpu::PresentMode::AutoVsync,
             backends: wgpu::Backends::all(),
+            power_preference: backend::PowerPreference::None,
             antialiasing: None,
-            power_preference: PowerPreference::NoPreference,
         }
     }
 }


### PR DESCRIPTION
This PR adds a `PowerPreference` setting to `iced::Settings` so that the power-preference of the GPU can be configured manually by the user. Previously, in v0.14, it would use the WGPU environment variable and fall back to `wgpu::PowerPreference::HighPerformance`. This PR adds a function to `iced::Application` called `power_preference` which allows the user to have a preference in which adapter will get chosen.

Fixes [#3143](https://github.com/iced-rs/iced/issues/3143).