### PR TITLE
Implement `From<()>` for `Element`

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -518,6 +518,15 @@ where
     }
 }
 
+impl<'a, Message, Theme, Renderer> From<()> for Element<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::Renderer,
+{
+    fn from(_: ()) -> Self {
+        Option::<Self>::None.into()
+    }
+}
+
 impl<'a, T, Message, Theme, Renderer> From<Option<T>> for Element<'a, Message, Theme, Renderer>
 where
     T: Into<Self>,


### PR DESCRIPTION
`()` is sometimes more ergonomic than `None` for producing an empty `Element`. `None.into()` requires a type annotation because the compiler *cannot infer type of the type parameter `T` declared on the enum `Option`*, while `().into()` just works.

Delegates to `Option::<Self>::None.into()` to reuse the existing `Void` widget without duplication.