### PR TITLE
Separate `window` from `application` scale factor hints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["wgpu", "tiny-skia", "crisp", "hinting", "web-colors", "thread-pool", "linux-theme-detection", "x11", "wayland"]
+default = ["wgpu", "tiny-skia", "crisp", "web-colors", "thread-pool", "linux-theme-detection", "x11", "wayland"]
 # Enables the `wgpu` GPU-accelerated renderer with all its default features (Vulkan, Metal, DX12, OpenGL, and WebGPU)
 wgpu = ["wgpu-bare", "iced_renderer/wgpu"]
 # Enables the `wgpu` GPU-accelerated renderer with the minimum required features (no backends!)
@@ -77,8 +77,6 @@ fira-sans = ["iced_renderer/fira-sans"]
 basic-shaping = ["iced_core/basic-shaping"]
 # Enables advanced text shaping by default
 advanced-shaping = ["iced_core/advanced-shaping"]
-# Enables rendering hints (e.g. metrics hinting)
-hinting = ["iced_winit/hinting"]
 # Enables strict assertions for debugging purposes at the expense of performance
 strict-assertions = ["iced_renderer/strict-assertions"]
 # Redraws on every runtime event, and not only when a widget requests it

--- a/benches/wgpu.rs
+++ b/benches/wgpu.rs
@@ -93,7 +93,13 @@ fn benchmark<'a>(
 
     let mut renderer = Renderer::new(engine, renderer::Settings::default());
 
