### PR TITLE
Fix text_editor selection rendering.

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -964,7 +964,7 @@ where
                     {
                         renderer.fill_quad(
                             renderer::Quad {
-                                bounds: range,
+                                bounds: range.round(),
                                 ..renderer::Quad::default()
                             },
                             style.selection,


### PR DESCRIPTION
Fixes the gap when multiple lines are selected.