### PR TITLE
Emulator: load fonts and honor ICED_TEST_BACKEND, matching Simulator

### DIFF
--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -95,8 +95,13 @@ impl<P: Program + 'static> Emulator<P> {
         // TODO: Error handling
         let executor = P::Executor::new().expect("Create emulator executor");
 
+        let backend = std::env::var("ICED_TEST_BACKEND").ok();
+
         let renderer = executor
-            .block_on(P::Renderer::new(renderer::Settings::from(&settings), None))
+            .block_on(P::Renderer::new(
+                renderer::Settings::from(&settings),
+                backend.as_deref(),
+            ))
             .expect("Create emulator renderer");
 
         let runtime = Runtime::new(executor, sender);

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -21,6 +21,7 @@ use crate::runtime::user_interface;
 use crate::runtime::{Task, UserInterface};
 use crate::{Instruction, Selector};
 
+use std::borrow::Cow;
 use std::fmt;
 
 /// A headless runtime that can run iced applications and execute
@@ -86,6 +87,10 @@ impl<P: Program + 'static> Emulator<P> {
         use renderer::Headless;
 
         let settings = program.settings();
+
+        for font in &settings.fonts {
+            load_font(font.clone()).expect("Font must be valid");
+        }
 
         // TODO: Error handling
         let executor = P::Executor::new().expect("Create emulator executor");
@@ -237,8 +242,14 @@ impl<P: Program + 'static> Emulator<P> {
                     dbg!(action);
                 }
                 runtime::Action::Font(action) => {
-                    // TODO
-                    dbg!(action);
+                    use crate::runtime::font;
+                    match action {
+                        font::Action::Load { bytes, channel } => {
+                            let _ = load_font(bytes);
+                            let _ = channel.send(Ok(()));
+                        }
+                        _ => {}
+                    }
                 }
                 runtime::Action::Image(action) => {
                     // TODO
@@ -538,4 +549,13 @@ impl fmt::Display for Mode {
             Self::Immediate => "Immediate",
         })
     }
+}
+
+fn load_font(font: impl Into<Cow<'static, [u8]>>) -> Result<(), crate::error::Error> {
+    crate::renderer::graphics::text::font_system()
+        .write()
+        .expect("Write to font system")
+        .load_font(font.into());
+
+    Ok(())
 }

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -1,5 +1,6 @@
 //! Run your application in a headless runtime.
 use crate::core;
+use crate::core::font;
 use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::shell;
@@ -248,12 +249,16 @@ impl<P: Program + 'static> Emulator<P> {
                 }
                 runtime::Action::Font(action) => {
                     use crate::runtime::font;
+
                     match action {
                         font::Action::Load { bytes, channel } => {
-                            let _ = load_font(bytes);
-                            let _ = channel.send(Ok(()));
+                            let result = load_font(bytes);
+                            let _ = channel.send(result);
                         }
-                        _ => {}
+                        _ => {
+                            // TODO
+                            dbg!(action);
+                        }
                     }
                 }
                 runtime::Action::Image(action) => {
@@ -556,11 +561,11 @@ impl fmt::Display for Mode {
     }
 }
 
-fn load_font(font: impl Into<Cow<'static, [u8]>>) -> Result<(), crate::error::Error> {
+fn load_font(font: Cow<'static, [u8]>) -> Result<(), font::Error> {
     crate::renderer::graphics::text::font_system()
         .write()
         .expect("Write to font system")
-        .load_font(font.into());
+        .load_font(font);
 
     Ok(())
 }

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -1,6 +1,7 @@
 //! Run a simulation of your application without side effects.
 use crate::core;
 use crate::core::event;
+use crate::core::font;
 use crate::core::keyboard;
 use crate::core::mouse;
 use crate::core::shell;
@@ -395,11 +396,11 @@ pub fn typewrite(text: &str) -> impl Iterator<Item = Event> + '_ {
         .flat_map(|c| tap_key(keyboard::Key::Character(c.clone()), Some(c)))
 }
 
-fn load_font(font: impl Into<Cow<'static, [u8]>>) -> Result<(), Error> {
+fn load_font(font: Cow<'static, [u8]>) -> Result<(), font::Error> {
     renderer::graphics::text::font_system()
         .write()
         .expect("Write to font system")
-        .load_font(font.into());
+        .load_font(font);
 
     Ok(())
 }


### PR DESCRIPTION
The headless Emulator is missing two behaviors that Simulator already has, which makes cross-machine screenshot testing of full applications impractical:

Fonts — Emulator ignores Settings::fonts and leaves runtime::Action::Font as a dbg! TODO, so applications with custom fonts render missing glyphs (tofu) in emulator screenshots. This PR loads Settings::fonts before creating the renderer and handles font::Action::Load (loading the bytes and acknowledging the channel), mirroring Simulator.

Backend selection — Simulator reads ICED_TEST_BACKEND to pick its headless renderer backend, but Emulator always passes None, so emulator screenshots cannot be pinned to the deterministic tiny-skia software renderer for golden comparisons (GPU output differs between machines). This PR makes Emulator honor the same variable.

Context: we use Emulator for full-app visual regression tests (boot on recorded data, screenshot, compare against committed goldens). With these two changes, the same goldens verify byte-identically across different machines.