-    let viewport = graphics::Viewport::with_physical_size(Size::new(3840, 2160), 2.0);
+    let viewport = graphics::Viewport::with_physical_size(
+        Size::new(3840, 2160),
+        renderer::Scale {
+            window: 2.0,
+            application: 1.0,
+        },
+    );
 
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: None,

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -73,8 +73,13 @@ pub trait Renderer {
     /// Returns the last [`Scale`] provided as a [`hint`](Self::hint).
     fn scale(&self) -> Option<Scale>;
 
-    /// Returns the last scale factor provided as a [`hint`](Self::hint).
-    fn scale_factor(&self) -> Option<f32> {
+    /// Returns the last hint factor provided as a [`hint`](Self::hint),
+    /// only if [`Settings::metrics_hinting`] is enabled.
+    fn hint_factor(&self) -> Option<f32> {
+        if !self.settings().metrics_hinting {
+            return None;
+        }
+
         self.scale().map(Scale::total)
     }
 
@@ -170,7 +175,7 @@ pub struct Settings {
     /// Whether the [`Renderer`] should perform metrics hinting.
     ///
     /// By default, it is enabled.
-    pub text_hinting: bool,
+    pub metrics_hinting: bool,
 }
 
 impl Default for Settings {
@@ -178,7 +183,7 @@ impl Default for Settings {
         Self {
             default_font: Font::DEFAULT,
             default_text_size: Pixels(16.0),
-            text_hinting: true,
+            metrics_hinting: true,
         }
     }
 }

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -65,16 +65,24 @@ pub trait Renderer {
     /// This may be used internally by the [`Renderer`] to perform optimizations
     /// and/or improve rendering quality.
     ///
-    /// For instance, providing a `scale_factor` may be used by some renderers to
+    /// For instance, providing a [`Scale`] may be used by some renderers to
     /// perform metrics hinting internally in physical coordinates while keeping
     /// layout coordinates logical and, therefore, maintain linearity.
-    fn hint(&mut self, scale_factor: f32);
+    fn hint(&mut self, scale: Scale);
+
+    /// Returns the last [`Scale`] provided as a [`hint`](Self::hint).
+    fn scale(&self) -> Option<Scale>;
 
     /// Returns the last scale factor provided as a [`hint`](Self::hint).
-    fn scale_factor(&self) -> Option<f32>;
+    fn scale_factor(&self) -> Option<f32> {
+        self.scale().map(Scale::total)
+    }
 
     /// Resets the [`Renderer`] to start drawing in the `new_bounds` from scratch.
     fn reset(&mut self, new_bounds: Rectangle);
+
+    /// Returns the [`Settings`] of this [`Renderer`].
+    fn settings(&self) -> Settings;
 
     /// Polls any concurrent computations that may be pending in the [`Renderer`].
     ///
@@ -158,6 +166,11 @@ pub struct Settings {
     ///
     /// By default, it will be set to `16.0`.
     pub default_text_size: Pixels,
+
+    /// Whether the [`Renderer`] should perform metrics hinting.
+    ///
+    /// By default, it is enabled.
+    pub text_hinting: bool,
 }
 
 impl Default for Settings {
@@ -165,6 +178,37 @@ impl Default for Settings {
         Self {
             default_font: Font::DEFAULT,
             default_text_size: Pixels(16.0),
+            text_hinting: true,
+        }
+    }
+}
+
+/// The scale factor of a [`Renderer`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Scale {
+    /// The global scale factor of the window.
+    ///
+    /// This is normally controlled by the OS, and applied globally to all apps.
+    pub window: f32,
+
+    /// The local scale factor of the application.
+    pub application: f32,
+}
+
+impl Scale {
+    /// Returns the total scale factor applied by the [`Renderer`].
+    ///
+    /// This is the product of the window and application scale factors.
+    pub fn total(self) -> f32 {
+        self.window * self.application
+    }
+}
+
+impl Default for Scale {
+    fn default() -> Self {
+        Self {
+            window: 1.0,
+            application: 1.0,
         }
     }
 }

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -25,13 +25,17 @@ impl Renderer for () {
         callback(Ok(unsafe { image::allocate(handle, Size::new(100, 100)) }));
     }
 
-    fn hint(&mut self, _scale_factor: f32) {}
+    fn hint(&mut self, _scale: renderer::Scale) {}
 
-    fn scale_factor(&self) -> Option<f32> {
+    fn scale(&self) -> Option<renderer::Scale> {
         None
     }
 
     fn reset(&mut self, _new_bounds: Rectangle) {}
+
+    fn settings(&self) -> renderer::Settings {
+        renderer::Settings::default()
+    }
 }
 
 impl text::Renderer for () {

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -27,13 +27,13 @@ pub struct Settings {
     /// By default, it is `16.0`.
     pub default_text_size: Pixels,
 
-    /// Whether text should be rendered using metrics hinting.
+    /// Whether certain widgets should be rendered using metrics hinting.
     ///
     /// Metrics hinting can improve the readability of smaller text in
-    /// low-DPI screens.
+    /// low-DPI screens, as well as the clarity of widgets that render thin lines.
     ///
     /// By default, it is enabled.
-    pub text_hinting: bool,
+    pub metrics_hinting: bool,
 
     /// The graphical backend to use.
     ///
@@ -71,7 +71,7 @@ impl Default for Settings {
             fonts: Vec::new(),
             default_font: renderer.default_font,
             default_text_size: renderer.default_text_size,
-            text_hinting: true,
+            metrics_hinting: true,
             backend: Backend::default(),
             power_preference: backend::PowerPreference::None,
             antialiasing: true,
@@ -85,7 +85,7 @@ impl From<&Settings> for renderer::Settings {
         Self {
             default_font: settings.default_font,
             default_text_size: settings.default_text_size,
-            text_hinting: settings.text_hinting,
+            metrics_hinting: settings.metrics_hinting,
         }
     }
 }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -27,6 +27,14 @@ pub struct Settings {
     /// By default, it is `16.0`.
     pub default_text_size: Pixels,
 
+    /// Whether text should be rendered using metrics hinting.
+    ///
+    /// Metrics hinting can improve the readability of smaller text in
+    /// low-DPI screens.
+    ///
+    /// By default, it is enabled.
+    pub text_hinting: bool,
+
     /// The graphical backend to use.
     ///
     /// By default, it is [`Backend::Best`].
@@ -63,6 +71,7 @@ impl Default for Settings {
             fonts: Vec::new(),
             default_font: renderer.default_font,
             default_text_size: renderer.default_text_size,
+            text_hinting: true,
             backend: Backend::default(),
             power_preference: backend::PowerPreference::None,
             antialiasing: true,
@@ -76,6 +85,7 @@ impl From<&Settings> for renderer::Settings {
         Self {
             default_font: settings.default_font,
             default_text_size: settings.default_text_size,
+            text_hinting: settings.text_hinting,
         }
     }
 }

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -325,7 +325,7 @@ where
             shaping: format.shaping,
             wrapping: format.wrapping,
             ellipsis: format.ellipsis,
-            hint_factor: renderer.scale_factor(),
+            hint_factor: renderer.hint_factor(),
         });
 
         paragraph.min_bounds()

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -64,7 +64,10 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                 let physical_size = window.inner_size();
                 let viewport = Viewport::with_physical_size(
                     Size::new(physical_size.width, physical_size.height),
-                    window.scale_factor() as f32,
+                    renderer::Scale {
+                        window: window.scale_factor() as f32,
+                        application: 1.0,
+                    },
                 );
 
                 let backend = wgpu::Backends::from_env().unwrap_or_default();
@@ -208,7 +211,10 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
 
                         *viewport = Viewport::with_physical_size(
                             Size::new(size.width, size.height),
-                            window.scale_factor() as f32,
+                            renderer::Scale {
+                                window: window.scale_factor() as f32,
+                                application: 1.0,
+                            },
                         );
 
                         surface.configure(

--- a/graphics/src/viewport.rs
+++ b/graphics/src/viewport.rs
@@ -1,3 +1,4 @@
+use crate::core::renderer::Scale;
 use crate::core::{Size, Transformation};
 
 /// A viewing region for displaying computer graphics.
@@ -5,21 +6,23 @@ use crate::core::{Size, Transformation};
 pub struct Viewport {
     physical_size: Size<u32>,
     logical_size: Size<f32>,
-    scale_factor: f32,
+    scale: Scale,
     projection: Transformation,
 }
 
 impl Viewport {
     /// Creates a new [`Viewport`] with the given physical dimensions and scale
     /// factor.
-    pub fn with_physical_size(size: Size<u32>, scale_factor: f32) -> Viewport {
+    pub fn with_physical_size(size: Size<u32>, scale: Scale) -> Viewport {
+        let scale_factor = scale.total();
+
         Viewport {
             physical_size: size,
             logical_size: Size::new(
                 size.width as f32 / scale_factor,
                 size.height as f32 / scale_factor,
             ),
-            scale_factor,
+            scale,
             projection: Transformation::orthographic(size.width, size.height),
         }
     }
@@ -44,9 +47,14 @@ impl Viewport {
         self.logical_size
     }
 
+    /// Returns the [`Scale`] of the [`Viewport`].
+    pub fn scale(&self) -> Scale {
+        self.scale
+    }
+
     /// Returns the scale factor of the [`Viewport`].
     pub fn scale_factor(&self) -> f32 {
-        self.scale_factor
+        self.scale.total()
     }
 
     /// Returns the projection transformation of the [`Viewport`].

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -70,12 +70,12 @@ where
         delegate!(self, renderer, renderer.allocate_image(handle, callback));
     }
 
-    fn hint(&mut self, scale_factor: f32) {
-        delegate!(self, renderer, renderer.hint(scale_factor));
+    fn hint(&mut self, scale: renderer::Scale) {
+        delegate!(self, renderer, renderer.hint(scale));
     }
 
-    fn scale_factor(&self) -> Option<f32> {
-        delegate!(self, renderer, renderer.scale_factor())
+    fn scale(&self) -> Option<renderer::Scale> {
+        delegate!(self, renderer, renderer.scale())
     }
 
     fn tick(&mut self) {
@@ -84,6 +84,10 @@ where
 
     fn reset(&mut self, new_bounds: Rectangle) {
         delegate!(self, renderer, renderer.reset(new_bounds));
+    }
+
+    fn settings(&self) -> renderer::Settings {
+        delegate!(self, renderer, renderer.settings())
     }
 }
 

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -68,6 +68,7 @@ where
                 core::renderer::Settings {
                     default_font: settings.default_font,
                     default_text_size: settings.default_text_size,
+                    text_hinting: settings.text_hinting,
                 },
                 backend.as_deref(),
             ))

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -68,7 +68,7 @@ where
                 core::renderer::Settings {
                     default_font: settings.default_font,
                     default_text_size: settings.default_text_size,
-                    text_hinting: settings.text_hinting,
+                    metrics_hinting: settings.metrics_hinting,
                 },
                 backend.as_deref(),
             ))

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -222,17 +222,21 @@ impl core::Renderer for Renderer {
         callback(Err(core::image::Error::Unsupported));
     }
 
-    fn hint(&mut self, _scale_factor: f32) {
+    fn hint(&mut self, _scale: renderer::Scale) {
         // TODO: No hinting supported
         // We'll replace `tiny-skia` with `vello_cpu` soon
     }
 
-    fn scale_factor(&self) -> Option<f32> {
+    fn scale(&self) -> Option<renderer::Scale> {
         None
     }
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
+    }
+
+    fn settings(&self) -> renderer::Settings {
+        self.settings
     }
 }
 
@@ -407,7 +411,13 @@ impl renderer::Headless for Renderer {
         scale_factor: f32,
         background_color: Color,
     ) -> Vec<u8> {
-        let viewport = Viewport::with_physical_size(size, scale_factor);
+        let viewport = Viewport::with_physical_size(
+            size,
+            renderer::Scale {
+                window: 1.0,
+                application: scale_factor,
+            },
+        );
 
         window::compositor::screenshot(self, &viewport, background_color)
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -74,7 +74,7 @@ pub struct Renderer {
     settings: renderer::Settings,
 
     layers: layer::Stack,
-    scale_factor: Option<f32>,
+    scale: Option<renderer::Scale>,
 
     quad: quad::State,
     triangle: triangle::State,
@@ -96,7 +96,7 @@ impl Renderer {
         Self {
             settings,
             layers: layer::Stack::new(),
-            scale_factor: None,
+            scale: None,
 
             quad: quad::State::new(),
             triangle: triangle::State::new(&engine.device, &engine.triangle_pipeline),
@@ -695,12 +695,17 @@ impl core::Renderer for Renderer {
             .allocate_image(_handle, _callback);
     }
 
-    fn hint(&mut self, scale_factor: f32) {
-        self.scale_factor = Some(scale_factor);
+    fn hint(&mut self, scale_factor: renderer::Scale) {
+        self.scale = Some(scale_factor);
     }
 
-    fn scale_factor(&self) -> Option<f32> {
-        Some(self.scale_factor? * self.layers.transformation().scale_factor())
+    fn scale(&self) -> Option<renderer::Scale> {
+        let scale_factor = self.scale?;
+
+        Some(renderer::Scale {
+            application: scale_factor.application * self.layers.transformation().scale_factor(),
+            ..scale_factor
+        })
     }
 
     fn tick(&mut self) {
@@ -710,6 +715,10 @@ impl core::Renderer for Renderer {
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
+    }
+
+    fn settings(&self) -> renderer::Settings {
+        self.settings
     }
 }
 
@@ -953,7 +962,13 @@ impl renderer::Headless for Renderer {
         background_color: Color,
     ) -> Vec<u8> {
         self.screenshot(
-            &Viewport::with_physical_size(size, scale_factor),
+            &Viewport::with_physical_size(
+                size,
+                renderer::Scale {
+                    window: 1.0,
+                    application: scale_factor,
+                },
+            ),
             background_color,
         )
     }

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -545,7 +545,7 @@ where
                     shaping: self.shaping,
                     wrapping: text::Wrapping::None,
                     ellipsis: self.ellipsis,
-                    hint_factor: renderer.scale_factor(),
+                    hint_factor: renderer.hint_factor(),
                 },
                 Point::new(bounds.x + self.padding.left, bounds.center_y()),
                 if is_selected {

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -374,7 +374,7 @@ where
             shaping: self.shaping,
             wrapping: text::Wrapping::None,
             ellipsis: self.ellipsis,
-            hint_factor: renderer.scale_factor(),
+            hint_factor: renderer.hint_factor(),
         };
 
         if let Some(placeholder) = &self.placeholder {
@@ -681,7 +681,7 @@ where
                     shaping: self.shaping,
                     wrapping: text::Wrapping::None,
                     ellipsis: self.ellipsis,
-                    hint_factor: renderer.scale_factor(),
+                    hint_factor: renderer.hint_factor(),
                 },
                 Point::new(bounds.x + self.padding.left, bounds.center_y()),
                 if selected.is_some() {

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -168,7 +168,7 @@ where
         };
 
         if style.snap {
-            let unit = 1.0 / renderer.scale_factor().unwrap_or(1.0);
+            let unit = 1.0 / renderer.hint_factor().unwrap_or(1.0);
 
             bounds.width = bounds.width.max(unit);
             bounds.height = bounds.height.max(unit);

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1062,7 +1062,7 @@ where
 
         // Draw inner content
         if scrollbars.active() {
-            let scale_factor = renderer.scale_factor().unwrap_or(1.0);
+            let scale_factor = renderer.hint_factor().unwrap_or(1.0);
             let translation = (translation * scale_factor).round() / scale_factor;
 
             renderer.with_layer(visible_bounds, |renderer| {

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -472,7 +472,7 @@ where
             shaping: Shaping::Advanced,
             wrapping,
             ellipsis,
-            hint_factor: renderer.scale_factor(),
+            hint_factor: renderer.hint_factor(),
         };
 
         if state.spans != spans {
@@ -490,7 +490,7 @@ where
                 shaping: Shaping::Advanced,
                 wrapping,
                 ellipsis,
-                hint_factor: renderer.scale_factor(),
+                hint_factor: renderer.hint_factor(),
             }) {
                 core::text::Difference::None => {}
                 core::text::Difference::Bounds => {

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -597,7 +597,7 @@ where
             self.text_size.unwrap_or_else(|| renderer.default_size()),
             self.line_height,
             self.wrapping,
-            renderer.scale_factor(),
+            renderer.hint_factor(),
             state.highlighter.borrow_mut().deref_mut(),
         );
 
@@ -910,7 +910,7 @@ where
                         shaping: text::Shaping::Advanced,
                         wrapping: self.wrapping,
                         ellipsis: text::Ellipsis::None,
-                        hint_factor: renderer.scale_factor(),
+                        hint_factor: renderer.hint_factor(),
                     },
                     text_bounds.position(),
                     style.placeholder,
@@ -935,7 +935,7 @@ where
                         position + translation,
                         Size::new(
                             if renderer::CRISP {
-                                (1.0 / renderer.scale_factor().unwrap_or(1.0)).max(1.0)
+                                (1.0 / renderer.hint_factor().unwrap_or(1.0)).max(1.0)
                             } else {
                                 1.0
                             },

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -299,7 +299,7 @@ where
             shaping: text::Shaping::Advanced,
             wrapping: text::Wrapping::None,
             ellipsis: text::Ellipsis::None,
-            hint_factor: renderer.scale_factor(),
+            hint_factor: renderer.hint_factor(),
         };
 
         let _ = state.placeholder.update(placeholder_text);
@@ -326,7 +326,7 @@ where
                 shaping: text::Shaping::Advanced,
                 wrapping: text::Wrapping::None,
                 ellipsis: text::Ellipsis::None,
-                hint_factor: renderer.scale_factor(),
+                hint_factor: renderer.hint_factor(),
             };
 
             let _ = state.icon.update(icon_text);
@@ -485,7 +485,7 @@ where
                                     x: text_bounds.x + text_value_width,
                                     y: text_bounds.y,
                                     width: if renderer::CRISP {
-                                        (1.0 / renderer.scale_factor().unwrap_or(1.0)).max(1.0)
+                                        (1.0 / renderer.hint_factor().unwrap_or(1.0)).max(1.0)
                                     } else {
                                         1.0
                                     },
@@ -1587,7 +1587,7 @@ fn replace_paragraph<Renderer>(
         shaping: text::Shaping::Advanced,
         wrapping: text::Wrapping::None,
         ellipsis: text::Ellipsis::None,
-        hint_factor: renderer.scale_factor(),
+        hint_factor: renderer.hint_factor(),
     });
 }
 

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -270,7 +270,7 @@ where
             },
             |_| {
                 let size = if renderer::CRISP {
-                    let scale_factor = renderer.scale_factor().unwrap_or(1.0);
+                    let scale_factor = renderer.hint_factor().unwrap_or(1.0);
 
                     (self.size * scale_factor).round() / scale_factor
                 } else {
@@ -416,7 +416,7 @@ where
             );
         }
 
-        let scale_factor = renderer.scale_factor().unwrap_or(1.0);
+        let scale_factor = renderer.hint_factor().unwrap_or(1.0);
         let bounds = toggler_layout.bounds();
 
         let border_radius = style

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 default = ["x11", "wayland"]
 debug = ["iced_debug/enable"]
 sysinfo = ["dep:sysinfo"]
-hinting = []
 unconditional-rendering = []
 linux-theme-detection = ["dep:mundy", "mundy/async-io", "mundy/color-scheme"]
 image = ["iced_runtime/image", "arboard/image-data"]

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -653,8 +653,7 @@ async fn run_instance<P>(
 
                 let logical_size = window.state.logical_size();
 
-                #[cfg(feature = "hinting")]
-                window.renderer.hint(window.state.scale_factor());
+                window.renderer.hint(window.state.scale());
 
                 let _ = user_interfaces.insert(
                     id,
@@ -762,8 +761,7 @@ async fn run_instance<P>(
 
                         // Window was resized between redraws
                         if window.surface_version != window.state.surface_version() {
-                            #[cfg(feature = "hinting")]
-                            window.renderer.hint(window.state.scale_factor());
+                            window.renderer.hint(window.state.scale());
 
                             let ui = user_interfaces.remove(&id).expect("Remove user interface");
 
@@ -1825,8 +1823,7 @@ where
             });
         }
 
-        #[cfg(feature = "hinting")]
-        window.renderer.hint(window.state.scale_factor());
+        window.renderer.hint(window.state.scale());
     }
 
     debug::theme_changed(|| {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -370,7 +370,7 @@ where
                 shaping: text::Shaping::Advanced,
                 wrapping: text::Wrapping::None,
                 ellipsis: text::Ellipsis::None,
-                hint_factor: renderer.scale_factor(),
+                hint_factor: renderer.hint_factor(),
             });
 
             self.spans.clear();

--- a/winit/src/window/state.rs
+++ b/winit/src/window/state.rs
@@ -1,4 +1,5 @@
 use crate::conversion;
+use crate::core::renderer;
 use crate::core::{Color, Size};
 use crate::core::{mouse, theme, window};
 use crate::graphics::Viewport;
@@ -15,7 +16,6 @@ where
     P::Theme: theme::Base,
 {
     title: String,
-    scale_factor: f32,
     viewport: Viewport,
     surface_version: u64,
     cursor_position: Option<winit::dpi::PhysicalPosition<f64>>,
@@ -33,7 +33,6 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("window::State")
             .field("title", &self.title)
-            .field("scale_factor", &self.scale_factor)
             .field("viewport", &self.viewport)
             .field("cursor_position", &self.cursor_position)
             .field("style", &self.style)
@@ -64,13 +63,15 @@ where
 
             Viewport::with_physical_size(
                 Size::new(physical_size.width, physical_size.height),
-                window.scale_factor() as f32 * scale_factor,
+                renderer::Scale {
+                    window: window.scale_factor() as f32,
+                    application: scale_factor,
+                },
             )
         };
 
         Self {
             title,
-            scale_factor,
             viewport,
             surface_version: 0,
             cursor_position: None,
@@ -96,6 +97,10 @@ where
 
     pub fn logical_size(&self) -> Size<f32> {
         self.viewport.logical_size()
+    }
+
+    pub fn scale(&self) -> renderer::Scale {
+        self.viewport.scale()
     }
 
     pub fn scale_factor(&self) -> f32 {
@@ -138,7 +143,10 @@ where
 
                 self.viewport = Viewport::with_physical_size(
                     size,
-                    window.scale_factor() as f32 * self.scale_factor,
+                    renderer::Scale {
+                        window: window.scale_factor() as f32,
+                        application: self.viewport.scale().application,
+                    },
                 );
                 self.surface_version += 1;
             }
@@ -150,7 +158,10 @@ where
 
                 self.viewport = Viewport::with_physical_size(
                     size,
-                    *new_scale_factor as f32 * self.scale_factor,
+                    renderer::Scale {
+                        window: *new_scale_factor as f32,
+                        application: self.viewport.scale().application,
+                    },
                 );
                 self.surface_version += 1;
             }
@@ -196,13 +207,14 @@ where
         // Update scale factor
         let new_scale_factor = program.scale_factor(window_id);
 
-        if self.scale_factor != new_scale_factor {
+        if self.viewport.scale().application != new_scale_factor {
             self.viewport = Viewport::with_physical_size(
                 self.viewport.physical_size(),
-                window.scale_factor() as f32 * new_scale_factor,
+                renderer::Scale {
+                    window: window.scale_factor() as f32,
+                    application: new_scale_factor,
+                },
             );
-
-            self.scale_factor = new_scale_factor;
         }
 
         // Update theme and appearance


### PR DESCRIPTION
This PR changes a couple of rendering APIs:

- A new `renderer::Scale` struct has been introduced which exposes scaling information for the `window` and the `application` separately.
- The `hinting` feature flag has been replaced with the new `metrics_hinting` field in `Settings`. It can therefore be toggled at runtime now.
- `Renderer::scale_factor` has been renamed to `hint_factor` and will only ever return `Some` if `metrics_hinting` is enabled.