### PR TITLE
Fix `toggler` widget with `crisp` disabled

### DIFF
--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -439,7 +439,7 @@ where
         let toggle_bounds = {
             // Try to align toggle to the pixel grid
             let bounds = if renderer::CRISP {
-                (bounds * scale_factor).round()
+                (bounds * scale_factor).round() * (1.0 / scale_factor)
             } else {
                 bounds
             };
@@ -456,7 +456,7 @@ where
                 y: bounds.y + padding,
                 width: bounds.height - (2.0 * padding),
                 height: bounds.height - (2.0 * padding),
-            } * (1.0 / scale_factor)
+            }
         };
 
         renderer.fill_quad(


### PR DESCRIPTION
with the `crisp` feature disabled and a non-1 renderer hint factor, the dot would draw at the wrong position:
<img width="233" height="80" alt="image" src="https://github.com/user-attachments/assets/330b835a-e009-469c-87f1-6d3e78f7f6e3" />
